### PR TITLE
Resource policies API for bitstreams && items

### DIFF
--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/core/model/ResourcePolicyRestModel.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/core/model/ResourcePolicyRestModel.java
@@ -1,0 +1,29 @@
+package org.dspace.uclouvain.core.model;
+
+import java.util.Date;
+
+import org.dspace.authorize.ResourcePolicy;
+
+// This model represents a resource policy to be returned as an API call response.
+public class ResourcePolicyRestModel {
+
+    public ResourcePolicyRestModel(ResourcePolicy resourcePolicy) {
+        this.id = resourcePolicy.getID().toString();
+        this.name = resourcePolicy.getRpName();
+        this.description = resourcePolicy.getRpDescription();
+        this.policyType = resourcePolicy.getRpType();
+        this.action = resourcePolicy.getAction();
+        this.startDate = resourcePolicy.getStartDate();
+        this.endDate = resourcePolicy.getEndDate();
+        this.type = resourcePolicy.getGroup().getName();
+    }
+
+    public String id;
+    public String name;
+    public String description;
+    public String policyType;
+    public int action;
+    public Date startDate;
+    public Date endDate;
+    public String type;
+}

--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/core/model/ResourcePolicyRestResponse.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/core/model/ResourcePolicyRestResponse.java
@@ -1,0 +1,34 @@
+package org.dspace.uclouvain.core.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.dspace.authorize.ResourcePolicy;
+
+/**
+ * This is a class that returns resource policy information for a REST API response.
+ */
+public class ResourcePolicyRestResponse {
+    public List<ResourcePolicyRestModel> restPolicies = new ArrayList<ResourcePolicyRestModel>();
+    public ResourcePolicyRestModel masterPolicy;
+
+    /**
+     * Main constructor for the ResourcePolicyRestResponse class.
+     * It filters the policies by type and creates a list of ResourcePolicyRestModel objects.
+     * @param policies: The list of resource policies to use to instantiate the classes.
+     * @param type: A type to filter the policies by.
+     */
+    public ResourcePolicyRestResponse(List<ResourcePolicy> policies, String type) {
+        this(policies.stream().filter(p -> p.getRpType().equals(type)).collect(Collectors.toList()));
+    }
+
+    /**
+     * Main constructor for the ResourcePolicyRestResponse class.
+     * It creates a list of ResourcePolicyRestModel objects without any filtering.
+     * @param policies: The list of resource policies to use to instantiate the classes.
+     */
+    public ResourcePolicyRestResponse(List<ResourcePolicy> policies) {
+        policies.forEach(p -> this.restPolicies.add(new ResourcePolicyRestModel(p)));
+    }
+}

--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/core/utils/ItemUtils.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/core/utils/ItemUtils.java
@@ -1,0 +1,35 @@
+package org.dspace.uclouvain.core.utils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
+import org.dspace.content.Item;
+import org.dspace.services.factory.DSpaceServicesFactory;
+
+/** 
+* Set of util methods for an `Item` object.
+*/
+public class ItemUtils {
+    /** 
+    * This method is used to extract the files's bit stream from an item.
+    * 
+    * @param DSpaceItem: The item to extract files from.
+    * @return The list of bit streams for the given item.
+    */
+    public static List<Bitstream> extractItemFiles(Item DSpaceItem) {
+        // Configuration which indicates the bundles to use. 
+        List<String> acceptedBundles = Arrays.asList(
+            DSpaceServicesFactory.getInstance().getConfigurationService().getArrayProperty("uclouvain.resource_policy.accepted_bundles")
+        );
+        List<Bitstream> bitstreams = new ArrayList<Bitstream>();
+        for (Bundle bundle: DSpaceItem.getBundles()) {
+            if (acceptedBundles.contains(bundle.getName())) {
+                bitstreams.addAll(bundle.getBitstreams());
+            }
+        }
+        return bitstreams;
+    }
+}

