### PR TITLE
Mi session year indexing

### DIFF
--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/discovery/SolrServiceSessionYearFieldIndexingPlugin.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/discovery/SolrServiceSessionYearFieldIndexingPlugin.java
@@ -1,0 +1,72 @@
+package org.dspace.uclouvain.discovery;
+
+import static org.dspace.discovery.SearchUtils.FILTER_SEPARATOR;
+
+import org.apache.solr.common.SolrInputDocument;
+import org.dspace.content.Item;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Context;
+import org.dspace.discovery.IndexableObject;
+import org.dspace.discovery.SolrServiceIndexPlugin;
+import org.dspace.discovery.indexobject.IndexableClaimedTask;
+import org.dspace.discovery.indexobject.IndexableItem;
+import org.dspace.discovery.indexobject.IndexablePoolTask;
+import org.dspace.services.ConfigurationService;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * This class is a Solr indexing plugin that indexes the session and year fields as one field in Solr.
+ */
+public class SolrServiceSessionYearFieldIndexingPlugin implements SolrServiceIndexPlugin {
+
+    @Autowired
+    private ConfigurationService configurationService;
+
+    @Override
+    public void additionalIndex(Context context, IndexableObject dso, SolrInputDocument document){
+        Item item = this.getItem(dso);
+        if (item != null) {
+            this.generateSolrSessionYearField(item, document);
+        }
+    };
+
+    /**
+     * Get an instance of the item based on the handled types.
+     * @param dso: The object to get the item from.
+     * @return: The item instance or null if the object is not an instance of the handled types.
+     */
+    private Item getItem(IndexableObject dso) {
+        if (dso instanceof IndexablePoolTask) {
+            return ((IndexablePoolTask) dso).getIndexedObject().getWorkflowItem().getItem();
+        } else if (dso instanceof IndexableClaimedTask){
+            return ((IndexableClaimedTask) dso).getIndexedObject().getWorkflowItem().getItem();
+        } else if (dso instanceof IndexableItem){
+            return ((IndexableItem) dso).getIndexedObject();
+        }
+        return null;
+     }
+
+    /**
+     * Index the session and year fields as one in Solr.
+     * Here we need to index with the '_filter' & '_keyword' suffixes to allow for filtering and faceting.
+     * 
+     * @param item: The item to index.
+     * @param document: The Solr document to index.
+     */
+    private void generateSolrSessionYearField(Item item, SolrInputDocument document){
+        ItemService currentItemService = item.getItemService();
+        // TODO: Abstract this to configuration
+        String sessionValue = currentItemService.getMetadataFirstValue(item, "masterthesis", "session", null, null);
+        String yearValue = currentItemService.getMetadataFirstValue(item, "dc", "date", "issued", null);
+        
+        if (sessionValue != null && yearValue != null && !sessionValue.isEmpty() && !yearValue.isEmpty()){
+            String value = sessionValue + " " + yearValue;
+            String valueLowerCase = value.toLowerCase();
+
+            String separator = configurationService.getProperty("discovery.solr.facets.split.char", FILTER_SEPARATOR);
+
+            document.addField("sessionyear_filter", valueLowerCase + separator + value);
+            document.addField("sessionyear_keyword", value);
+        }
+    }
+}

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -24,6 +24,7 @@
 
     <context:annotation-config /> <!-- allows us to use spring annotations in beans -->
 
+    <bean id="solrServiceSessionYearFieldIndexingPlugin" class="org.dspace.uclouvain.discovery.SolrServiceSessionYearFieldIndexingPlugin" scope="prototype"/>
     <bean id="solrServiceResourceIndexPlugin" class="org.dspace.discovery.SolrServiceResourceRestrictionPlugin" scope="prototype"/>
     <bean id="solrServiceWorkspaceWorkflowPlugin" class="org.dspace.discovery.SolrServiceWorkspaceWorkflowRestrictionPlugin" scope="prototype"/>
     <bean id="solrServiceWorkflowMetadataRestrictionsPlugin" class="org.dspace.uclouvain.discovery.SolrServiceWorkflowMetadataRestrictionsPlugin" scope="prototype"/>
@@ -885,6 +886,7 @@
                 <!-- <ref bean="searchFilterSubmitter" /> -->
                 <ref bean="searchFilterFaculty"/>
                 <ref bean="searchFilterDegreeCode"/>
+                <ref bean="searchFilterSessionYear"/>
                 <ref bean="searchFilterAccessType"/>
             </list>
         </property>
@@ -898,6 +900,7 @@
                 <!-- <ref bean="searchFilterSubmitter" /> -->
                 <ref bean="searchFilterFaculty"/>
                 <ref bean="searchFilterDegreeCode"/>
+                <ref bean="searchFilterSessionYear"/>
                 <ref bean="searchFilterAccessType"/>
             </list>
         </property>
@@ -2822,6 +2825,14 @@
         <property name="pageSize" value="10"/>
         <property name="exposeMinAndMaxValue" value="true"/>
 
+    </bean>
+
+    <bean id="searchFilterSessionYear" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
+        <property name="indexFieldName" value="sessionyear"/>
+        <property name="type" value="text"/>
+        <property name="metadataFields">
+            <list/>
+        </property>
     </bean>
 
     <bean id="searchFilterContentInOriginalBundle" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">


### PR DESCRIPTION
#### First Commit: [[ADD] feat(Solr-Indexing): New Indexer for sessionyear field](https://github.com/bibsys/DSpace/commit/9f76067587f291532acaa99ce2a10a0eac75de04):

Added a new `Solr indexer` to concatenate both the session and the year, and then index this in Solr in the `sessionyear` field.

#### Second Commit: [[UPD] feat(facetting): New facet for sessionyear field in workflow validation](https://github.com/bibsys/DSpace/commit/ea47fa25168e7d14252a5e0e7222bc3dfe38d34d):

Using the previously created & indexed Solr fields, adds a new facet to the manager's workflow research page.