### PR TITLE
Librarian can edit archived item + config improvement

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/BitstreamDirectDownloadURLPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/BitstreamDirectDownloadURLPermissionEvaluatorPlugin.java
@@ -75,7 +75,6 @@ public class BitstreamDirectDownloadURLPermissionEvaluatorPlugin extends RestObj
                 }
             }
         }
-        System.out.println("Targetid was probably null: " + targetId + " and targetType: " + targetType + " and permission: " + permission);
         return false;
     }
 

--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/core/utils/AuthorizationUtils.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/core/utils/AuthorizationUtils.java
@@ -8,6 +8,8 @@ import org.dspace.content.Item;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.uclouvain.core.model.MetadataField;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -22,6 +24,14 @@ public class AuthorizationUtils {
 
     @Autowired
     private ItemService itemService;
+
+    private MetadataField promoterField;
+
+    public AuthorizationUtils() throws Exception {
+        this.promoterField = new MetadataField(
+            DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("uclouvain.global.metadata.advisoremail.field", "advisors.email")
+        );
+    }
 
     /**
      * Checks if the current user is a manager of the item's collection.
@@ -43,9 +53,8 @@ public class AuthorizationUtils {
      * @return True if the user is a promoter of the item, false otherwise.
      */
     public boolean isPromoterOfItem(Item item, EPerson person) {
-        // TODO: Use config for field name
         List<String> promoters = this.itemService.getMetadata(
-            item, "advisors", "email", null, null
+            item, this.promoterField.getSchema(), this.promoterField.getElement(), null, null
         ).stream().map(metadataValue -> metadataValue.getValue()).collect(Collectors.toList());
     
         return promoters.contains(person.getEmail());

--- a/dspace/config/modules/uclouvain.cfg
+++ b/dspace/config/modules/uclouvain.cfg
@@ -14,6 +14,8 @@ uclouvain.global.metadata.authorname.field = dc.contributor.author
 uclouvain.global.metadata.advisoremail.field = advisors.email
 uclouvain.global.metadata.advisorname.field = dc.contributor.advisor
 uclouvain.global.metadata.entitytype.field = dspace.entity.type
+uclouvain.global.metadata.session.field = masterthesis.session
+uclouvain.global.metadata.year.field = dc.date.issued
 
 #-----------------------------------------------------------#
 

--- a/dspace/config/spring/api/edititem-service.xml
+++ b/dspace/config/spring/api/edititem-service.xml
@@ -202,6 +202,20 @@
                             </property>
                             <property name="submissionDefinition" value="master-thesis-edit" />
                         </bean>
+                        <bean class="org.dspace.content.edit.EditItemMode">
+                            <property name="name" value="LIBRARIAN" />
+                            <property name="security">
+                                <value type="org.dspace.content.security.CrisSecurity">
+                                    GROUP
+                                </value>
+                            </property>
+                            <property name="groups">
+                                <list>
+                                    <value>librarian</value>
+                                </list>
+                            </property>
+                            <property name="submissionDefinition" value="master-thesis-edit" />
+                        </bean>
                     </list>
                 </entry>
             </map>


### PR DESCRIPTION
Librarians can now edit items that are validated and visible in the archive.
Also used configuration for a lot of redundant things like field names.