### PR TITLE
[ADD] feat(search): Facet expose filter suggestion

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoverySearchFilterFacet.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoverySearchFilterFacet.java
@@ -27,6 +27,7 @@ public class DiscoverySearchFilterFacet extends DiscoverySearchFilter {
     private boolean exposeTotalElements = false;
     private boolean fillDateGaps = false;
     private boolean inverseDirection = false;
+    private boolean exposeFilter = true;
 
     public int getFacetLimit() {
         if (facetLimit == -1) {
@@ -118,5 +119,13 @@ public class DiscoverySearchFilterFacet extends DiscoverySearchFilter {
 
     public void setInverseDirection(boolean inverseDirection) {
         this.inverseDirection = inverseDirection;
+    }
+
+    public void setExposeFilter(boolean exposeFilter) {
+        this.exposeFilter = exposeFilter;
+    }
+
+    public boolean exposeFilter() {
+        return this.exposeFilter;
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/DiscoverFacetConfigurationConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/DiscoverFacetConfigurationConverter.java
@@ -42,6 +42,7 @@ public class DiscoverFacetConfigurationConverter {
             SearchFacetEntryRest facetEntry = new SearchFacetEntryRest(discoverySearchFilterFacet.getIndexFieldName());
             facetEntry.setFacetType(discoverySearchFilterFacet.getType());
             facetEntry.setFacetLimit(discoverySearchFilterFacet.getFacetLimit());
+            facetEntry.setExposeFilter(discoverySearchFilterFacet.exposeFilter());
 
             facetConfigurationRest.addSidebarFacet(facetEntry);
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/DiscoverFacetResultsConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/DiscoverFacetResultsConverter.java
@@ -94,6 +94,9 @@ public class DiscoverFacetResultsConverter {
 
         facetResultsRest.setSearchFilters(searchFilters);
 
+        DiscoverySearchFilterFacet field = configuration.getSidebarFacet(facetName);
+        facetResultsRest.setExposeFilter(field.exposeFilter());
+
         for (SearchFilter searchFilter : CollectionUtils.emptyIfNull(searchFilters)) {
             facetResultsRest
                 .addAppliedFilter(searchFilterToAppliedFilterConverter.convertSearchFilter(context, searchFilter));

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/DiscoveryResultsRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/DiscoveryResultsRest.java
@@ -32,6 +32,7 @@ public abstract class DiscoveryResultsRest extends BaseObjectRest<String> {
     @JsonIgnore
     private List<SearchFilter> searchFilters;
     private String configuration;
+    private boolean exposeFilter;
 
     public String getCategory() {
         return CATEGORY;
@@ -122,5 +123,11 @@ public abstract class DiscoveryResultsRest extends BaseObjectRest<String> {
         return searchFilters;
     }
 
+    public boolean getExposeFilter() {
+        return exposeFilter;
+    }
 
+    public void setExposeFilter(boolean exposeFilter) {
+        this.exposeFilter = exposeFilter;
+    }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/SearchFacetEntryRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/SearchFacetEntryRest.java
@@ -50,6 +50,7 @@ public class SearchFacetEntryRest extends RestAddressableModel {
     private List<SearchFacetValueRest> values = new LinkedList<>();
     private boolean exposeMore;
     private boolean exposeMissing;
+    private boolean exposeFilter;
 
     public SearchFacetEntryRest(final String name) {
         this.name = name;
@@ -199,5 +200,13 @@ public class SearchFacetEntryRest extends RestAddressableModel {
 
     public void setExposeMissing(boolean exposeMissing) {
         this.exposeMissing = exposeMissing;
+    }
+
+    public boolean getExposeFilter() {
+        return exposeFilter;
+    }
+
+    public void setExposeFilter(boolean exposeFilter) {
+        this.exposeFilter = exposeFilter;
     }
 }


### PR DESCRIPTION
Adds a setting to specify if the suggestion text filter should be possible for a specific facet. The frontend-end should use this setting to display or not the suggestion input textarea.

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [x] Run unitest for `dspace-uclouvain` module