### PR TITLE
 [ADD] feat(submission-section): Change request form section

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/step/DataChangeRequest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/step/DataChangeRequest.java
@@ -1,0 +1,23 @@
+package org.dspace.app.rest.model.step;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+
+/**
+ * This is class represents the data structure for a DataChangeRequest.
+ * NOTE: We need to use @JsonUnwrapped to avoid having a 'null' value in the request response for this specific field.
+ * Instead it will return an empty object '{}', which is understood by the frontend has a hint to not display the section.
+ * 
+ * @Authored: Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+public class DataChangeRequest implements SectionData {
+    @JsonUnwrapped
+    private String changeData;
+
+    public String getChangeData() {
+        return changeData;
+    }
+
+    public void setChangeData(String changeData) {
+        this.changeData = changeData;
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/ChangeRequestStep.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/ChangeRequestStep.java
@@ -1,0 +1,47 @@
+package org.dspace.app.rest.submit.step;
+
+import static org.apache.commons.lang.StringUtils.isEmpty;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.dspace.app.rest.model.patch.Operation;
+import org.dspace.app.rest.model.step.DataChangeRequest;
+import org.dspace.app.rest.submit.AbstractProcessingStep;
+import org.dspace.app.rest.submit.SubmissionService;
+import org.dspace.app.util.SubmissionStepConfig;
+import org.dspace.content.InProgressSubmission;
+import org.dspace.content.Item;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Context;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.uclouvain.core.model.MetadataField;
+
+/**
+ * Section step class for the Change Request section. It searches for a change request value and returns it in a DataChangeRequest form.
+ * 
+ * @Authored: Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+public class ChangeRequestStep extends AbstractProcessingStep {
+
+    private ConfigurationService configService = DSpaceServicesFactory.getInstance().getConfigurationService();
+    // Active Request Field
+    private MetadataField activeRF = new MetadataField(configService.getProperty("uclouvain.global.metadata.activerequestchange.field"));
+
+    @Override
+    public DataChangeRequest getData(SubmissionService submissionService, InProgressSubmission obj, SubmissionStepConfig config) throws Exception {
+        DataChangeRequest result = new DataChangeRequest();
+        Item item = obj.getItem();
+        ItemService itemService = obj.getItem().getItemService();
+        // Get the change request metadata value from the item.
+        String requiredChanges = itemService.getMetadataFirstValue(item, activeRF, null);
+        if (!isEmpty(requiredChanges)) {
+            result.setChangeData(requiredChanges);
+        }
+        return result;
+    }
+
+    // Empty method since no specific operation can be done with the ChangeRequestStep.
+    @Override
+    public void doPatchProcessing(Context context, HttpServletRequest currentRequest, InProgressSubmission source, Operation op, SubmissionStepConfig stepConf) throws Exception {}
+}

--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/xmlworkflow/actions/UCLouvainThesisClearChangeRequestAction.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/xmlworkflow/actions/UCLouvainThesisClearChangeRequestAction.java
@@ -1,0 +1,71 @@
+package org.dspace.uclouvain.xmlworkflow.actions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.content.Item;
+import org.dspace.core.Context;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.uclouvain.core.model.MetadataField;
+import org.dspace.xmlworkflow.state.Step;
+import org.dspace.xmlworkflow.state.actions.ActionResult;
+import org.dspace.xmlworkflow.state.actions.processingaction.ProcessingAction;
+import org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem;
+
+
+/**
+ * Method to clean the active change request field value when the user submits the item.
+ * Before being deleted, the value can be stored in a request history field.
+ * This is determined by a configuration property 'uclouvain.feature.send_back_to_submitter.store_reason'.
+ * 
+ * @Authored: Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+public class UCLouvainThesisClearChangeRequestAction extends ProcessingAction {
+
+
+    private ConfigurationService configService = DSpaceServicesFactory.getInstance().getConfigurationService();
+
+    // Active Request Field
+    private MetadataField activeRF = new MetadataField(this.configService.getProperty("uclouvain.global.metadata.activerequestchange.field"));
+    // Request Field History
+    private MetadataField RFHistory = new MetadataField(this.configService.getProperty("uclouvain.global.metadata.requestchangehistory.field"));
+    // Indicates if we need to store the reason in history before deleting it ? 
+    private Boolean storeInHistory = this.configService.getBooleanProperty("uclouvain.feature.send_back_to_submitter.store_reason", false);
+
+    private Logger logger = LogManager.getLogger(UCLouvainThesisClearChangeRequestAction.class);
+
+
+    @Override
+    public void activate(Context context, XmlWorkflowItem wfItem) {}
+
+    @Override
+    public ActionResult execute(Context context,  XmlWorkflowItem wfi, Step step, HttpServletRequest request) {
+        Item item = wfi.getItem();
+        try {
+            // Retrieve the value of the active request field
+            String value = this.itemService.getMetadataFirstValue(item, activeRF, Item.ANY);
+            if (value != null) {
+                // If any value is found, we store it in the history field if desired and then we delete it.
+                if (this.storeInHistory) {
+                    this.itemService.addMetadata(context, item, RFHistory.getSchema(), RFHistory.getElement(), RFHistory.getQualifier(), null, value);
+                }
+                this.itemService.clearMetadata(context, item, activeRF.getSchema(), activeRF.getElement(), activeRF.getQualifier(), Item.ANY);
+            }
+            return new ActionResult(ActionResult.TYPE.TYPE_OUTCOME, ActionResult.OUTCOME_COMPLETE);
+        } catch (Exception e) {
+            logger.error("An error occurred while clearing the active request change metadata field.", e);
+            return new ActionResult(ActionResult.TYPE.TYPE_ERROR);
+        }
+
+    }
+
+    @Override
+    public List<String> getOptions() {
+        return new ArrayList<String>();
+    }
+}

--- a/dspace-uclouvain/src/main/java/org/dspace/uclouvain/xmlworkflow/actions/UCLouvainThesisReviewAction.java
+++ b/dspace-uclouvain/src/main/java/org/dspace/uclouvain/xmlworkflow/actions/UCLouvainThesisReviewAction.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.util.Util;
@@ -25,6 +26,9 @@ import org.dspace.core.Constants;
 import org.dspace.eperson.Group;
 import org.dspace.eperson.service.GroupService;
 import org.dspace.uclouvain.plugins.UCLouvainAccessStatusHelper;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.uclouvain.core.model.MetadataField;
 import org.dspace.xmlworkflow.factory.XmlWorkflowServiceFactory;
 import org.dspace.xmlworkflow.service.WorkflowRequirementsService;
 import org.dspace.xmlworkflow.state.Step;
@@ -38,7 +42,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Custom review action for master theses.
- * This Action contains 3 outputs: 'Accepted', 'Accepted without diffusion' and 'Rejected'.
+ * This Action contains three outputs: 'Accepted', 'Accepted without diffusion' and 'Rejected'.
  * In the case 'Accepted', we continue the workflow;
  * In the case 'Accepted without diffusion', same as 'Accepted' but we restrict bitstream && add a message to the metadata;
  * In the case 'Rejected', we change the state of the workflow item to 'Withdrawn' && we add it to archive;
@@ -48,11 +52,16 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 public class UCLouvainThesisReviewAction extends ReviewAction {
 
+    private ConfigurationService configService = DSpaceServicesFactory.getInstance().getConfigurationService();
+
     private static final String SUBMITTER_IS_DELETED_PAGE = "submitter_deleted";
     private static final String SUBMIT_APPROVE = "submit_confirm_approve";
     private static final String SUBMIT_APPROVE_WITHOUT_DIFFUSION = "submit_approve_no_diffusion";
     private static final String SUBMIT_WITHDRAW_REJECT = "submit_withdraw_reject";
     private static final String RETURN_TO_SUBMITTER = "submit_return_to_submitter";
+
+    // Active Request Field
+    private MetadataField activeRF = new MetadataField(this.configService.getProperty("uclouvain.global.metadata.activerequestchange.field"));
 
     @Autowired(required = true)
     protected WorkflowItemRoleService workflowItemRoleService;
@@ -114,13 +123,12 @@ public class UCLouvainThesisReviewAction extends ReviewAction {
 
     /**
      * Process result when option 'SUBMIT_APPROVE_WITHOUT_DIFFUSION' is selected.
-     * - First delete all bitstream restriction and add only administrator access.
+     * - First delete all bitstream restrictions and add only administrator access.
      * - Add a new tag to keep a trace of the operation in the 'dc.description.X' metadata field.
      * If reason is not given => error
      */
     public ActionResult processAcceptWithoutDiffusion(Context ctx, XmlWorkflowItem wfi, HttpServletRequest request) throws SQLException, AuthorizeException {
         Item currentItem = wfi.getItem();
-
         // 1. Change bitstreams access to admin only
         Group adminGroup = this.groupService.findByName(ctx, "Administrator");
         if (adminGroup != null){
@@ -129,18 +137,23 @@ public class UCLouvainThesisReviewAction extends ReviewAction {
                 this.restrictBitstream(ctx, bitstream, adminGroup);
             }
         }
-
         // 2. Add provenance with the name of the user that performed the action.
         this.addProvenance(ctx, currentItem, "Approved with no diffusion for entry into archive by user: '" + ctx.getCurrentUser().getEmail() + "'");
         this.itemService.update(ctx, currentItem);
-
         return new ActionResult(ActionResult.TYPE.TYPE_OUTCOME, ActionResult.OUTCOME_COMPLETE);
     }
 
     /**
      * Process result when option 'SUBMIT_WITHDRAW_REJECT' is selected:
-     * - Archive the item.
-     * - Once archived, withdrawn it.
+     * - First archive the item.
+     * - Once archived, withdrawn it, to be only visible by administrators.
+     * 
+     * @param context: The current DSpace context.
+     * @param wfi: The workflow item that is being operated.
+     * @param request: The current request object.
+     * @return An ActionResult object which represents the output of the action.
+     * @throws SQLException if any database exception occurred
+     * @throws AuthorizeException if any authorization occurred
      */
     @Override
     public ActionResult processRejectPage(Context context, XmlWorkflowItem wfi, HttpServletRequest request) throws SQLException, AuthorizeException, IOException {
@@ -151,16 +164,32 @@ public class UCLouvainThesisReviewAction extends ReviewAction {
         Item archivedItem = this.archive(context, wfi);
         this.itemService.withdraw(context, archivedItem);
         context.restoreAuthSystemState();
-
         return new ActionResult(ActionResult.TYPE.TYPE_PAGE);
     }
 
-    public ActionResult processReturnToSubmitter(Context context, XmlWorkflowItem wfi, HttpServletRequest request) throws SQLException, AuthorizeException {
-        // Return the item to the submitter && encode the required changes in a specific metadata field.
+    /**
+     * Process the action 'RETURN_TO_SUBMITTER' which can be performed by a manager and will:
+     *  -> Send the item back to the submitter for modifications.
+     *  -> Add a message (given by the manager) into a metadata field of the item.
+     *  -> The message will then be used to inform the submitter of the needed changes.
+     * 
+     * @param context: The current DSpace context.
+     * @param wfi: The workflow item that is being operated.
+     * @param request: The current request object.
+     * @return An ActionResult object which represents the output of the action.
+     */
+    public ActionResult processReturnToSubmitter(Context context, XmlWorkflowItem wfi, HttpServletRequest request) {
         try {
-            // TODO: Add a message to the metadata to explain the return.
             context.turnOffAuthorisationSystem();
-            this.xmlWorkflowService.sendWorkflowItemBackSubmission(context, wfi, context.getCurrentUser(), "","Send back to submitter for modifications");
+            // Send the item back to submission state.
+            this.xmlWorkflowService.sendWorkflowItemBackSubmission(context, wfi, context.getCurrentUser(), "", "Send back to submitter for modifications");
+            // Get the mandatory reason from the request object
+            String reason = request.getParameter("reason");
+            if (StringUtils.isEmpty(reason)) {
+                return new ActionResult(ActionResult.TYPE.TYPE_CANCEL);
+            }
+            // Encode the reason in the metadata field 
+            this.itemService.setMetadataSingleValue(context, wfi.getItem(), activeRF, null, reason);
             context.restoreAuthSystemState();
             return new ActionResult(ActionResult.TYPE.TYPE_SUBMISSION_PAGE);
         } catch (Exception e) {
@@ -173,33 +202,39 @@ public class UCLouvainThesisReviewAction extends ReviewAction {
      * Used to archive an item and remove all metadata related to the workflow.
      * @param context: The current DSpace context.
      * @param wfi: The workflow item to archive.
-     * @return: The archived item.
-     * @throws SQLException
-     * @throws IOException
-     * @throws AuthorizeException
+     * @return The archived item.
+     * @throws SQLException if any database exception occurred
+     * @throws AuthorizeException if any authorization occurred
      */
-    private Item archive(Context context, XmlWorkflowItem wfi) throws SQLException, IOException, AuthorizeException {
+    private Item archive(Context context, XmlWorkflowItem wfi) throws SQLException, AuthorizeException {
         Item item = wfi.getItem();
-
         workflowItemRoleService.deleteForWorkflowItem(context, wfi);
         installItemService.installItem(context, wfi);
         this.itemService.clearMetadata(context, item, WorkflowRequirementsService.WORKFLOW_SCHEMA, Item.ANY, Item.ANY, Item.ANY);
         this.itemService.update(context, item);
-
         return item;
     }
 
     /**
      * Take a bitstream and restricts the access to the administrator group only.
      * @param ctx: The current DSpace context.
-     * @param bs: The bitstream to restrict.
+     * @param bitstream: The bitstream to restrict.
      * @param adminGroup: The administrator group to grant read rights to.
-     * @throws SQLException
-     * @throws AuthorizeException
+     * @throws SQLException if any database exception occurred
+     * @throws AuthorizeException if any authorization occurred
      */
-    private void restrictBitstream(Context ctx, Bitstream bs, Group adminGroup) throws SQLException, AuthorizeException {
-        authorizeService.removeAllPolicies(ctx, bs);
-        authorizeService.createResourcePolicy(ctx, bs, adminGroup, null,  Constants.READ, ResourcePolicy.TYPE_CUSTOM, UCLouvainAccessStatusHelper.ADMINISTRATOR, null, null, null);
+    private void restrictBitstream(Context ctx, Bitstream bitstream, Group adminGroup) throws SQLException, AuthorizeException {
+        authorizeService.removeAllPolicies(ctx, bitstream);
+        authorizeService.createResourcePolicy(
+                ctx,
+                bitstream,
+                adminGroup,
+                null,
+                Constants.READ,
+                ResourcePolicy.TYPE_CUSTOM,
+                UCLouvainAccessStatusHelper.ADMINISTRATOR,
+                null, null, null
+        );
     }
 
     /**
@@ -207,25 +242,26 @@ public class UCLouvainThesisReviewAction extends ReviewAction {
      * @param ctx: The current DSpace context.
      * @param item: The item to which the provenance information will be added to.
      * @param message: The custom message to be added to the provenance information.
-     * @throws SQLException
-     * @throws AuthorizeException
+     * @throws SQLException if any database exception occurred
+     * @throws AuthorizeException if any authorization occurred
      */
-    public void addProvenance(Context ctx, Item item, String message) throws SQLException, AuthorizeException {
+    private void addProvenance(Context ctx, Item item, String message) throws SQLException, AuthorizeException {
         // Retrieve current datetime
         String now = DCDate.getCurrent().toString();
-
         // Get user's name + email address
-        String usersName =
-            XmlWorkflowServiceFactory.getInstance().getXmlWorkflowService().getEPersonName(ctx.getCurrentUser());
-
-        String provDescription = getProvenanceStartId() + " " + message + " " + usersName + " on "
-            + now + " (GMT) ";
-
+        String usersName = XmlWorkflowServiceFactory.getInstance().getXmlWorkflowService().getEPersonName(ctx.getCurrentUser());
+        String provDescription = getProvenanceStartId() + " " + message + " " + usersName + " on " + now + " (GMT) ";
         // Add provenance info in the 'dc.description.provenance' field
         ctx.turnOffAuthorisationSystem();
-        this.itemService.addMetadata(ctx, item, MetadataSchemaEnum.DC.getName(), "description", "provenance", "en",
-            provDescription);
+        this.itemService.addMetadata(
+                ctx,
+                item,
+                MetadataSchemaEnum.DC.getName(),
+                "description", "provenance",
+                "en",
+                provDescription
+        );
         this.itemService.update(ctx, item);
         ctx.restoreAuthSystemState();
-    } 
+    }
 }

--- a/dspace/config/item-submission.xml
+++ b/dspace/config/item-submission.xml
@@ -216,15 +216,22 @@
       <processing-class>org.dspace.app.rest.submit.step.ShowIdentifiersStep</processing-class>
       <type>identifiers</type>
     </step-definition>
+    <step-definition id="change-request" mandatory="true">
+      <heading>submit.progressbar.changerequest</heading>
+      <processing-class>org.dspace.app.rest.submit.step.ChangeRequestStep</processing-class>
+      <type>change-request</type>
+    </step-definition>
   </step-definitions>
   <submission-definitions>
     <submission-process name="master-thesis">
       <!--<step id="collection" />-->
       <step id="extractionstep" />
+      <step id="change-request" />
       <step id="upload" />
       <step id="master-thesis" />
       <step id="correction" />
       <step id="license" />
+      <step id="detect-duplicate"/>
     </submission-process>
     <submission-process name="master-thesis-edit">
       <step id="extractionstep" />

--- a/dspace/config/modules/uclouvain.cfg
+++ b/dspace/config/modules/uclouvain.cfg
@@ -57,6 +57,8 @@ uclouvain.global.metadata.advisorname.field = dc.contributor.advisor
 uclouvain.global.metadata.entitytype.field = dspace.entity.type
 uclouvain.global.metadata.session.field = masterthesis.session
 uclouvain.global.metadata.year.field = dc.date.issued
+uclouvain.global.metadata.activerequestchange.field = masterthesis.changerequest.active
+uclouvain.global.metadata.requestchangehistory.field = masterthesis.changerequest.history
 
 #------------------------------------------------------------------#
 #-------------- Packager ingestion configuration ------------------#
@@ -88,6 +90,9 @@ uclouvain.resource_policy.accepted_bundles = ORIGINAL
 uclouvain.feature.can_create_submission.permit_all_time = Administrator
 uclouvain.feature.can_create_submission.permit_all_time = manager
 uclouvain.feature.can_create_submission.permit_all_time = unresticted_submit_student
+
+# Determines if we need to store the reasons of a 'send back to submitter' action in a specific field.
+uclouvain.feature.send_back_to_submitter.store_reason = true
 
 #------------------------------------------------------------------#
 #-------------- UCLouvain consumers configuration -----------------#

--- a/dspace/config/spring/api/workflow-actions.xml
+++ b/dspace/config/spring/api/workflow-actions.xml
@@ -7,6 +7,7 @@
     <bean id="claimactionAPI" class="org.dspace.xmlworkflow.state.actions.userassignment.ClaimAction" scope="prototype"/>
     <bean id="sendemailattestationactionAPI" class="org.dspace.uclouvain.pdfAttestationGenerator.xmlworkflow.actions.SendEmailAttestationAction" scope="prototype" />
     <bean id="uclouvainthesisreviewactionAPI" class="org.dspace.uclouvain.xmlworkflow.actions.UCLouvainThesisReviewAction" scope="prototype"/>
+    <bean id="clearchangerequestactionAPI" class="org.dspace.uclouvain.xmlworkflow.actions.UCLouvainThesisClearChangeRequestAction" scope="prototype"/>
     <bean id="reviewactionAPI" class="org.dspace.xmlworkflow.state.actions.processingaction.ReviewAction" scope="prototype"/>
     <bean id="editactionAPI" class="org.dspace.xmlworkflow.state.actions.processingaction.AcceptEditRejectAction" scope="prototype"/>
     <bean id="finaleditactionAPI" class="org.dspace.xmlworkflow.state.actions.processingaction.FinalEditAction" scope="prototype"/>
@@ -39,6 +40,12 @@
         <constructor-arg type="java.lang.String" value="uclouvainthesisreviewaction"/>
         <property name="processingAction" ref="uclouvainthesisreviewactionAPI"/>
         <property name="requiresUI" value="true"/>
+    </bean>
+
+    <bean id="clearchangerequestaction" class="org.dspace.xmlworkflow.state.actions.WorkflowActionConfig" scope="prototype">
+        <constructor-arg type="java.lang.String" value="clearchangerequestaction"/>
+        <property name="processingAction" ref="clearchangerequestactionAPI"/>
+        <property name="requiresUI" value="false"/>
     </bean>
 
     <bean id="reviewaction" class="org.dspace.xmlworkflow.state.actions.WorkflowActionConfig" scope="prototype">

--- a/dspace/config/spring/api/workflow.xml
+++ b/dspace/config/spring/api/workflow.xml
@@ -36,9 +36,10 @@
     </bean>
     <!-- Master Theses Workflow -->
     <bean name="masterThesisWorkflow" class="org.dspace.xmlworkflow.state.Workflow">
-        <property name="firstStep" ref="generatepdfattestationstep"/>
+        <property name="firstStep" ref="clearThesisMetadataStep"/>
         <property name="steps">
             <util:list>
+                <ref bean="clearThesisMetadataStep"/>
                 <ref bean="generatepdfattestationstep" />
                 <ref bean="uclouvainthesisreviewstep"/>
             </util:list>
@@ -119,6 +120,21 @@
         <property name="actions">
             <list>
                 <ref bean="checkcorrectionaction"/>
+            </list>
+        </property>
+    </bean>
+
+    <bean name="clearThesisMetadataStep" class="org.dspace.xmlworkflow.state.Step">
+        <property name="userSelectionMethod" ref="noUserSelectionAction"/>
+        <property name="outcomes">
+            <util:map>
+                <entry key="#{ T(org.dspace.xmlworkflow.state.actions.ActionResult).OUTCOME_COMPLETE}" 
+                       value-ref="generatepdfattestationstep"/>
+            </util:map>
+        </property>
+        <property name="actions">
+            <list>
+                <ref bean="clearchangerequestaction"/>
             </list>
         </property>
     </bean>

--- a/scripts/config/registries/masterthesis-types.xml
+++ b/scripts/config/registries/masterthesis-types.xml
@@ -53,4 +53,14 @@
         <qualifier/>
         <scope_note>Session when thesis was defended</scope_note>
     </dc-type>
+    <dc-type>
+        <schema>masterthesis</schema>
+        <element>changerequest</element>
+        <qualifier>active</qualifier>
+    </dc-type>
+    <dc-type>
+        <schema>masterthesis</schema>
+        <element>changerequest</element>
+        <qualifier>history</qualifier>
+    </dc-type>
  </dspace-dc-types>


### PR DESCRIPTION
When a manager requests a 'return to submitter', his reason is store in the item's metadata.
A new submission section displays the current change request for the submitter by reading the corresponding metadata.
Also, a new workflow step removes the current active change request each time an item is submitted.