### PR TITLE
Author authority + Affiliation Controller + Metadata schema field definition

### DIFF
--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/authority/PublicationAuthorAuthority.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/authority/PublicationAuthorAuthority.java
@@ -1,0 +1,62 @@
+package org.dspace.uclouvain.authority;
+
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.dspace.content.Item;
+
+/**
+ * Simple authority to search for Persons.
+ * 
+ * @author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+public class PublicationAuthorAuthority extends PublicationAuthority {
+    private String authorityName;
+
+    /**
+     * The filter query that will give us only Persons item in the search results.
+     */
+    @Override
+    protected String getEntityTypeFilterString(){
+        return "dspace.entity.type:Person";
+    }
+
+    /**
+     * Generate extra information to fill some fields in the forms.
+     */
+    @Override
+    protected Map<String, String> generateExtras(Item item) throws SQLException {
+        Map<String, String> extras = new HashMap<String, String>();
+        String email = this.itemService.getMetadataFirstValue(item, "person", "email", null, null);
+        String orcid = this.itemService.getMetadataFirstValue(item, "person", "identifier", "orcid", null);
+        String orgUnit = this.itemService.getMetadataFirstValue(item, "person", "affiliation", "name", null);
+        if (email != null) {
+            extras.put("data-authors_email", email);
+        }
+        if (orcid != null) {
+            extras.put("data-authors_identifier_orcid", orcid);
+        }
+        if (orgUnit != null) {
+            extras.put("data-oairecerif_authors_orgunit", orgUnit);
+        }
+        // TODO: Find how/where to extract institution name && affiliation departement
+        extras.put("data-authors_institution_name", "Université Catholique de Louvain");
+        extras.put("data-oairecerif_authors_orgunitDepartement", "Test departement");
+        return extras;
+    }
+
+    @Override
+    public String getLabel(String key, String locale) {
+        return "";
+    }
+
+    public void setPluginInstanceName(String name) {
+        authorityName = name;
+    }
+
+    @Override
+    public String getPluginInstanceName() {
+        return authorityName;
+    }
+}

--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/authority/PublicationAuthority.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/authority/PublicationAuthority.java
@@ -1,0 +1,124 @@
+package org.dspace.uclouvain.authority;
+
+import org.dspace.content.authority.Choices;
+import org.dspace.content.authority.ItemAuthority;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Context;
+import org.dspace.discovery.SearchService;
+import org.dspace.utils.DSpace;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.common.SolrDocument;
+import org.apache.solr.common.SolrDocumentList;
+import org.dspace.content.Item;
+import org.dspace.content.authority.Choice;
+import org.dspace.content.authority.ChoiceAuthority;
+import org.dspace.web.ContextUtil;
+
+/**
+ * Simple abstract authority class that can be extended to create simple authorities.
+ * 
+ * @author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+public abstract class PublicationAuthority implements ChoiceAuthority {
+    private static Logger logger = LogManager.getLogger(ItemAuthority.class);
+    protected DSpace dspace = new DSpace();
+    protected ItemService itemService = ContentServiceFactory.getInstance().getItemService();
+    protected SearchService searchService = dspace.getServiceManager().getServiceByName(
+        "org.dspace.discovery.SearchService", SearchService.class);
+
+    @Override
+    public Choices getBestMatch(String text, String locale) {
+        return getMatches(text, 0, 2, locale, true);
+    }
+
+    @Override
+    public Choices getMatches(String text, int start, int limit, String locale) {
+        return getMatches(text, start, limit, locale, false);
+    }
+
+    /**
+     * Get the matches for the given text (query).
+     * @param text: the query.
+     * @param start: the start index.
+     * @param limit: the limit of results.
+     * @param locale: the locale.
+     * @param onlyExactMatches: if true, only exact matches will be returned.
+     * @return: A Choices object that contains the results of the search.
+     */
+    protected Choices getMatches(String text, int start, int limit, String locale, boolean onlyExactMatches) {
+        if (limit <= 0) {
+            limit = 20;
+        }
+
+        SolrClient solr = searchService.getSolrSearchCore().getSolr();
+        if (Objects.isNull(solr)) {
+            logger.error("unable to find solr instance");
+            return new Choices(Choices.CF_UNSET);
+        }
+
+        String query = text;
+        SolrQuery solrQuery = new SolrQuery();
+        solrQuery.setQuery(query);
+        solrQuery.setStart(start);
+        solrQuery.setRows(limit);
+        solrQuery.addFilterQuery("search.resourcetype:" + Item.class.getSimpleName());
+        solrQuery.addFilterQuery(getEntityTypeFilterString());
+
+        try {
+            Context context = getContext();
+            QueryResponse queryResponse = solr.query(solrQuery);
+            List<Choice> choices = new ArrayList<Choice>();
+
+            SolrDocumentList results = queryResponse.getResults();
+            for (int i = 0; i < results.size(); i++) {
+                try {
+                    SolrDocument doc = results.get(i);
+                    String uuid = (String) doc.getFieldValue("search.resourceid");
+                    String title = ((ArrayList<String>) doc.getFieldValue("dc.title"))
+                            .stream()
+                            .findFirst()
+                            .orElse(text);
+                    Item item = itemService.find(context, UUID.fromString(uuid));
+                    if (item != null) {
+                        choices.add(new Choice(uuid, title, title, this.generateExtras(item)));
+                    }
+                } catch (Exception e) {
+                    logger.error(e.getMessage(), e);
+                }
+            }
+            Choice[] final_results = new Choice[choices.size()];
+            final_results = choices.toArray(final_results);
+            long numFound = queryResponse.getResults().getNumFound();
+
+            return new Choices(final_results, 0, (int) numFound, Choices.CF_AMBIGUOUS, false, -1);
+
+        } catch (Exception e) {
+            logger.error(e.getMessage(), e);
+            return new Choices(Choices.CF_UNSET);
+        }
+    }
+
+    protected Context getContext() {
+        Context context = ContextUtil.obtainCurrentRequestContext();
+        return context != null ? context : new Context();
+    }
+    
+    public abstract String getPluginInstanceName();
+    public abstract void setPluginInstanceName(String pluginInstanceName);
+    public abstract String getLabel(String key, String locale);
+
+    protected abstract Map<String, String> generateExtras(Item item) throws Exception;
+    protected abstract String getEntityTypeFilterString();
+}