--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/core/utils/MetadataUtils.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/core/utils/MetadataUtils.java
@@ -4,9 +4,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import org.dspace.content.Bitstream;
-import org.dspace.content.Bundle;
-import org.dspace.content.Item;
 import org.dspace.content.MetadataValue;
 
 /** 
@@ -59,21 +56,6 @@ public class MetadataUtils {
     public static String extractItemType(String inputType) {
         String[] splitted = inputType.split("::");
         return splitted[splitted.length - 1];
-    }
-
-    /** 
-    * This method is used to extract the files's bit stream from an item.
-    * 
-    * @param DSpaceItem: The item to extract files from.
-    * @return The list of bit streams for the given item.
-    */
-    public static List<Bitstream> extractItemFiles(Item DSpaceItem) {
-        for (Bundle bundle: DSpaceItem.getBundles()) {
-            if (bundle.getName().equals("ORIGINAL")) {
-                return bundle.getBitstreams();
-            }
-        }
-        return new ArrayList<Bitstream>();
     }
 
     /** 

--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/pdfAttestationGenerator/handlers/MasterThesisPdfAttestationGeneratorHandler.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/pdfAttestationGenerator/handlers/MasterThesisPdfAttestationGeneratorHandler.java
@@ -29,10 +29,13 @@ import org.dspace.content.MetadataValue;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Context;
 import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.uclouvain.core.model.ResourcePolicyRestModel;
+import org.dspace.uclouvain.core.utils.ItemUtils;
 import org.dspace.uclouvain.core.utils.MetadataUtils;
 import org.dspace.uclouvain.pdfAttestationGenerator.configuration.PDFAttestationGeneratorConfiguration;
 import org.dspace.uclouvain.pdfAttestationGenerator.exceptions.PDFGenerationException;
 import org.dspace.uclouvain.pdfAttestationGenerator.model.MasterThesisPDFAttestationModel;
+import org.dspace.uclouvain.services.ResourcePolicyUtilService;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /** 
@@ -48,6 +51,9 @@ public class MasterThesisPdfAttestationGeneratorHandler implements PDFAttestatio
 
     @Autowired
     PDFAttestationGeneratorConfiguration config;
+
+    @Autowired
+    ResourcePolicyUtilService resourcePolicyUtilService;
 
     private String templateName;
 
@@ -157,9 +163,12 @@ public class MasterThesisPdfAttestationGeneratorHandler implements PDFAttestatio
         pdfModel.handle = "http://handle.net/";
         
         // Add files to model
-        // TODO: Recover permissions for each files ?? => For now, HARD CODED.
-        for (Bitstream bitstream: MetadataUtils.extractItemFiles(dspaceItem)) {
-            pdfModel.addFile(bitstream.getName(), "Open access");
+        for (Bitstream bitstream: ItemUtils.extractItemFiles(dspaceItem)) {
+            ResourcePolicyRestModel masterPolicy = this.resourcePolicyUtilService.getRestResponse(bitstream.getResourcePolicies()).masterPolicy;
+            pdfModel.addFile(
+                bitstream.getName(),
+                masterPolicy != null ? masterPolicy.name : "Open Access"
+            );
         }
 
         pdfModel.abstractText = map.get("dc_description_abstract").get(0);

--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/rest/ResourcePoliciesRestController.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/rest/ResourcePoliciesRestController.java
@@ -1,0 +1,107 @@
+package org.dspace.uclouvain.rest;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.dspace.authorize.ResourcePolicy;
+import org.dspace.authorize.service.ResourcePolicyService;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
+import org.dspace.content.Item;
+import org.dspace.content.service.BitstreamService;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Context;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.uclouvain.core.model.ResourcePolicyRestModel;
+import org.dspace.uclouvain.core.model.ResourcePolicyRestResponse;
+import org.dspace.uclouvain.services.ResourcePolicyUtilService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Controller that can be used to retrieve resource policies information for a given dspace object.
+ */
+@RestController
+@RequestMapping("/api/uclouvain/resourcepolicies")
+public class ResourcePoliciesRestController {
+
+    // List of all accepted bundles that will be used to generate the global access type of an item.
+    private List<String> acceptedBundles = Arrays.asList(
+        DSpaceServicesFactory.getInstance().getConfigurationService().getArrayProperty("uclouvain.resource_policy.accepted_bundles")
+    );
+
+    @Autowired
+    private ResourcePolicyService resourcePolicyService;
+
+    @Autowired
+    private BitstreamService bitstreamService;
+
+    @Autowired
+    private ItemService itemService;
+
+    @Autowired
+    private ResourcePolicyUtilService resourcePolicyUtilService;
+
+    /**
+     * Endpoint to retrieve resource policies information for a given bitstream UUID.
+     * @param context: The current DSpace context.
+     * @param id: The UUID of the bitstream to search resource policies of.
+     * @return A ResourcePolicyRestResponse object giving all the resource policies for the bitstream.
+     * @throws SQLException
+     * @throws IOException
+     */
+    @RequestMapping(value = "/bitstream/{id}", method = RequestMethod.GET)
+    public ResourcePolicyRestResponse getResourcePolicies(Context context, @PathVariable UUID id, HttpServletResponse response) throws SQLException, IOException {
+        Bitstream bitstream = bitstreamService.find(context, id);
+        if (bitstream != null) {
+            List<ResourcePolicy> rp = resourcePolicyService.find(context, bitstream);
+            return this.resourcePolicyUtilService.getRestResponse(rp);
+        }
+        response.sendError(400, "Object not found or not a bitstream");
+        return null;
+    }
+
+    /**
+     * Endpoint to retrieve the main access type for a given item UUID.
+     * @param context: The current DSpace context.
+     * @param id: The UUID of the item to search resource policies of.
+     * @return A global policy generated from all the master policies of the item's bitstreams.
+     * @throws SQLException
+     * @throws IOException
+     */
+    @RequestMapping(value = "/item/{id}", method = RequestMethod.GET)
+    public HashMap<String, String> getItemGlobalPolicy(Context context, @PathVariable UUID id, HttpServletResponse response) throws SQLException, IOException {
+        Item item = itemService.find(context, id);
+        if (item != null) {
+            List<String> rpTypes = new ArrayList<String>();
+            for (Bundle bundle: item.getBundles()) {
+                // Retrieve all the bitstreams from the accepted bundles and get their master policy.
+                if (this.acceptedBundles.contains(bundle.getName())){
+                    for (Bitstream bs: bundle.getBitstreams()) {
+                        ResourcePolicyRestModel masterPolicy = this.resourcePolicyUtilService.getRestResponse(bs.getResourcePolicies()).masterPolicy;
+                        if (masterPolicy != null) {
+                            rpTypes.add(masterPolicy.name);
+                        }
+                    }
+                }
+            }
+            // Use hashmap object to return the global access type of the item in a JSON format.
+            HashMap<String, String> responseMap = new HashMap<String, String>();
+            // From all the master policies, generate the global access type of the item.
+            responseMap.put("globalAccessType", this.resourcePolicyUtilService.getGlobalAccessType(rpTypes));
+            return responseMap;
+        }
+        response.sendError(400, "Object not found or not an item");
+        return null;
+    }
+}

