### PR TITLE
[UPD] feat(accept-no-diff): RPname for policy added to accepted without diffusion items.

### DIFF
--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/xmlworkflow/actions/UCLouvainThesisReviewAction.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/xmlworkflow/actions/UCLouvainThesisReviewAction.java
@@ -22,6 +22,7 @@ import org.dspace.core.Context;
 import org.dspace.core.Constants;
 import org.dspace.eperson.Group;
 import org.dspace.eperson.service.GroupService;
+import org.dspace.uclouvain.plugins.UCLouvainAccessStatusHelper;
 import org.dspace.xmlworkflow.factory.XmlWorkflowServiceFactory;
 import org.dspace.xmlworkflow.service.WorkflowRequirementsService;
 import org.dspace.xmlworkflow.state.Step;
@@ -184,7 +185,7 @@ public class UCLouvainThesisReviewAction extends ReviewAction {
      */
     private void restrictBitstream(Context ctx, Bitstream bs, Group adminGroup) throws SQLException, AuthorizeException {
         authorizeService.removeAllPolicies(ctx, bs);
-        authorizeService.addPolicy(ctx, bs, Constants.READ, adminGroup, ResourcePolicy.TYPE_CUSTOM);
+        authorizeService.createResourcePolicy(ctx, bs, adminGroup, null,  Constants.READ, ResourcePolicy.TYPE_CUSTOM, UCLouvainAccessStatusHelper.ADMINISTRATOR, null, null, null);
     }
 
     /**


### PR DESCRIPTION
Added a 'RPName' property for the resource policy which is added to the item when it is accepted without diffusion. This makes the policy more in compliant compared to the others already present in the application.