### PR TITLE
[UPD] feat(backend-fixes): Global search, profile edit and profile file upload.

### DIFF
--- a/dspace/config/item-submission.xml
+++ b/dspace/config/item-submission.xml
@@ -300,19 +300,19 @@
       <step id="custom-url" />
       <step id="correction" />
       <step id="detect-duplicate" />
-      <step id="upload" />
+      <!-- <step id="upload" /> -->
       <step id="license" />
     </submission-process>
     <submission-process name="person-edit">
       <step id="person" />
       <step id="custom-url" />
-      <step id="upload" />
+      <!-- <step id="upload" /> -->
     </submission-process>
     <submission-process name="admin-person-edit">
       <step id="person" />
       <step id="custom-url" />
       <step id="owner" />
-      <step id="upload" />
+      <!-- <step id="upload" /> -->
     </submission-process>
     <submission-process name="event">
       <step id="collection" />

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -738,7 +738,7 @@
 		            global search. Replace the following filter with the commented one if you
 		            prefer the default dspace behavior -->
                 <value>search.resourcetype:Item</value>
-                <value>-withdrawn:true AND -discoverable:false</value>
+                <value>-withdrawn:true AND -discoverable:false AND entityType:MasterThesis</value>
             </list>
         </property>
         <!-- Limit recent submissions on homepage to only 5 (default is 20) -->

--- a/dspace/config/spring/api/edititem-service.xml
+++ b/dspace/config/spring/api/edititem-service.xml
@@ -34,7 +34,7 @@
                             </property>
                             <property name="submissionDefinition" value="admin-person-edit" />
                         </bean>
-                        <bean class="org.dspace.content.edit.EditItemMode">
+                        <!-- <bean class="org.dspace.content.edit.EditItemMode">
                             <property name="name" value="OWNER" />
                             <property name="security">
                                 <value type="org.dspace.content.security.CrisSecurity">
@@ -42,7 +42,7 @@
                                 </value>
                             </property>
                             <property name="submissionDefinition" value="person-edit" />
-                        </bean>
+                        </bean> -->
                     </list>
                 </entry>
                 <entry key="equipment">


### PR DESCRIPTION
[Master Thesis specific]
-- Global Search --
Adding a new condition into the Solr query for the global search: 'entityType:MasterThesis'. This forces Solr to only return Item with a 'entityType' of 'MasterThesis' and so it does not return Person items.

-- Profile Edit --
A user can no longer edit his profile. This prevents the manager from changing his managed degree codes.

-- Profile File Upload --
We no longer need to upload a file when creating/modifying a user researcher profile. Done by modifying the form for this functionnality called 'person-edit'.

This commit is specific for the master thesis repository and is then separated from the others.
