### PR TITLE
[UPD] feat(metadata-generators): `canBeProcessed` method for metadata generators

### DIFF
--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/submissionMetadataGenerators/GenerateMetadataServiceImpl.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/submissionMetadataGenerators/GenerateMetadataServiceImpl.java
@@ -13,7 +13,9 @@ public class GenerateMetadataServiceImpl implements GenerateMetadataService {
     public void executeMetadataGenerationSteps(Context ctx, Item item) throws Exception {
         for (MetadataGenerator mg: generateMetadataConfigurationService.getMetadataGenerators()) {
             try {
-                mg.process(ctx, item);
+                if (mg.canBeProcessed(ctx, item)) {
+                    mg.process(ctx, item);
+                }
             }
             catch (Exception e){
                 throw new Exception("An error occurred with the following metadata generator: " + mg.getGeneratorName(), e);

--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/submissionMetadataGenerators/generators/AccessTypeMetadataGenerator.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/submissionMetadataGenerators/generators/AccessTypeMetadataGenerator.java
@@ -19,6 +19,7 @@ public class AccessTypeMetadataGenerator implements MetadataGenerator {
     
     private String NAME = "accessTypeMetadataGenerator";
     private String MAIN_BUNDLE_NAME = "ORIGINAL";
+    private List<String> acceptedEntityTypes;
     private List<String> accessTypes = new ArrayList<String>();
     private MetadataField accessTypeField;
 
@@ -47,6 +48,18 @@ public class AccessTypeMetadataGenerator implements MetadataGenerator {
         } catch (Exception e) {
             throw new GeneratorProcessException("An unhandled exception occurred", e);
         }
+    }
+
+    /**
+     * Check if the item can be processed by this generator.
+     * 
+     * @param ctx: The DSpace context.
+     * @param item: The item to process.
+     */
+    @Override
+    public Boolean canBeProcessed(Context ctx, Item item) {
+        String currentEntityType = item.getItemService().getEntityType(item);
+        return currentEntityType != null && this.acceptedEntityTypes.contains(currentEntityType);
     }
 
     /**
@@ -104,6 +117,15 @@ public class AccessTypeMetadataGenerator implements MetadataGenerator {
     }
 
     // Getters && Setters
+
+    public List<String> getAcceptedEntityTypes() {
+        return this.acceptedEntityTypes;
+    }
+
+    public void setAcceptedEntityTypes(List<String> acceptedEntityTypes) {
+        this.acceptedEntityTypes = acceptedEntityTypes;
+    }
+
     public List<String> getAccessTypes() {
         return this.accessTypes;
     }

--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/submissionMetadataGenerators/generators/DegreeMetadataGenerator.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/submissionMetadataGenerators/generators/DegreeMetadataGenerator.java
@@ -30,6 +30,8 @@ public class DegreeMetadataGenerator implements MetadataGenerator {
 
     public String NAME = "degreeMetadataGenerator";
 
+    private List<String> acceptedEntityTypes;
+
     private MetadataField degreeCodeField;
 
     private MetadataField degreeLabelField;
@@ -103,6 +105,12 @@ public class DegreeMetadataGenerator implements MetadataGenerator {
         } catch (AuthorizeException e) {
             throw new GeneratorProcessException("Not authorized to update the item", e);
         }
+    }
+
+    @Override
+    public Boolean canBeProcessed(Context ctx, Item item) {
+        String currentEntityType = item.getItemService().getEntityType(item);
+        return currentEntityType != null && this.acceptedEntityTypes.contains(currentEntityType);
     }
 
     /**
@@ -210,6 +218,14 @@ public class DegreeMetadataGenerator implements MetadataGenerator {
     // -------------------
     // Getters && Setters
     // -------------------
+
+    public List<String> getAcceptedEntityTypes(){
+        return this.acceptedEntityTypes;
+    }
+
+    public void setAcceptedEntityTypes(List<String> acceptedEntityTypes){
+        this.acceptedEntityTypes = acceptedEntityTypes;
+    }
 
     public MetadataField getDegreeCodeField(){
         return this.degreeCodeField;

--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/submissionMetadataGenerators/generators/MetadataGenerator.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/submissionMetadataGenerators/generators/MetadataGenerator.java
@@ -7,4 +7,5 @@ import org.dspace.uclouvain.submissionMetadataGenerators.exceptions.GeneratorPro
 public interface MetadataGenerator {
     public String getGeneratorName();
     public void process(Context ctx, Item item) throws GeneratorProcessException;
+    public Boolean canBeProcessed(Context ctx, Item item);
 }

--- a/dspace/config/spring/uclouvain/uclouvain-external-services.xml
+++ b/dspace/config/spring/uclouvain/uclouvain-external-services.xml
@@ -72,6 +72,11 @@
     <bean id="generateMetadataService" class="org.dspace.uclouvain.submissionMetadataGenerators.GenerateMetadataServiceImpl"/>
 
     <bean id="degreeMetadataGenerator" class="org.dspace.uclouvain.submissionMetadataGenerators.generators.DegreeMetadataGenerator">
+        <property name="acceptedEntityTypes">
+            <util:list>
+                <value>MasterThesis</value>
+            </util:list>
+        </property>
         <property name="degreeCodeField" >
             <bean class="org.dspace.uclouvain.core.model.MetadataField">
                 <constructor-arg value="masterthesis.degree.code"/>
@@ -105,6 +110,11 @@
     </bean>
 
     <bean id="accessTypeMetadataGenerator" class="org.dspace.uclouvain.submissionMetadataGenerators.generators.AccessTypeMetadataGenerator">
+        <property name="acceptedEntityTypes">
+            <util:list>
+                <value>MasterThesis</value>
+            </util:list>
+        </property>
         <!-- List of accessTypes that are handled by the generator -->
         <property name="accessTypes">
             <util:list>


### PR DESCRIPTION
Added a boolean method that tells if a metadata generator can be used on the current item. This method can be overridden to allow different behavior from one action to another.