--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/authority/PublicationAuthority.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/authority/PublicationAuthority.java
@@ -6,6 +6,8 @@ import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Context;
 import org.dspace.discovery.SearchService;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.utils.DSpace;
 
 import java.util.ArrayList;
@@ -35,6 +37,7 @@ public abstract class PublicationAuthority implements ChoiceAuthority {
     private static Logger logger = LogManager.getLogger(ItemAuthority.class);
     protected DSpace dspace = new DSpace();
     protected ItemService itemService = ContentServiceFactory.getInstance().getItemService();
+    protected ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
     protected SearchService searchService = dspace.getServiceManager().getServiceByName(
         "org.dspace.discovery.SearchService", SearchService.class);
 
@@ -59,7 +62,7 @@ public abstract class PublicationAuthority implements ChoiceAuthority {
      */
     protected Choices getMatches(String text, int start, int limit, String locale, boolean onlyExactMatches) {
         if (limit <= 0) {
-            limit = 20;
+            limit = this.configurationService.getIntProperty("uclouvain.authority.authorAuthority.default");
         }
 
         SolrClient solr = searchService.getSolrSearchCore().getSolr();
@@ -98,8 +101,7 @@ public abstract class PublicationAuthority implements ChoiceAuthority {
                     logger.error(e.getMessage(), e);
                 }
             }
-            Choice[] final_results = new Choice[choices.size()];
-            final_results = choices.toArray(final_results);
+            Choice[] final_results = choices.toArray(new Choice[choices.size()]);
             long numFound = queryResponse.getResults().getNumFound();
 
             return new Choices(final_results, 0, (int) numFound, Choices.CF_AMBIGUOUS, false, -1);

--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/consumer/AffiliationModificationConsumer.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/consumer/AffiliationModificationConsumer.java
@@ -1,0 +1,52 @@
+package org.dspace.uclouvain.consumer;
+
+import java.sql.SQLException;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.content.EntityType;
+import org.dspace.content.Item;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.EntityTypeService;
+import org.dspace.core.Context;
+import org.dspace.event.Consumer;
+import org.dspace.event.Event;
+import org.dspace.uclouvain.factories.UCLouvainServiceFactory;
+import org.dspace.uclouvain.services.UCLouvainAffiliationEntityRestService;
+
+/**
+ * Consumer which is used to trigger an update of the {@link org.dspace.uclouvain.services.UCLouvainAffiliationEntityRestServiceImpl}'s 'affiliationsEntities' property when an OrgUnit is modified.
+ * 
+ * @Author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+public class AffiliationModificationConsumer implements Consumer {
+    private UCLouvainAffiliationEntityRestService affiliationEntityRestService;
+    private EntityTypeService entityTypeService;
+    private Logger logger;
+
+    @Override
+    public void initialize() throws Exception {
+        this.affiliationEntityRestService = UCLouvainServiceFactory.getInstance().getAffiliationEntityRestService();
+        this.entityTypeService = ContentServiceFactory.getInstance().getEntityTypeService();
+        this.logger = LogManager.getLogger(AffiliationModificationConsumer.class);
+    }
+
+    @Override
+    public void consume(Context context, Event event) throws SQLException {
+        try {
+            Item item = (Item) event.getSubject(context);
+            EntityType targetEntityType = this.entityTypeService.findByEntityType(context, "OrgUnit");
+            if (targetEntityType != null && this.entityTypeService.findByItem(context, item) == targetEntityType) {
+                this.affiliationEntityRestService.updateAffiliationEntities();
+            }
+        } catch (Exception e) {
+            this.logger.error("Error while updating affiliation entities via the consumer.", e);
+        }
+    }
+
+    @Override
+    public void finish(Context context) throws Exception {}
+
+    @Override
+    public void end(Context context) throws Exception {}
+}

--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/consumer/AffiliationModificationConsumer.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/consumer/AffiliationModificationConsumer.java
@@ -20,16 +20,12 @@ import org.dspace.uclouvain.services.UCLouvainAffiliationEntityRestService;
  * @Author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
  */
 public class AffiliationModificationConsumer implements Consumer {
-    private UCLouvainAffiliationEntityRestService affiliationEntityRestService;
-    private EntityTypeService entityTypeService;
-    private Logger logger;
+    private UCLouvainAffiliationEntityRestService affiliationEntityRestService = UCLouvainServiceFactory.getInstance().getAffiliationEntityRestService();
+    private EntityTypeService entityTypeService = ContentServiceFactory.getInstance().getEntityTypeService();
+    private Logger logger = LogManager.getLogger(AffiliationModificationConsumer.class);
 
     @Override
-    public void initialize() throws Exception {
-        this.affiliationEntityRestService = UCLouvainServiceFactory.getInstance().getAffiliationEntityRestService();
-        this.entityTypeService = ContentServiceFactory.getInstance().getEntityTypeService();
-        this.logger = LogManager.getLogger(AffiliationModificationConsumer.class);
-    }
+    public void initialize() {}
 
     @Override
     public void consume(Context context, Event event) throws SQLException {

--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/core/model/AffiliationEntityRestModel.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/core/model/AffiliationEntityRestModel.java
@@ -1,0 +1,31 @@
+package org.dspace.uclouvain.core.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+
+public class AffiliationEntityRestModel {
+    public UUID UUID;
+    public String name;
+    public String acronym;
+    public String type;
+    public boolean isSelectable;
+    public UUID parent;
+    public List<AffiliationEntityRestModel> children = new ArrayList<AffiliationEntityRestModel>();
+
+    public AffiliationEntityRestModel(){
+    }
+
+    public AffiliationEntityRestModel(AffiliationEntityRestModel model){
+        this.UUID = model.UUID;
+        this.name = model.name;
+        this.acronym = model.acronym;
+        this.type = model.type;
+        this.isSelectable = model.isSelectable;
+        this.parent = model.parent;
+        model.children.forEach(modelChild -> {
+            this.children.add(new AffiliationEntityRestModel(modelChild));
+        });
+    }
+}

--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/core/model/AffiliationEntityRestModel.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/core/model/AffiliationEntityRestModel.java
@@ -24,8 +24,6 @@ public class AffiliationEntityRestModel {
         this.type = model.type;
         this.isSelectable = model.isSelectable;
         this.parent = model.parent;
-        model.children.forEach(modelChild -> {
-            this.children.add(new AffiliationEntityRestModel(modelChild));
-        });
+        model.children.forEach(modelChild -> this.children.add(new AffiliationEntityRestModel(modelChild)));
     }
 }

--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/factories/UCLouvainServiceFactory.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/factories/UCLouvainServiceFactory.java
@@ -3,6 +3,7 @@ package org.dspace.uclouvain.factories;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.uclouvain.services.UCLouvainEntityService;
 import org.dspace.uclouvain.services.UCLouvainResourcePolicyService;
+import org.dspace.uclouvain.services.UCLouvainAffiliationEntityRestService;
 
 /**
  * Abstract factory to get services for the UCLouvain package.
@@ -14,6 +15,7 @@ public abstract  class UCLouvainServiceFactory {
 
     public abstract UCLouvainResourcePolicyService getResourcePolicyService();
     public abstract UCLouvainEntityService getEntityService();
+    public abstract UCLouvainAffiliationEntityRestService getAffiliationEntityRestService();
 
     public static UCLouvainServiceFactory getInstance() {
         return DSpaceServicesFactory

--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/factories/UCLouvainServiceFactoryImpl.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/factories/UCLouvainServiceFactoryImpl.java
@@ -2,6 +2,7 @@ package org.dspace.uclouvain.factories;
 
 import org.dspace.uclouvain.services.UCLouvainEntityService;
 import org.dspace.uclouvain.services.UCLouvainResourcePolicyService;
+import org.dspace.uclouvain.services.UCLouvainAffiliationEntityRestService;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -15,10 +16,14 @@ public class UCLouvainServiceFactoryImpl extends UCLouvainServiceFactory {
     private UCLouvainResourcePolicyService uclouvainResourcePolicyService;
     @Autowired(required = true)
     private UCLouvainEntityService uclouvainEntityService;
+    @Autowired(required = true)
+    private UCLouvainAffiliationEntityRestService uclouvainAffiliationEntityRestService;
 
     @Override
     public UCLouvainResourcePolicyService getResourcePolicyService() { return uclouvainResourcePolicyService; }
     @Override
     public UCLouvainEntityService getEntityService(){ return uclouvainEntityService; }
+    @Override
+    public UCLouvainAffiliationEntityRestService getAffiliationEntityRestService() { return uclouvainAffiliationEntityRestService; }
 
 }

--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/rest/AffiliationsRestController.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/rest/AffiliationsRestController.java
@@ -1,0 +1,112 @@
+package org.dspace.uclouvain.rest;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.core.Context;
+import org.dspace.uclouvain.consumer.AffiliationModificationConsumer;
+import org.dspace.uclouvain.core.model.AffiliationEntityRestModel;
+import org.dspace.uclouvain.factories.UCLouvainServiceFactory;
+import org.dspace.uclouvain.services.UCLouvainAffiliationEntityRestService;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Main controller to retrieve the affiliation tree structure.
+ * The main structure can be sorted by parent UUID and depth.
+ * - The parent UUID filter returns only the target affiliation and its children.
+ * - The depth filter returns the children up to the given depth.
+ *  Ex: (0 - would be only the target items and no children, 1 - would be the target items and their children, 2 - would be the target items, their children and their children's children, etc.).
+ * 
+ * @Author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+@RestController
+@RequestMapping("/api/uclouvain/affiliations")
+public class AffiliationsRestController {
+
+    private UCLouvainAffiliationEntityRestService uclouvainAffiliationEntityRestService;
+    private Logger logger;
+
+    public AffiliationsRestController(){
+        this.uclouvainAffiliationEntityRestService = UCLouvainServiceFactory.getInstance().getAffiliationEntityRestService();
+        this.logger = LogManager.getLogger(AffiliationModificationConsumer.class);
+    }
+
+    /** 
+     * Main endpoint to retrieve the affiliation tree structure.
+     */ 
+    @RequestMapping(value= "/affiliationStructure", method = RequestMethod.GET)
+    public List<AffiliationEntityRestModel> getAffiliations(Context context, HttpServletResponse response, 
+        @RequestParam(value = "parentUUID", required = false) UUID parentUUID,
+        @RequestParam(value = "depth", required = false) Integer depth) throws IOException {
+
+        // Get the tree from the service. This tree automatically regenerated once an OrgUnit is modified so we are sure to be up to date.
+        List<AffiliationEntityRestModel> modelsList = this.deepCopy(this.uclouvainAffiliationEntityRestService.getAffiliationsEntities());
+        // If nothing found return an empty list
+        if (modelsList == null) {
+            this.logger.warn("No affiliation tree found from 'UCLouvainAffiliationEntityRestService' service.");
+            return new ArrayList<AffiliationEntityRestModel>();
+        }
+
+        List<AffiliationEntityRestModel> dataToReturn;
+
+        // Parent filtering
+        if (parentUUID != null) {
+            AffiliationEntityRestModel searchedElement = modelsList.stream().filter(model -> model.UUID.equals(parentUUID)).findFirst().orElse(null);
+            if (searchedElement == null) {
+                response.sendError(404, "Given affiliation UUID not valid or not found");
+                return null;
+            }
+            dataToReturn =  new ArrayList<AffiliationEntityRestModel>(Arrays.asList(searchedElement));
+        } else {
+            dataToReturn = modelsList.stream().filter(model -> model.parent == null).collect(Collectors.toList());
+        }
+
+        // Depth filtering
+        // TODO: Find a way to make it work without modifying the original list => Will need to use deep copy.
+        if (depth != null && depth < modelsList.size()) {
+            List<AffiliationEntityRestModel> filteredElements = dataToReturn;
+            if (depth >= 0) {
+                recursiveDepthRemover(filteredElements, depth, 0);
+            } else {
+                response.sendError(400, "Depth parameter invalid, it should be a positive integer");
+                return null;
+            }
+            dataToReturn = filteredElements;
+        }
+        return dataToReturn;
+    }
+
+    /**
+     * Recursive method to filter a list of AffiliationEntityRestModel to the desired depth.
+     * 
+     * @param models: The list of AffiliationEntityRestModel to filter.
+     * @param maxDepth: The maximum depth to keep.
+     * @param currentDepth: The current depth of the recursion.
+     */
+    private void recursiveDepthRemover(List<AffiliationEntityRestModel> models, Integer maxDepth, Integer currentDepth) {
+        if (maxDepth == currentDepth) {
+            // Empty the children since we reached the desired depth.
+            models.forEach(model -> model.children = new ArrayList<AffiliationEntityRestModel>());
+        } else {
+            // We have not yet reached the desired depth, so we continue the recursion.
+            models.forEach(model -> recursiveDepthRemover(model.children, maxDepth, currentDepth + 1));
+        }
+    }
+
+    private List<AffiliationEntityRestModel> deepCopy(List<AffiliationEntityRestModel> models) {
+        List<AffiliationEntityRestModel> copiedList = new ArrayList<AffiliationEntityRestModel>();
+        models.forEach(model -> copiedList.add(new AffiliationEntityRestModel(model)));
+        return copiedList;
+    }
+}

--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/rest/AffiliationsRestController.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/rest/AffiliationsRestController.java
@@ -50,7 +50,7 @@ public class AffiliationsRestController {
         @RequestParam(value = "parentUUID", required = false) UUID parentUUID,
         @RequestParam(value = "depth", required = false) Integer depth) throws IOException {
 
-        // Get the tree from the service. This tree automatically regenerated once an OrgUnit is modified so we are sure to be up to date.
+        // Get the tree from the service. This tree automatically regenerated once an OrgUnit is modified so we are sure to be up-to-date.
         List<AffiliationEntityRestModel> modelsList = this.deepCopy(this.uclouvainAffiliationEntityRestService.getAffiliationsEntities());
         // If nothing found return an empty list
         if (modelsList == null) {
@@ -73,16 +73,12 @@ public class AffiliationsRestController {
         }
 
         // Depth filtering
-        // TODO: Find a way to make it work without modifying the original list => Will need to use deep copy.
-        if (depth != null && depth < modelsList.size()) {
-            List<AffiliationEntityRestModel> filteredElements = dataToReturn;
-            if (depth >= 0) {
-                recursiveDepthRemover(filteredElements, depth, 0);
-            } else {
+        if (depth != null && depth < dataToReturn.size()) {
+            if (depth < 0) {
                 response.sendError(400, "Depth parameter invalid, it should be a positive integer");
                 return null;
             }
-            dataToReturn = filteredElements;
+            recursiveDepthRemover(dataToReturn, depth, 0);
         }
         return dataToReturn;
     }

--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/services/UCLouvainAffiliationEntityRestService.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/services/UCLouvainAffiliationEntityRestService.java
@@ -1,0 +1,10 @@
+package org.dspace.uclouvain.services;
+
+import java.util.List;
+
+import org.dspace.uclouvain.core.model.AffiliationEntityRestModel;
+
+public interface UCLouvainAffiliationEntityRestService {
+    public List<AffiliationEntityRestModel> getAffiliationsEntities();
+    public void updateAffiliationEntities();
+}

--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/services/UCLouvainAffiliationEntityRestServiceImpl.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/services/UCLouvainAffiliationEntityRestServiceImpl.java
@@ -1,0 +1,175 @@
+package org.dspace.uclouvain.services;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
+import org.dspace.content.MetadataValue;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Context;
+import org.dspace.core.Context.Mode;
+import org.dspace.discovery.DiscoverQuery;
+import org.dspace.discovery.IndexableObject;
+import org.dspace.discovery.SearchService;
+import org.dspace.discovery.SearchServiceException;
+import org.dspace.discovery.SearchUtils;
+import org.dspace.uclouvain.core.model.AffiliationEntityRestModel;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+/**
+ * Service to manage an affiliation entity tree. This tree holds information about institutions, institutes, sectors, etc.
+ * The service holds a property 'affiliationsEntities' (to store the tree) which can be accessed by other classes with the 'getAffiliationsEntities' method.
+ * 
+ * @Author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+@EnableAsync
+public class UCLouvainAffiliationEntityRestServiceImpl implements UCLouvainAffiliationEntityRestService {
+    private ItemService itemService;
+    private SearchService searchService;
+    private Logger logger;
+    private List<AffiliationEntityRestModel> affiliationsEntities = new ArrayList<AffiliationEntityRestModel>();
+
+    public UCLouvainAffiliationEntityRestServiceImpl() {
+        this.itemService = ContentServiceFactory.getInstance().getItemService();
+        this.searchService = SearchUtils.getSearchService();
+        this.logger = LogManager.getLogger(UCLouvainAffiliationEntityRestServiceImpl.class);
+        this.updateAffiliationEntities();
+    }
+
+    // Method to get affiliations entities. Must use the synchronized keyword to avoid concurrency issues.
+    public synchronized List<AffiliationEntityRestModel> getAffiliationsEntities() {
+        return affiliationsEntities;
+    }
+
+    // Method to set affiliations entities. Must use the synchronized keyword to avoid concurrency issues.
+    private synchronized void setAffiliationsEntities(List<AffiliationEntityRestModel> affiliationsEntities) {
+        this.affiliationsEntities = affiliationsEntities;
+    }
+
+    @Async
+    public void updateAffiliationEntities() {
+        this.logger.info("Starting affiliations entities refresh...");
+        Context context = new Context(Mode.READ_ONLY);
+        this.processUpdate(context);
+        // Important to close each context to avoid memory leaks && cache issues
+        context.close();
+    }
+
+    /**
+     * Triggers an update of the affiliations entities tree.
+     * @param context: The current DSpace context.
+     */
+    private void processUpdate(Context context) {
+        try {            
+            long startTime;
+            long endTime;
+            
+            startTime = System.currentTimeMillis();
+            // Retrieve all OrgUnits from Solr
+            List<Item> orgUnits = this.getOrgUnits(context);
+
+            // Convert the list of OrgUnits to a list of AffiliationEntityRestModel 
+            List<AffiliationEntityRestModel> modelsList = this.getModelsFromItem(orgUnits);
+
+            // Generate the tree structure of the affiliations
+            this.createAffiliationsStructure(modelsList);
+
+            // Set the public property to the new affiliation tree
+            this.setAffiliationsEntities(modelsList);
+            endTime = System.currentTimeMillis();
+            this.logger.info("Refreshed affiliation tree in " + (endTime - startTime) + "ms");
+        } catch (Exception e) {
+            this.logger.error("Error while processing affiliations entities: " + e);
+        }
+    }
+
+    /**
+     * Creates the tree structure of the affiliations entities using the 'parent' property of the AffiliationEntityRestModel to find the UUID of the parent.
+     * @param models: The list of AffiliationEntityRestModel to create the tree structure from.
+     */
+    private void createAffiliationsStructure(List<AffiliationEntityRestModel> models) {
+        for (AffiliationEntityRestModel model: models) {
+            if (model.parent != null) {
+                AffiliationEntityRestModel parent = models.stream().filter(m -> m.UUID.equals(model.parent)).findFirst().orElse(null);
+                if (parent != null) {
+                    parent.children.add(model);
+                }
+            }
+        }
+    }
+
+    /**
+     * Converts a list of Items into a list of AffiliationEntityRestModel.
+     * Maps the metadata of the Item to the properties of the model.
+     * @param items: The list of Items to convert.
+     * @return A list of AffiliationEntityRestModel.
+     */
+    private List<AffiliationEntityRestModel> getModelsFromItem(List<Item> items) {
+        List<AffiliationEntityRestModel> models = new ArrayList<AffiliationEntityRestModel>();
+        for (Item item: items) {
+            AffiliationEntityRestModel model = new AffiliationEntityRestModel();
+            model.UUID = item.getID();
+            model.name = itemService.getMetadataFirstValue(item, "dc", "title", null, Item.ANY);
+            model.acronym = itemService.getMetadataFirstValue(item, "oairecerif", "acronym", null, Item.ANY);
+            model.type = itemService.getMetadataFirstValue(item, "dc", "type", null, Item.ANY);
+
+            String selectable = itemService.getMetadataFirstValue(item, "organization", "isSelectable", null, Item.ANY);
+            // TODO: See if we set true by default if metadata not found.
+            model.isSelectable = (selectable != null) ? selectable.equals("true"): true;
+
+            // Extract parent UUID
+            MetadataValue parentValue = this.itemService.getMetadata(item, "organization", "parentOrganization", null, Item.ANY).stream().findFirst().orElse(null);
+            try {
+                if (parentValue != null && parentValue.getAuthority() != null) {
+                    model.parent = UUID.fromString(parentValue.getAuthority());
+                }
+            } catch (Exception e) {
+                // LOG error, authority should be a valid UUID string
+                this.logger.error("Error while parsing parent UUID of OrgUnit with ID: " + item.getID() + " - error: " + e);
+            }
+            model.children = new ArrayList<AffiliationEntityRestModel>();
+            models.add(model);
+        }
+        return models;
+    }
+
+    /**
+     * Retrieve all OrgUnits (affiliations entities) from Solr.
+     * @param context: The current DSpace context.
+     * @return A list of Items representing the OrgUnits (Affiliations).
+     * @throws SearchServiceException
+     */
+    @SuppressWarnings("rawtypes")
+    private List<Item> getOrgUnits(Context context) throws SearchServiceException {
+        DiscoverQuery query = this.getOrgUnitQuery();
+        List<IndexableObject> results = this.searchService.search(context, query).getIndexableObjects();
+
+        // Conversion from ReloadableEntity to Item
+        return results.stream()
+            .map(result -> result.getIndexedObject())
+            .filter(dso -> dso instanceof DSpaceObject)
+            .map(dso -> (DSpaceObject) dso)
+            .filter(dso -> dso instanceof Item)
+            .map(dso -> (Item) dso)
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns the query to get all OrgUnits from Solr.
+     * @return The Solr query.
+     */
+    private DiscoverQuery getOrgUnitQuery(){
+        DiscoverQuery orgUnitQuery = new DiscoverQuery();
+        orgUnitQuery.setQuery("search.entitytype:\"OrgUnit\" && search.resourcetype: \"Item\" && discoverable:\"true\"");
+        // Set to configuration variable
+        orgUnitQuery.setMaxResults(1000);
+        return orgUnitQuery;
+    }
+}

--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/services/UCLouvainAffiliationEntityRestServiceImpl.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/services/UCLouvainAffiliationEntityRestServiceImpl.java
@@ -7,7 +7,6 @@ import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.factory.ContentServiceFactory;
@@ -84,7 +83,7 @@ public class UCLouvainAffiliationEntityRestServiceImpl implements UCLouvainAffil
             // Set the public property to the new affiliation tree
             this.setAffiliationsEntities(modelsList);
             endTime = System.currentTimeMillis();
-            this.logger.info("Refreshed affiliation tree in " + (endTime - startTime) + "ms");
+            this.logger.debug("Refreshed affiliation tree in " + (endTime - startTime) + "ms");
         } catch (Exception e) {
             this.logger.error("Error while processing affiliations entities: " + e);
         }
@@ -121,7 +120,6 @@ public class UCLouvainAffiliationEntityRestServiceImpl implements UCLouvainAffil
             model.type = itemService.getMetadataFirstValue(item, "dc", "type", null, Item.ANY);
 
             String selectable = itemService.getMetadataFirstValue(item, "organization", "isSelectable", null, Item.ANY);
-            // TODO: See if we set true by default if metadata not found.
             model.isSelectable = (selectable != null) ? selectable.equals("true"): true;
 
             // Extract parent UUID
@@ -154,8 +152,6 @@ public class UCLouvainAffiliationEntityRestServiceImpl implements UCLouvainAffil
         // Conversion from ReloadableEntity to Item
         return results.stream()
             .map(result -> result.getIndexedObject())
-            .filter(dso -> dso instanceof DSpaceObject)
-            .map(dso -> (DSpaceObject) dso)
             .filter(dso -> dso instanceof Item)
             .map(dso -> (Item) dso)
             .collect(Collectors.toList());

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -810,7 +810,7 @@ event.dispatcher.RelatedItemEnhancerUpdatePoller.class = org.dspace.event.BasicD
 # Add rdf here, if you are using dspace-rdf to export your repository content as RDF.
 # Add iiif here, if you are using dspace-iiif.
 # Add orcidqueue here, if the integration with ORCID is configured and wish to enable the synchronization queue functionality
-event.dispatcher.default.consumers = versioning, discovery, eperson, dedup, crisconsumer, orcidqueue, audit, nbeventsdelete, referenceresolver, orcidwebhook, itemenhancer, customurl, iiif, reciprocal, filetypemetadataenhancer, authoritylink
+event.dispatcher.default.consumers = versioning, discovery, eperson, dedup, crisconsumer, orcidqueue, audit, nbeventsdelete, referenceresolver, orcidwebhook, itemenhancer, customurl, reciprocal, filetypemetadataenhancer, licensegenerator, accesstype, affiliationTree
 event.dispatcher.RelatedItemEnhancerUpdatePoller.consumers = versioning, discovery, eperson, dedup, crisconsumer, orcidqueue, audit, nbeventsdelete, referenceresolver, orcidwebhook, itemenhancer, customurl, iiif, reciprocal, filetypemetadataenhancer, authoritylink
 
 # enable the item enhancer poller

--- a/dspace/config/modules/authority.cfg
+++ b/dspace/config/modules/authority.cfg
@@ -95,9 +95,9 @@ plugin.named.org.dspace.content.authority.ChoiceAuthority = \
  org.dspace.content.authority.EPersonAuthority = EPersonAuthority,\
  org.dspace.content.authority.GroupAuthority = GroupAuthority,\
  org.dspace.content.authority.ZDBAuthority = ZDBAuthority,\
- org.dspace.content.authority.SherpaAuthority = SherpaAuthority
- 
-
+ org.dspace.content.authority.SherpaAuthority = SherpaAuthority,\
+ #UCLouvain authority
+ org.dspace.uclouvain.authority.PublicationAuthorAuthority = PublicationAuthorAuthority,
 ### Login MIUR
 #for login MIUR addon please configure the following entry in the list above
 #org.dspace.content.authority.ANCEAuthority = JournalAuthority
@@ -154,7 +154,11 @@ cris.SherpaAuthority.local-item-choices-enabled = true
 ItemAuthority.reciprocalMetadata.Publication.dc.relation.product = dc.relation.publication
 ItemAuthority.reciprocalMetadata.Product.dc.relation.publication = dc.relation.product
 
-choices.plugin.dc.contributor.author = AuthorAuthority
+# choices.plugin.dc.contributor.author = AuthorAuthority
+# choices.presentation.dc.contributor.author = suggest
+# authority.controlled.dc.contributor.author = true
+
+choices.plugin.dc.contributor.author = PublicationAuthorAuthority
 choices.presentation.dc.contributor.author = suggest
 authority.controlled.dc.contributor.author = true
 

--- a/dspace/config/modules/authority.cfg
+++ b/dspace/config/modules/authority.cfg
@@ -158,6 +158,11 @@ ItemAuthority.reciprocalMetadata.Product.dc.relation.publication = dc.relation.p
 # choices.presentation.dc.contributor.author = suggest
 # authority.controlled.dc.contributor.author = true
 
+authority.controlled.oairecerif.authors.orgunit = true
+authority.controlled.oairecerif.authors.orgunitDepartement = true
+authority.controlled.oairecerif.affiliation.orgunit = true
+authority.controlled.oairecerif.affiliation.orgunitDepartement = true
+
 choices.plugin.dc.contributor.author = PublicationAuthorAuthority
 choices.presentation.dc.contributor.author = suggest
 authority.controlled.dc.contributor.author = true

--- a/dspace/config/modules/uclouvain.cfg
+++ b/dspace/config/modules/uclouvain.cfg
@@ -36,3 +36,8 @@ event.consumer.affiliationTree.filters = Item+All
 #------------- Community/Collection configuration -----------------#
 #------------------------------------------------------------------#
 core.authorization.collection-mapping.solr.limit = 10000
+
+#--------------------------------------------#
+#-----------------Authority -----------------#
+#--------------------------------------------#
+uclouvain.authority.authorAuthority.default = 20

--- a/dspace/config/modules/uclouvain.cfg
+++ b/dspace/config/modules/uclouvain.cfg
@@ -29,6 +29,9 @@ event.consumer.licensegenerator.filters = Bitstream+All
 event.consumer.accesstype.class = org.dspace.uclouvain.consumer.AccessTypeConsumer
 event.consumer.accesstype.filters = Bitstream+Create|Modify|Delete|Remove
 
+event.consumer.affiliationTree.class = org.dspace.uclouvain.consumer.AffiliationModificationConsumer
+event.consumer.affiliationTree.filters = Item+All
+
 #------------------------------------------------------------------#
 #------------- Community/Collection configuration -----------------#
 #------------------------------------------------------------------#

--- a/dspace/config/spring/uclouvain/uclouvain-services.xml
+++ b/dspace/config/spring/uclouvain/uclouvain-services.xml
@@ -24,6 +24,10 @@
     </bean>
 
     <!-- SERVICES ========================================================= -->
+
+    <bean id="publicationAuthorAuthority" class="org.dspace.uclouvain.authority.PublicationAuthorAuthority"/>
+    <bean id="publicationAffiliationAuthority" class="org.dspace.uclouvain.authority.PublicationAffiliationAuthority"/>
+
     <bean id="uclouvainEntityService" class="org.dspace.uclouvain.services.UCLouvainEntityServiceImpl"/>
     <bean id="uclouvainResourcePolicyService" class="org.dspace.uclouvain.services.UCLouvainResourcePolicyServiceImpl"/>
 

--- a/dspace/config/spring/uclouvain/uclouvain-services.xml
+++ b/dspace/config/spring/uclouvain/uclouvain-services.xml
@@ -26,7 +26,6 @@
     <!-- SERVICES ========================================================= -->
 
     <bean id="publicationAuthorAuthority" class="org.dspace.uclouvain.authority.PublicationAuthorAuthority"/>
-    <bean id="publicationAffiliationAuthority" class="org.dspace.uclouvain.authority.PublicationAffiliationAuthority"/>
 
     <bean id="uclouvainEntityService" class="org.dspace.uclouvain.services.UCLouvainEntityServiceImpl"/>
     <bean id="uclouvainResourcePolicyService" class="org.dspace.uclouvain.services.UCLouvainResourcePolicyServiceImpl"/>

--- a/dspace/config/spring/uclouvain/uclouvain-services.xml
+++ b/dspace/config/spring/uclouvain/uclouvain-services.xml
@@ -30,7 +30,8 @@
 
     <bean id="uclouvainEntityService" class="org.dspace.uclouvain.services.UCLouvainEntityServiceImpl"/>
     <bean id="uclouvainResourcePolicyService" class="org.dspace.uclouvain.services.UCLouvainResourcePolicyServiceImpl"/>
-
+    <bean id="uclouvainAffiliationEntityRestService" class="org.dspace.uclouvain.services.UCLouvainAffiliationEntityRestServiceImpl"/>
+    
     <!-- UTILS ============================================================ -->
     <bean id="itemUtils" class="org.dspace.uclouvain.core.utils.ItemUtils" />
 

--- a/scripts/config/registries/person.types.xml
+++ b/scripts/config/registries/person.types.xml
@@ -1,0 +1,24 @@
+<dspace-dc-types>
+    <dspace-header>
+        <title>Additional metadata fields for the 'person' schema</title>
+        <contributor.author>Michaël Pourbaix</contributor.author>
+    </dspace-header>
+    <!-- SCHEMA ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <dc-schema>
+        <name>person</name>
+        <namespace>http://dspace.org/person</namespace>
+    </dc-schema>
+    <!-- FIELDS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <dc-type>
+        <schema>person</schema>
+        <element>affiliation</element>
+        <qualifier>institution</qualifier>
+        <scope_note>An institution for a person's affiliation</scope_note>
+    </dc-type>
+    <dc-type>
+        <schema>person</schema>
+        <element>affiliation</element>
+        <qualifier>department</qualifier>
+        <scope_note>A department for a person's affiliation</scope_note>
+    </dc-type>
+</dspace-dc-types>

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -162,6 +162,7 @@ METADATA_REGISTRIES=(
   "registries/oairecerif-types.xml"
   "registries/organization-types.xml"
   "registries/publication-types.xml"
+  "registries/person-types.xml"
 )
 for registry in "${METADATA_REGISTRIES[@]}"
 do


### PR DESCRIPTION
### 3 Commits:

1. [[ADD] feat(submission-form) Author authority in form fields.](https://github.com/bibsys/DSpace/commit/9ddbc4aca02b771faef829069fb24468277c477f)
Definition of a simple author authority which can be used to search for local person in DSpace registry.
The authority also imports some data of the eperson into the form fields.

2.  [[ADD] feat(controller): Controller to retrieve affiliation tree + Affiliation form field](https://github.com/bibsys/DSpace/commit/59ab0f703b4e85f279aff2d092466faade11caa5)
Addition of a controller that can be used to retrieve all the affiliation tree structure. It uses a caching system for better performances.

3. [[ADD] feat(metadata-schema): Field definition for person affiliations.](https://github.com/bibsys/DSpace/commit/ce2cb5f097c144499f65db596a492be20ef37349)
New field definition to store affiliation data in an eperson item.
