### PR TITLE
[UPD] feat(RP-API): Add 'access' bistream subresource API

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/BitstreamAccessConditionConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/BitstreamAccessConditionConverter.java
@@ -1,0 +1,71 @@
+package org.dspace.app.rest.converter;
+
+import org.dspace.app.rest.model.AccessConditionDTO;
+import org.dspace.app.rest.model.BitstreamAccessConditionRest;
+import org.dspace.app.rest.projection.Projection;
+import org.dspace.authorize.ResourcePolicy;
+import org.dspace.app.rest.model.BitstreamAccessConditions;
+import org.dspace.uclouvain.services.UCLouvainResourcePolicyService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * This is the converter from/to the BitstreamAccessCondition in the DSpace API data model and
+ * the REST data model
+ *
+ * @author Renaud Michotte (renaud.michotte@uclouvain.be)
+ */
+@Component
+public class BitstreamAccessConditionConverter implements DSpaceConverter<BitstreamAccessConditions, BitstreamAccessConditionRest> {
+
+    @Autowired
+    UCLouvainResourcePolicyService uclouvainResourcePolicyService;
+
+    @Override
+    public BitstreamAccessConditionRest convert(BitstreamAccessConditions bac, Projection projection) {
+        BitstreamAccessConditionRest response = new BitstreamAccessConditionRest();
+
+        UUID bitstreamID = (bac.getPolicies().isEmpty()) ? UUID.randomUUID() : bac.getPolicies().get(0).getdSpaceObject().getID();
+        ResourcePolicy masterPolicy = uclouvainResourcePolicyService.getMasterPolicy(bac.getPolicies());
+
+        response.setProjection(projection);
+        response.setId(bitstreamID);
+        response.setPolicies(convertPoliciesToAccessConditions(bac.getPolicies()));
+        if (masterPolicy != null) {
+            response.setMasterPolicy(createAccessConditionFromResourcePolicy(masterPolicy));
+        }
+        return response;
+    }
+
+    @Override
+    public Class<BitstreamAccessConditions> getModelClass() {
+        return BitstreamAccessConditions.class;
+    }
+
+    /** Utils method used to convert a list of {@link org.dspace.authorize.ResourcePolicy} to a list of
+     * serializable {@link org.dspace.app.rest.model.AccessConditionDTO}
+     * @param policies: The policies to convert
+     * @return the corresponding `AccessConditionDTO` list
+     */
+    private List<AccessConditionDTO> convertPoliciesToAccessConditions(List<ResourcePolicy> policies) {
+        return policies
+                .stream()
+                .map(this::createAccessConditionFromResourcePolicy)
+                .collect(Collectors.toList());
+    }
+
+    private AccessConditionDTO createAccessConditionFromResourcePolicy(ResourcePolicy rp) {
+        AccessConditionDTO accessCondition = new AccessConditionDTO();
+        accessCondition.setId(rp.getID());
+        accessCondition.setName(rp.getRpName());
+        accessCondition.setDescription(rp.getRpDescription());
+        accessCondition.setStartDate(rp.getStartDate());
+        accessCondition.setEndDate(rp.getEndDate());
+        return accessCondition;
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/BitstreamAccessConditionRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/BitstreamAccessConditionRest.java
@@ -1,0 +1,47 @@
+package org.dspace.app.rest.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.dspace.app.rest.RestResourceController;
+
+import java.util.List;
+import java.util.UUID;
+
+/** The BitstreamAccessConditions REST Resource
+ *
+ * @author Renaud Michotte (renaud.michotte@uclouvain.be)
+ */
+public class BitstreamAccessConditionRest extends BaseObjectRest<UUID> {
+    public static final String NAME = "bitstreamaccesscondition";
+    public static final String CATEGORY = RestAddressableModel.CORE;
+
+    private List<AccessConditionDTO> policies;
+    private AccessConditionDTO masterPolicy;
+
+    public List<AccessConditionDTO> getPolicies() { return this.policies; }
+    public void setPolicies(List<AccessConditionDTO> inPolicies) { this.policies = inPolicies; }
+
+    @JsonInclude(Include.NON_NULL)
+    public AccessConditionDTO getMasterPolicy() { return this.masterPolicy; }
+    public void setMasterPolicy(AccessConditionDTO policy) { this.masterPolicy = policy; }
+
+    @JsonIgnore
+    @Override
+    public String getCategory() {
+        return CATEGORY;
+    }
+
+    @Override
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    public String getType() {
+        return NAME;
+    }
+
+    @Override
+    @JsonIgnore
+    public Class getController() {
+        return RestResourceController.class;
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/BitstreamAccessConditions.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/BitstreamAccessConditions.java
@@ -1,0 +1,15 @@
+package org.dspace.app.rest.model;
+
+import org.dspace.authorize.ResourcePolicy;
+import java.util.List;
+
+/** Wrapper class to allow `List<ResourcePolicy>` to be converted using classic converter
+ *
+ * @author Renaud Michotte (renaud.michotte@uclouvain.be)
+ */
+public class BitstreamAccessConditions {
+
+    private List<ResourcePolicy> policies;
+    public List<ResourcePolicy> getPolicies() { return this.policies; }
+    public void setPolicies(List<ResourcePolicy> inPolicies) { this.policies = inPolicies; }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/BitstreamRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/BitstreamRest.java
@@ -27,6 +27,10 @@ import com.fasterxml.jackson.annotation.JsonProperty.Access;
         @LinkRest(
                 name = BitstreamRest.THUMBNAIL,
                 method = "getThumbnail"
+        ),
+        @LinkRest(
+                name = BitstreamRest.ACCESS,
+                method = "getAccessCondition"
         )
 })
 public class BitstreamRest extends DSpaceObjectRest {
@@ -37,6 +41,7 @@ public class BitstreamRest extends DSpaceObjectRest {
     public static final String BUNDLE = "bundle";
     public static final String FORMAT = "format";
     public static final String THUMBNAIL = "thumbnail";
+    public static final String ACCESS = "access";
 
     private String bundleName;
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/hateoas/BitstreamAccessConditionResource.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/hateoas/BitstreamAccessConditionResource.java
@@ -1,0 +1,18 @@
+package org.dspace.app.rest.model.hateoas;
+
+import org.dspace.app.rest.model.BitstreamAccessConditionRest;
+import org.dspace.app.rest.model.hateoas.annotations.RelNameDSpaceResource;
+import org.dspace.app.rest.utils.Utils;
+
+/**
+ * BitstreamAccessConditionRest HAL Resource.
+ * The HAL Resource wraps the REST Resource adding support for the links and embedded resources
+ *
+ * @author Renaud Michotte (renaud.michotte@uclouvain.be)
+ */
+@RelNameDSpaceResource(BitstreamAccessConditionRest.NAME)
+public class BitstreamAccessConditionResource extends DSpaceResource<BitstreamAccessConditionRest> {
+    public BitstreamAccessConditionResource(BitstreamAccessConditionRest bac, Utils utils) {
+        super(bac, utils);
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamAccessConditionsLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamAccessConditionsLinkRepository.java
@@ -1,0 +1,62 @@
+package org.dspace.app.rest.repository;
+
+import org.dspace.app.rest.model.BitstreamAccessConditionRest;
+import org.dspace.app.rest.model.BitstreamAccessConditions;
+import org.dspace.app.rest.model.BitstreamRest;
+import org.dspace.app.rest.projection.Projection;
+import org.dspace.content.Bitstream;
+import org.dspace.content.service.BitstreamService;
+import org.dspace.core.Context;
+import org.dspace.uclouvain.services.UCLouvainResourcePolicyService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Nullable;
+import javax.servlet.http.HttpServletRequest;
+import java.sql.SQLException;
+import java.util.UUID;
+
+/** Link repository for "access" subresource of an individual bitstream.
+ *
+ * We created this rest endpoint to list all useful resource policies on a `Bitstream` object. The existing
+ * `api/authz/resourcepolicies` endpoint filter resource policies depending on current user (ex: an anonymous user
+ * doesn't show any 'administrator' policy) ; but for the bitstream access condition display on UI we need to get
+ * these policies.
+ *
+ * @author Renaud Michotte (renaud.michotte@uclouvain.be)
+ */
+@Component(BitstreamRest.CATEGORY + "." + BitstreamRest.NAME + "." + BitstreamRest.ACCESS)
+public class BitstreamAccessConditionsLinkRepository extends AbstractDSpaceRestRepository
+        implements LinkRestRepository {
+
+    @Autowired
+    BitstreamService bitstreamService;
+    @Autowired
+    UCLouvainResourcePolicyService uclouvainResourcePolicyService;
+
+    @PreAuthorize("hasPermission(#bitstreamId, 'BITSTREAM', 'METADATA_READ')")
+    public BitstreamAccessConditionRest getAccessCondition(
+            @Nullable HttpServletRequest request,
+            UUID bitstreamId,
+            @Nullable Pageable optionalPageable,
+            Projection projection
+    ) {
+        try {
+            Context context = obtainContext();
+            Bitstream bitstream = bitstreamService.find(context, bitstreamId);
+            if (bitstream == null) {
+                throw new ResourceNotFoundException("No such bitstream: " + bitstreamId);
+            }
+
+            BitstreamAccessConditions bac = new BitstreamAccessConditions();
+            bac.setPolicies(uclouvainResourcePolicyService.find(context, bitstream));
+
+            return converter.toRest(bac, projection);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamAccessConditionsRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamAccessConditionsRestRepository.java
@@ -1,0 +1,63 @@
+package org.dspace.app.rest.repository;
+
+import org.dspace.app.rest.exception.RepositoryMethodNotImplementedException;
+import org.dspace.app.rest.model.BitstreamAccessConditionRest;
+import org.dspace.app.rest.model.BitstreamAccessConditions;
+import org.dspace.content.Bitstream;
+import org.dspace.content.service.BitstreamService;
+import org.dspace.core.Context;
+import org.dspace.uclouvain.services.UCLouvainResourcePolicyService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Component;
+
+import java.sql.SQLException;
+import java.util.UUID;
+
+
+/**
+ * This is the repository responsible to manage BitstreamAccessConditions Rest object
+ *
+ * @author Renaud Michotte (renaud.michotte@uclouvain.be)
+ */
+@Component(BitstreamAccessConditionRest.CATEGORY + "." + BitstreamAccessConditionRest.NAME)
+public class BitstreamAccessConditionsRestRepository extends DSpaceRestRepository<BitstreamAccessConditionRest, UUID> {
+
+    @Autowired
+    BitstreamService bitstreamService;
+    @Autowired
+    UCLouvainResourcePolicyService uclouvainResourcePolicyService;
+
+    @Override
+    @PreAuthorize("permitAll()")
+    public BitstreamAccessConditionRest findOne(Context context, UUID uuid) {
+        try {
+            Bitstream bitstream = bitstreamService.find(context, uuid);
+            if (bitstream == null) {
+                throw new ResourceNotFoundException("No such bitstream: " + uuid);
+            }
+
+            BitstreamAccessConditions bac = new BitstreamAccessConditions();
+            bac.setPolicies(uclouvainResourcePolicyService.find(context, bitstream));
+
+            return converter.toRest(bac, utils.obtainProjection());
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Page<BitstreamAccessConditionRest> findAll(Context context, Pageable pageable) {
+        throw new RepositoryMethodNotImplementedException("No implementation found; Method not allowed!", "");
+    }
+
+    @Override
+    public Class<BitstreamAccessConditionRest> getDomainClass() {
+        return BitstreamAccessConditionRest.class;
+    }
+}
+
+

--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/core/model/ResourcePolicyPriority.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/core/model/ResourcePolicyPriority.java
@@ -1,0 +1,19 @@
+package org.dspace.uclouvain.core.model;
+
+/** Class to represent a ResourcePolicy priority. It allows to determine a master policy if multiple policy are defined
+ *  on the same DSpaceObject (Item, Bitstream, ...)
+ *  More the weight is high, more the priority is important
+ *
+ * @author Renaud Michotte (renaud.michotte@uclouvain.be)
+ */
+public class ResourcePolicyPriority {
+
+    private String rpName;
+    private int weight;
+
+    public String getRpName() { return rpName; }
+    public void setRpName(String rpName) { this.rpName = rpName; }
+
+    public int getWeight() { return weight; }
+    public void setWeight(int weight) { this.weight = weight; }
+}

--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/services/UCLouvainResourcePolicyService.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/services/UCLouvainResourcePolicyService.java
@@ -1,0 +1,92 @@
+package org.dspace.uclouvain.services;
+
+import org.dspace.authorize.ResourcePolicy;
+import org.dspace.authorize.service.ResourcePolicyService;
+import org.dspace.content.DSpaceObject;
+import org.dspace.core.Context;
+import org.dspace.uclouvain.core.model.ResourcePolicyPriority;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.sql.SQLException;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.dspace.authorize.ResourcePolicy.TYPE_CUSTOM;
+
+/**
+ * Extension of {@link org.dspace.authorize.service.ResourcePolicyService} with
+ * custom methods for UCLouvain features.
+ *
+ * @author Renaud Michotte (renaud.michotte@uclouvain.be)
+ */
+
+@Service
+public class UCLouvainResourcePolicyService {
+
+    @Autowired
+    private ResourcePolicyService resourcePolicyService;
+    private List<ResourcePolicyPriority> rpPriorities;
+    private ResourcePolicyPriority defaultResourcePolicyPriority;
+
+    /** Find all valid resource policies specifically created on a DSpace object.
+     *
+     * @param context The application context
+     * @param dso     The DspaceObject to analyze
+     * @return corresponding resource policies.
+     * @throws SQLException if database error
+     */
+    public List<ResourcePolicy> find(Context context, DSpaceObject dso) throws SQLException {
+        return resourcePolicyService.find(context, dso)
+                .stream()
+                .filter(p -> p.getRpType().equals(TYPE_CUSTOM))
+                .filter(this::isValidDateInterval)
+                .collect(Collectors.toList());
+    }
+
+    /** Select the master resource policy into a list of resource policies.
+     *  The master policy is defined depending on `rpPriorities` attributes and based on policy name.
+     *
+     * @param policies The list of resource policies to analyze.
+     * @return the master resource policy into this list. Could be `null` if `policies` argument is an empty list.
+     */
+    public ResourcePolicy getMasterPolicy(List<ResourcePolicy> policies) {
+        ResourcePolicy masterPolicy = null;
+        int currentMaxWeight = Integer.MIN_VALUE;
+        for(ResourcePolicy policy : policies) {
+            int policyWeight = getPolicyWeight(policy);
+            if (policyWeight > currentMaxWeight) {
+                currentMaxWeight = policyWeight;
+                masterPolicy = policy;
+            }
+        }
+        return masterPolicy;
+    }
+
+
+    private boolean isValidDateInterval(ResourcePolicy policy) {
+        // in a resourcePolicy, the `startDate` field is used to expose "start date where access is granted" ;
+        // opposite, the `endDate` field is used to expose "date where access is revoked". So to test if the
+        // policy is valid, we need to check endDate <= currentDate <= startDate
+        long currentTime = new Date().getTime();
+        long startDate = ((policy.getStartDate() != null) ? policy.getStartDate() : new Date(Long.MAX_VALUE)).getTime();
+        long endDate = ((policy.getEndDate() != null) ? policy.getEndDate() : new Date(0)).getTime();
+        return endDate <= currentTime && currentTime <= startDate;
+    }
+
+    private int getPolicyWeight(ResourcePolicy policy) {
+        return this.rpPriorities
+                .stream()
+                .filter(p -> p.getRpName().equalsIgnoreCase(policy.getRpName()))
+                .findFirst().orElse(defaultResourcePolicyPriority)
+                .getWeight();
+    }
+
+
+    public void setRpPriorities(List<ResourcePolicyPriority> rpPriorities) { this.rpPriorities = rpPriorities; }
+    public List<ResourcePolicyPriority> getRpPriorities() { return this.rpPriorities; }
+
+    public void setDefaultResourcePolicyPriority(ResourcePolicyPriority rpPriority) { this.defaultResourcePolicyPriority = rpPriority; }
+    public ResourcePolicyPriority getDefaultResourcePolicyPriority() { return this.defaultResourcePolicyPriority; }
+}

--- a/dspace/config/spring/uclouvain/uclouvain-external-services.xml
+++ b/dspace/config/spring/uclouvain/uclouvain-external-services.xml
@@ -171,6 +171,7 @@
     </bean>
 
     <!-- CUSTOM RESOURCE POLICIES SERVICE -->
+    <!-- TODO :: remove when completly replaced by resource subrequest API -->
     <bean id="resourcePolicyUtilService" class="org.dspace.uclouvain.services.ResourcePolicyUtilService">
         <property name="typeList">
             <util:list>
@@ -182,6 +183,39 @@
                 <value>embargo</value>
                 <value>openaccess</value>
             </util:list>
+        </property>
+    </bean>
+
+    <bean id="uclouvainResourcePolicyService" class="org.dspace.uclouvain.services.UCLouvainResourcePolicyService">
+        <property name="rpPriorities">
+            <util:list>
+                <bean class="org.dspace.uclouvain.core.model.ResourcePolicyPriority">
+                    <property name="rpName" value="administrator"/>
+                    <property name="weight" value="0"/>
+                </bean>
+                <bean class="org.dspace.uclouvain.core.model.ResourcePolicyPriority">
+                    <property name="rpName" value="UCLouvain networks restriction"/>
+                    <property name="weight" value="10"/>
+                </bean>
+                <bean class="org.dspace.uclouvain.core.model.ResourcePolicyPriority">
+                    <property name="rpName" value="embargo"/>
+                    <property name="weight" value="20"/>
+                </bean>
+                <bean class="org.dspace.uclouvain.core.model.ResourcePolicyPriority">
+                    <property name="rpName" value="lease"/>
+                    <property name="weight" value="20"/>
+                </bean>
+                <bean class="org.dspace.uclouvain.core.model.ResourcePolicyPriority">
+                    <property name="rpName" value="openaccess"/>
+                    <property name="weight" value="#{T(java.lang.Integer).MAX_VALUE}"/>
+                </bean>
+            </util:list>
+        </property>
+        <property name="defaultResourcePolicyPriority">
+            <bean class="org.dspace.uclouvain.core.model.ResourcePolicyPriority">
+                <property name="rpName" value="defaultPriority"/>
+                <property name="weight" value="#{T(java.lang.Integer).MAX_VALUE}"/>
+            </bean>
         </property>
     </bean>
 </beans>


### PR DESCRIPTION
Create a specific subresource under bitstream API to list access conditions related to a specific bitstream. This subresource are available into "_links" related API on the global bitstreams API.