--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/services/ResourcePolicyUtilService.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/services/ResourcePolicyUtilService.java
@@ -1,0 +1,137 @@
+package org.dspace.uclouvain.services;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.dspace.authorize.ResourcePolicy;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
+import org.dspace.content.Item;
+import org.dspace.core.Context;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.uclouvain.constants.AccessConditions;
+import org.dspace.uclouvain.core.model.ResourcePolicyRestModel;
+import org.dspace.uclouvain.core.model.ResourcePolicyRestResponse;
+
+/**
+ * Service to handle different operations related to resource policies.
+ */
+public class ResourcePolicyUtilService {
+    private List<String> acceptedBundles = Arrays.asList(
+        DSpaceServicesFactory.getInstance().getConfigurationService().getArrayProperty("uclouvain.resource_policy.accepted_bundles")
+    );
+    /**
+     * 'typeList' controls the handled access types for a resource policy.
+     * The order matters and sets the 'weight' of each access type.
+     */
+    private List<String> typeList;
+
+
+    /**
+     * Retrieve a 'ResourcePolicyRestResponse' object from a list of resource policies.
+     * This object contains the list of resource policies converted to a list of 'ResourcePolicyRestModel'
+     * and a 'masterPolicy'.
+     */
+    public ResourcePolicyRestResponse getRestResponse(List<ResourcePolicy> rp) {
+        ResourcePolicyRestResponse rpRestResponse = new ResourcePolicyRestResponse(rp, ResourcePolicy.TYPE_CUSTOM);
+        this.setMasterPolicy(rpRestResponse);
+        return rpRestResponse;
+    };
+
+    /**
+     * Finds out the main policy among a list. The logic to give the master policy is influenced by the 'typeList'.
+     * @param rpRestResponse: A object containing the list of all the resource policy of a bitstream.
+     */
+    private void setMasterPolicy(ResourcePolicyRestResponse rpRestResponse) {
+        List<ResourcePolicyRestModel> activePolicies = rpRestResponse.restPolicies.stream()
+            // Only keep active embargo
+            .filter(
+                policy -> {
+                    if(policy.name.equals("embargo")){
+                        long currentDate = new Date().getTime();
+                        return policy.startDate != null && (currentDate < policy.startDate.getTime());
+                    }
+                    return true;
+                }
+            )
+            .collect(Collectors.toList());
+        List<String> policiesTypes = activePolicies.stream().map(x -> x.name).collect(Collectors.toList());
+
+        for (String type: this.typeList) {
+            if (policiesTypes.contains(type)){
+                rpRestResponse.masterPolicy = this.getResourceForType(type, activePolicies);
+                return;
+            }
+        }
+    }
+
+    private ResourcePolicyRestModel getResourceForType(String type, List<ResourcePolicyRestModel> policies){
+        return policies.stream().filter(x -> x.name.equals(type)).findFirst().orElse(null);
+    }
+
+    /**
+     * Extract a list of access types from the bitstreams of an item.
+     * @param ctx: The current DSpace context.
+     * @param item: The item to extract bitstream from.
+     * @return A list of access types for the given item.
+     */
+    public List<String> extractItemAccessTypes(Context ctx, Item item) {
+        List<ResourcePolicy> allItemResourcePolicies = new ArrayList<ResourcePolicy>();
+        for (Bundle bundle: item.getBundles()) {
+            // Retrieve bitstreams only from the configured bundles
+            if (this.acceptedBundles.contains(bundle.getName())) {
+                // For each bitstream, add resource policies to the list
+                for (Bitstream bs: bundle.getBitstreams()) {
+                    allItemResourcePolicies.addAll(bs.getResourcePolicies());
+                }
+            }
+        }
+        // Return only the "rpname" of the resource policies which have the type "custom" and are in the list of controlled access types.
+        // RP that have the type "custom" are the one that are assigned by the user in the file form.
+        return allItemResourcePolicies.stream().filter(
+            (rp) -> {
+                return rp.getRpType().equals(ResourcePolicy.TYPE_CUSTOM) && this.typeList.contains(rp.getRpName());
+            }
+        ).map(
+            rp -> rp.getRpName()
+        ).collect(Collectors.toList());
+    }
+
+    /**
+     * Retrieve the global access type for a given list of access types.
+     * @param accessTypes: The list of all the different access types.
+     * @return The processed global access type.
+     */
+    public String getGlobalAccessType(List<String> accessTypes) {
+        if (accessTypes.isEmpty()){
+            return null;
+        }
+        // filter to keep only distinct values
+        accessTypes = accessTypes.stream().distinct().collect(Collectors.toList());
+        // * If list contains only 1 value, just return this value as global access type.
+        // * If list contains only `embargo` and `openaccess`, just return OA because when the embargo will be over, then all
+        // * bitstream will be OA.
+        // * In case multiple access conditions are detected, just return `mixed`.
+        if (accessTypes.size() == 1){
+            return accessTypes.get(0);
+        } else if (accessTypes.size() == 2 &&
+                   accessTypes.contains(AccessConditions.EMBARGO) &&
+                   accessTypes.contains(AccessConditions.OPEN_ACCESS)) {
+            return AccessConditions.OPEN_ACCESS;
+        } else {
+            return AccessConditions.MIXED;
+        }
+    }
+
+    // Getters && Setters
+    public List<String> getTypeList() {
+        return this.typeList;
+    }
+
+    public void setTypeList(List<String> typeList) {
+        this.typeList = typeList;
+    }
+}

