### PR TITLE
[ADD] feat(itemRest): Exposed new 'changeRequested' property on itemRest model.

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/ItemRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/ItemRest.java
@@ -74,6 +74,7 @@ public class ItemRest extends DSpaceObjectRest {
     public static final String METRICS = "metrics";
     public static final String THUMBNAIL = "thumbnail";
 
+    private boolean changeRequested = false;
     private boolean inArchive = false;
     private boolean discoverable = false;
     private boolean withdrawn = false;
@@ -90,6 +91,14 @@ public class ItemRest extends DSpaceObjectRest {
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     public String getType() {
         return NAME;
+    }
+
+    public boolean getChangeRequested() {
+        return changeRequested;
+    }
+
+    public void setChangeRequested(boolean changeRequested) {
+        this.changeRequested = changeRequested;
     }
 
     public boolean getInArchive() {


### PR DESCRIPTION
A new property is exposed for each itemRest to see if a change request is currently active for the request or not. This property is visible through the API when requesting for an item.