### PR TITLE
[ADD] feat(promoter-discovery-config): Discovery config to allow promoter to see related archived items

### DIFF
--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/discovery/SolrServicePromoterItemPlugin.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/discovery/SolrServicePromoterItemPlugin.java
@@ -1,0 +1,24 @@
+package org.dspace.uclouvain.discovery;
+
+import org.apache.solr.client.solrj.SolrQuery;
+import org.dspace.core.Context;
+import org.dspace.discovery.DiscoverQuery;
+import org.dspace.discovery.SearchServiceException;
+import org.dspace.discovery.SolrServiceSearchPlugin;
+import org.dspace.eperson.EPerson;
+
+public class SolrServicePromoterItemPlugin implements SolrServiceSearchPlugin {
+    public static final String DISCOVER_PROMOTER_CONFIGURATION_NAME = "promoter";
+
+    @Override
+    public void additionalSearchParameters(Context context, DiscoverQuery discoveryQuery, SolrQuery solrQuery) throws SearchServiceException {
+        // Check if the current discovery configuration is for the promoter discovery
+        boolean isPromoterDiscovery = DISCOVER_PROMOTER_CONFIGURATION_NAME.equals(discoveryQuery.getDiscoveryConfigurationName());
+
+        EPerson currentPerson = context.getCurrentUser();
+        if (currentPerson != null && isPromoterDiscovery) {
+            // Add a filter to the query that checks for the item field 'advisors.email'
+            solrQuery.addFilterQuery("advisors.email:" + currentPerson.getEmail());
+        }
+    }
+}

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -24,6 +24,7 @@
 
     <context:annotation-config /> <!-- allows us to use spring annotations in beans -->
 
+    <bean id="solrServicePromoterItemPlugin" class="org.dspace.uclouvain.discovery.SolrServicePromoterItemPlugin" scope="prototype"/>
     <bean id="solrServiceSessionYearFieldIndexingPlugin" class="org.dspace.uclouvain.discovery.SolrServiceSessionYearFieldIndexingPlugin" scope="prototype"/>
     <bean id="solrServiceResourceIndexPlugin" class="org.dspace.discovery.SolrServiceResourceRestrictionPlugin" scope="prototype"/>
     <bean id="solrServiceWorkspaceWorkflowPlugin" class="org.dspace.discovery.SolrServiceWorkspaceWorkflowRestrictionPlugin" scope="prototype"/>
@@ -100,6 +101,9 @@
                 <entry key="workflowAdmin" value-ref="workflowAdminConfiguration" />
                 <!-- "supervision" is a special entry to search for all workspace and workflow items if you are an administrator -->
                 <entry key="supervision" value-ref="supervisionConfiguration" />
+
+                <!-- "promoter" is a special entry to search for the promoter's kined items -->
+                <entry key="promoter" value-ref="promoterConfiguration" />
 
                 <entry key="undiscoverable" value-ref="unDiscoverableItems" />
                 <entry key="administrativeView" value-ref="administrativeView" />
@@ -186,6 +190,40 @@
                     </list>
                 </entry>
             </map>
+        </property>
+    </bean>
+
+    <bean id="promoterConfiguration" class="org.dspace.discovery.configuration.DiscoveryConfiguration" scope="prototype">
+        <property name="id" value="promoterConfiguration"/>
+        <property name="sidebarFacets">
+            <list>
+                <ref bean="searchFilterIssued" />
+                <ref bean="searchFilterAuthor" />
+            </list>
+        </property>
+        <property name="searchFilters">
+            <list>
+                <ref bean="searchFilterIssued" />
+                <ref bean="searchFilterAuthor" />
+            </list>
+        </property>
+        <property name="searchSortConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
+                <property name="defaultSortField" ref="sortLastModified" />
+                <property name="sortFields">
+                    <list>
+                        <ref bean="sortLastModified" />
+                        <ref bean="sortTitleAsc" />
+                        <ref bean="sortDateIssuedDesc" />
+                    </list>
+                </property>
+            </bean>
+        </property>
+        <property name="defaultFilterQueries">
+            <list>
+                <value>search.resourcetype:Item</value>
+                <value>withdrawn:false AND discoverable:true</value>
+            </list>
         </property>
     </bean>
 


### PR DESCRIPTION
New configuration in `discovery.xml` that allows a promoter to log in and to see all the related submission in the 'mydspace' page.
