### PR TITLE
[FIX] feat(discovery/browse): Autor, Date, Subject, Title and Type views for MasterThesis

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1286,13 +1286,13 @@ webui.browse.index.11 = eqtitle:itemEquipment:title
 # When you are limiting a two level browse you need to configure, typically the same filter, also for the second level.
 # In such case the browse index is used
 # browse.solr.bi_<n>_dis.filter = <your-solr-filter-query>
-browse.solr.bi_2_dis.filter= entityType:Publication OR entityType:Product OR entityType:Patent
-browse.solr.bi_4_dis.filter= entityType:Publication OR entityType:Product OR entityType:Patent
-browse.solr.bi_5_dis.filter= entityType:Publication OR entityType:Product OR entityType:Patent
-browse.solr.bi_6_dis.filter= entityType:Publication OR entityType:Product OR entityType:Patent
+browse.solr.bi_2_dis.filter= entityType:Publication OR entityType:Product OR entityType:Patent OR entityType:MasterThesis
+browse.solr.bi_4_dis.filter= entityType:Publication OR entityType:Product OR entityType:Patent OR entityType:MasterThesis
+browse.solr.bi_5_dis.filter= entityType:Publication OR entityType:Product OR entityType:Patent OR entityType:MasterThesis
+browse.solr.bi_6_dis.filter= entityType:Publication OR entityType:Product OR entityType:Patent OR entityType:MasterThesis
 browse.solr.bi_8_dis.filter= entityType:Person
-browse.solr.bi_itemResOutputs.filter= entityType:Publication OR entityType:Product OR entityType:Patent
-browse.solr.bi_itemPublication.filter= entityType:Publication
+browse.solr.bi_itemResOutputs.filter= entityType:Publication OR entityType:Product OR entityType:Patent OR entityType:MasterThesis
+browse.solr.bi_itemPublication.filter= entityType:Publication OR entityType:MasterThesis
 browse.solr.bi_itemProduct.filter= entityType:Product
 browse.solr.bi_itemPatent.filter= entityType:Patent
 browse.solr.bi_itemOrgUnit.filter= entityType:OrgUnit

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -1744,7 +1744,7 @@
         <property name="defaultFilterQueries">
             <list>
                 <!--Only find items, communities and collections-->
-                <value>search.resourcetype:Item AND (entityType_keyword:Publication OR entityType_keyword:Patent OR entityType_keyword:Product)</value>
+                <value>search.resourcetype:Item AND (entityType_keyword:Publication OR entityType_keyword:Patent OR entityType_keyword:Product OR entityType_keyword:MasterThesis)</value>
                 <value>-withdrawn:true AND -discoverable:false</value>
             </list>
         </property>


### PR DESCRIPTION
Previously, all those discovery endpoint were set to use only the 'Publication' entity type. I added the 'MasterThesis' type to the configuration and now it works.

Authored-By: Michaël Pourbaix <michael.pourbaix@uclouvain.be>