--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/services/ResourcePolicyUtilService.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/services/ResourcePolicyUtilService.java
@@ -1,28 +1,23 @@
 package org.dspace.uclouvain.services;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.dspace.authorize.ResourcePolicy;
 import org.dspace.content.Bitstream;
-import org.dspace.content.Bundle;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
-import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.uclouvain.constants.AccessConditions;
 import org.dspace.uclouvain.core.model.ResourcePolicyRestModel;
 import org.dspace.uclouvain.core.model.ResourcePolicyRestResponse;
+import org.dspace.uclouvain.core.utils.ItemUtils;
 
 /**
  * Service to handle different operations related to resource policies.
  */
 public class ResourcePolicyUtilService {
-    private List<String> acceptedBundles = Arrays.asList(
-        DSpaceServicesFactory.getInstance().getConfigurationService().getArrayProperty("uclouvain.resource_policy.accepted_bundles")
-    );
     /**
      * 'typeList' controls the handled access types for a resource policy.
      * The order matters and sets the 'weight' of each access type.
@@ -80,14 +75,8 @@ public class ResourcePolicyUtilService {
      */
     public List<String> extractItemAccessTypes(Context ctx, Item item) {
         List<ResourcePolicy> allItemResourcePolicies = new ArrayList<ResourcePolicy>();
-        for (Bundle bundle: item.getBundles()) {
-            // Retrieve bitstreams only from the configured bundles
-            if (this.acceptedBundles.contains(bundle.getName())) {
-                // For each bitstream, add resource policies to the list
-                for (Bitstream bs: bundle.getBitstreams()) {
-                    allItemResourcePolicies.addAll(bs.getResourcePolicies());
-                }
-            }
+        for (Bitstream bs: ItemUtils.extractItemFiles(item)) {
+            allItemResourcePolicies.addAll(bs.getResourcePolicies());
         }
         // Return only the "rpname" of the resource policies which have the type "custom" and are in the list of controlled access types.
         // RP that have the type "custom" are the one that are assigned by the user in the file form.

--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/submissionMetadataGenerators/generators/AccessTypeMetadataGenerator.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/submissionMetadataGenerators/generators/AccessTypeMetadataGenerator.java
@@ -1,41 +1,43 @@
 package org.dspace.uclouvain.submissionMetadataGenerators.generators;
 
-import org.dspace.authorize.ResourcePolicy;
-import org.dspace.content.Bitstream;
-import org.dspace.content.Bundle;
 import org.dspace.content.Item;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Context;
-import org.dspace.uclouvain.constants.AccessConditions;
 import org.dspace.uclouvain.core.model.MetadataField;
+import org.dspace.uclouvain.services.ResourcePolicyUtilService;
 import org.dspace.uclouvain.submissionMetadataGenerators.exceptions.GeneratorProcessException;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class AccessTypeMetadataGenerator implements MetadataGenerator {
     
     private String NAME = "accessTypeMetadataGenerator";
-    private String MAIN_BUNDLE_NAME = "ORIGINAL";
     private List<String> acceptedEntityTypes;
-    private List<String> accessTypes = new ArrayList<String>();
     private MetadataField accessTypeField;
+
+    @Autowired
+    private ResourcePolicyUtilService resourcePoliciesUtilService;
+
+    @Autowired
+    private ItemService itemService;
 
     @Override
     public String getGeneratorName() {
         return this.NAME;
     }
 
+    /**
+     * Retrieve all the access types of the item and generate the global access type from them.
+     */
     @Override
     public void process(Context ctx, Item item) throws GeneratorProcessException {
         try {
-            ItemService currentItemService = item.getItemService();
-            List<String> accessTypesRP = this.extractFileAccessTypeList(ctx, item);
-            String globalAccessType = this.getGlobalAccessType(accessTypesRP);
+            List<String> accessTypesRP = this.resourcePoliciesUtilService.extractItemAccessTypes(ctx, item);
+            String globalAccessType = this.resourcePoliciesUtilService.getGlobalAccessType(accessTypesRP);
             if (globalAccessType != null) {
-                currentItemService.setMetadataSingleValue(ctx, item,
+                this.itemService.setMetadataSingleValue(ctx, item,
                         this.accessTypeField.getSchema(),
                         this.accessTypeField.getElement(),
                         this.accessTypeField.getQualifier(),
@@ -62,60 +64,6 @@ public class AccessTypeMetadataGenerator implements MetadataGenerator {
         return currentEntityType != null && this.acceptedEntityTypes.contains(currentEntityType);
     }
 
-    /**
-     * Extract the list of access types from the item's bitstreams
-     * @param ctx: The DSpace context
-     * @param item: The item to process
-     * @return A list of access types
-     */
-    private List<String> extractFileAccessTypeList(Context ctx, Item item) {
-        List<Bundle> bundles = item.getBundles();
-        List<ResourcePolicy> allItemResourcePolicies = new ArrayList<ResourcePolicy>();
-        for (Bundle bundle: bundles) {
-            // Retrieve bitstreams from the main file bundle
-            if (bundle.getName().equals(MAIN_BUNDLE_NAME)) {
-                // For each bitstream, add resource policies to the list
-                for (Bitstream bs: bundle.getBitstreams()) {
-                    allItemResourcePolicies.addAll(bs.getResourcePolicies());
-                }
-            }
-        }
-        // Return only the "rpname" of the resource policies which have the type "custom" and are in the list of controlled access types 
-        return allItemResourcePolicies.stream().filter(
-            (rp) -> {
-                return rp.getRpType().equals(ResourcePolicy.TYPE_CUSTOM) && this.accessTypes.contains(rp.getRpName());
-            }
-        ).map(
-            rp -> rp.getRpName()
-        ).collect(Collectors.toList());
-    }
-
-    /**
-     * Retrieve the global access type for a given list of access types
-     * @param accessTypes: The list of all the different access types
-     * @return The processed global access type
-     */
-    private String getGlobalAccessType(List<String> accessTypes) {
-        if (accessTypes.isEmpty()){
-            return null;
-        }
-        // filter to keep only distinct values
-        accessTypes = accessTypes.stream().distinct().collect(Collectors.toList());
-        // * If list contains only 1 value, just return this value as global access type
-        // * If list contains only `embargo` and `openaccess`, just return OA because when embargo will be over, then all
-        //   bitstream will be OA.
-        // * Otherwise, multiple access conditions are detected, just return `mixed`
-        if (accessTypes.size() == 1){
-            return accessTypes.get(0);
-        } else if (accessTypes.size() == 2 &&
-                   accessTypes.contains(AccessConditions.EMBARGO) &&
-                   accessTypes.contains(AccessConditions.OPEN_ACCESS)) {
-            return AccessConditions.OPEN_ACCESS;
-        } else {
-            return AccessConditions.MIXED;
-        }
-    }
-
     // Getters && Setters
 
     public List<String> getAcceptedEntityTypes() {
@@ -124,14 +72,6 @@ public class AccessTypeMetadataGenerator implements MetadataGenerator {
 
     public void setAcceptedEntityTypes(List<String> acceptedEntityTypes) {
         this.acceptedEntityTypes = acceptedEntityTypes;
-    }
-
-    public List<String> getAccessTypes() {
-        return this.accessTypes;
-    }
-
-    public void setAccessTypes(List<String> accessTypes) {
-        this.accessTypes = accessTypes;
     }
 
     public MetadataField getAccessTypeField() {

--- a/dspace/config/modules/uclouvain.cfg
+++ b/dspace/config/modules/uclouvain.cfg
@@ -44,6 +44,11 @@ mets.dspaceSIP.ingest.manifestBitstreamFormat=XML
 uclouvain.solr.plugin.workflow.degree.field.filter = degreecode_keyword
 uclouvain.solr.plugin.workflow.degree.field.metadata = crisrp.workgroup
 
+# Resource policy endpoint configuration
+uclouvain.resource_policy.accepted_bundles = ORIGINAL
+# Could add more bundle by adding more occurence of this key: 
+# ex: uclouvain.resource_policy.accepted_bundles = METADATA
+
 #-----------------------------------------------------------#
 #------------------Feature Configuration--------------------#
 #-----------------------------------------------------------#

--- a/dspace/config/spring/uclouvain/uclouvain-external-services.xml
+++ b/dspace/config/spring/uclouvain/uclouvain-external-services.xml
@@ -135,15 +135,6 @@
                 <value>MasterThesis</value>
             </util:list>
         </property>
-        <!-- List of accessTypes that are handled by the generator -->
-        <property name="accessTypes">
-            <util:list>
-                <value>openaccess</value>
-                <value>UCLouvain networks restriction</value>
-                <value>embargo</value>
-                <value>administrator</value>
-            </util:list>
-        </property>
         <!-- The field in which the new metadata will go in -->
         <property name="accessTypeField">
             <bean class="org.dspace.uclouvain.core.model.MetadataField">
@@ -177,5 +168,20 @@
     <bean id="degreeMappersConfigurationFile" class="org.dspace.uclouvain.configurationFiles.files.DegreeMappersConfigurationFile">
         <!-- Relative path to the configuration file -->
         <constructor-arg value="/config/mapping/json/degree-mappers.json"/>
+    </bean>
+
+    <!-- CUSTOM RESOURCE POLICIES SERVICE -->
+    <bean id="resourcePolicyUtilService" class="org.dspace.uclouvain.services.ResourcePolicyUtilService">
+        <property name="typeList">
+            <util:list>
+                <!-- List of policy types sorted by weight-->
+                <!-- Forbidden Access -->
+                <value>administrator</value>
+                <!-- Restricted Access -->
+                <value>UCLouvain networks restriction</value>
+                <value>embargo</value>
+                <value>openaccess</value>
+            </util:list>
+        </property>
     </bean>
 </beans>


### PR DESCRIPTION
New API that can be used to retrieve resource policies information about a given bitstream or item.
One endpoint to handle the 'item' type and one for the 'bitstream' type.
Also added a service (to group similar code from 'AccessTypeMetadataGenerator') called 'ResourcePolicyUtilService'.