### PR TITLE
[UPD] feat(ReviewAction): Managers can now edit workflow items

### DIFF
--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/xmlworkflow/actions/UCLouvainThesisReviewAction.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/xmlworkflow/actions/UCLouvainThesisReviewAction.java
@@ -26,6 +26,7 @@ import org.dspace.xmlworkflow.factory.XmlWorkflowServiceFactory;
 import org.dspace.xmlworkflow.service.WorkflowRequirementsService;
 import org.dspace.xmlworkflow.state.Step;
 import org.dspace.xmlworkflow.state.actions.ActionResult;
+import org.dspace.xmlworkflow.state.actions.processingaction.ProcessingAction;
 import org.dspace.xmlworkflow.state.actions.processingaction.ReviewAction;
 import org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem;
 import org.dspace.xmlworkflow.storedcomponents.service.WorkflowItemRoleService;
@@ -95,6 +96,8 @@ public class UCLouvainThesisReviewAction extends ReviewAction {
         options.add(SUBMIT_APPROVE);
         options.add(SUBMIT_APPROVE_WITHOUT_DIFFUSION);
         options.add(SUBMIT_REJECT);
+        // Edit item button
+        options.add(ProcessingAction.SUBMIT_EDIT_METADATA);
         options.add(RETURN_TO_POOL);
         return options;
     }


### PR DESCRIPTION
Adds a button in the frontend side to allow the managers to edit the workflow items that are in their 'workflow tasks' section.