### PR TITLE
[ADD] feat(metadata-enhancer) Authority based metadata enhancing.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -100,6 +100,7 @@ import org.dspace.orcid.service.OrcidTokenService;
 import org.dspace.profile.service.ResearcherProfileService;
 import org.dspace.qaevent.dao.QAEventsDAO;
 import org.dspace.services.ConfigurationService;
+import org.dspace.uclouvain.itemEnhancer.UCLouvainItemEnhancerService;
 import org.dspace.versioning.Version;
 import org.dspace.versioning.VersionHistory;
 import org.dspace.versioning.service.VersionHistoryService;
@@ -209,6 +210,9 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
 
     @Autowired
     private QAEventsDAO qaEventsDao;
+
+    @Autowired(required = true)
+    private UCLouvainItemEnhancerService uclouvainItemEnhancerService;
 
     protected ItemServiceImpl() {
     }
@@ -1017,6 +1021,9 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         if (configurationService.getBooleanProperty("item-deletion.authority-cleanup.enabled", false)) {
             removeAuthorityReferences(context, item);
         }
+
+        // Clear any enhancement scheduled for this item.
+        clearItemEnhancers(context, item);
 
         // Finally remove item row
         itemDAO.delete(context, item);
@@ -2340,4 +2347,14 @@ prevent the generation of resource policy entry values with null dspace_object a
         return this.itemDAO.exists(context, Item.class, id);
     }
 
+    /**
+     * Cancel the scheduled enhancement for a specific item.
+     * It basically deletes all the planned enhancement where an item is present as either a target or a source.
+     *
+     * @param context The current DSpace context.
+     * @param item The item to clear the enhancement for.
+     */
+    private void clearItemEnhancers(Context context, Item item) {
+        uclouvainItemEnhancerService.cleanForItem(context, item.getID());
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/uclouvain/factories/UCLouvainServiceFactory.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/factories/UCLouvainServiceFactory.java
@@ -8,6 +8,7 @@
 package org.dspace.uclouvain.factories;
 
 import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.uclouvain.itemEnhancer.UCLouvainItemEnhancerService;
 import org.dspace.uclouvain.services.UCLouvainEntityService;
 import org.dspace.uclouvain.services.UCLouvainResourcePolicyService;
 
@@ -21,6 +22,7 @@ public abstract  class UCLouvainServiceFactory {
 
     public abstract UCLouvainResourcePolicyService getResourcePolicyService();
     public abstract UCLouvainEntityService getEntityService();
+    public abstract UCLouvainItemEnhancerService getItemEnhancerService();
 
     public static UCLouvainServiceFactory getInstance() {
         return DSpaceServicesFactory

--- a/dspace-api/src/main/java/org/dspace/uclouvain/factories/UCLouvainServiceFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/factories/UCLouvainServiceFactoryImpl.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.uclouvain.factories;
 
+import org.dspace.uclouvain.itemEnhancer.UCLouvainItemEnhancerService;
 import org.dspace.uclouvain.services.UCLouvainEntityService;
 import org.dspace.uclouvain.services.UCLouvainResourcePolicyService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,6 +23,8 @@ public class UCLouvainServiceFactoryImpl extends UCLouvainServiceFactory {
     private UCLouvainResourcePolicyService uclouvainResourcePolicyService;
     @Autowired(required = true)
     private UCLouvainEntityService uclouvainEntityService;
+    @Autowired(required = true)
+    private UCLouvainItemEnhancerService uclouvainItemEnhancerService;
 
     @Override
     public UCLouvainResourcePolicyService getResourcePolicyService() {
@@ -31,5 +34,8 @@ public class UCLouvainServiceFactoryImpl extends UCLouvainServiceFactory {
     public UCLouvainEntityService getEntityService() {
         return uclouvainEntityService;
     }
-
+    @Override
+    public UCLouvainItemEnhancerService getItemEnhancerService() {
+        return uclouvainItemEnhancerService;
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/uclouvain/itemEnhancer/UCLouvainItemEnhancerService.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/itemEnhancer/UCLouvainItemEnhancerService.java
@@ -1,0 +1,25 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.itemEnhancer;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.dspace.content.Item;
+import org.dspace.core.Context;
+import org.dspace.uclouvain.itemEnhancer.enhancers.ItemEnhancerConfiguration;
+import org.dspace.uclouvain.itemEnhancer.model.ItemToEnhance;
+
+public interface UCLouvainItemEnhancerService {
+    public List<ItemEnhancerConfiguration> getValidConfigurationsForItem(Item item);
+    public void addRelatedItemsForEnhancement(
+        Context context, Item item, List<ItemEnhancerConfiguration> validConfigurations
+    );
+    public List<ItemToEnhance> retrieveAllItemsToUpdate(Context context);
+    public Integer cleanForItem(Context context, UUID uuid);
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/itemEnhancer/UCLouvainItemEnhancerServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/itemEnhancer/UCLouvainItemEnhancerServiceImpl.java
@@ -1,0 +1,247 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.itemEnhancer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.content.Item;
+import org.dspace.content.MetadataField;
+import org.dspace.content.MetadataFieldName;
+import org.dspace.content.service.ItemService;
+import org.dspace.content.service.MetadataFieldService;
+import org.dspace.core.Context;
+import org.dspace.uclouvain.itemEnhancer.dao.UCLouvainItemEnhancerDAO;
+import org.dspace.uclouvain.itemEnhancer.enhancers.ItemEnhancerConfiguration;
+import org.dspace.uclouvain.itemEnhancer.model.ItemToEnhance;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Service to handle the custom enhancement system.
+ * This class holds the configuration for the feature, describing which item must be enhanced
+ * and under which conditions.
+ * 
+ * @author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+public class UCLouvainItemEnhancerServiceImpl implements UCLouvainItemEnhancerService {
+
+    // The full list of metadata enhancers configuration. See 'uclouvain-metadata-enhancers.xml' for full config.
+    private List<ItemEnhancerConfiguration> enhancers = new ArrayList<ItemEnhancerConfiguration>();
+    private Logger logger = LogManager.getLogger(UCLouvainItemEnhancerServiceImpl.class);
+
+    @Autowired
+    private ItemService itemService;
+
+    @Autowired
+    private MetadataFieldService metadataFieldService;
+
+    @Autowired
+    private UCLouvainItemEnhancerDAO uclouvainItemEnhancerDAO;
+
+    /**
+     * Get all the applicable configurations for a specific source item.
+     * If the source item has the same entity type as the config and holds a value for at least one
+     * of the configured metadata fields, then it is applicable.
+     * Returns an empty list if no configuration is matching.
+     * 
+     * @param item The source item to use in order to find applicable configurations.
+     * @return A list of applicable configurations, which could be empty if none found.
+     */
+    public List<ItemEnhancerConfiguration> getValidConfigurationsForItem(Item item) {
+        // First get entity type of the item.
+        String itemEntityType = itemService.getEntityType(item);
+        List<ItemEnhancerConfiguration> validConfigurations = new ArrayList<ItemEnhancerConfiguration>();
+        if (itemEntityType == null) {
+            logger.warn(
+                "Cannot get valid configuration for item " + item.getID() + " because the EntityType cannot be found."
+            );
+            return validConfigurations;
+        }
+
+        // Loop over all the configurations and find valid ones using the item entity type.
+        enhancers
+            .stream()
+            .filter(enhancer -> enhancer.getSourceEntityType().equals(itemEntityType))
+            .forEach(enhancer -> {
+                for (String mdField: enhancer.getSourceMetadataFields()) {
+                    if (itemService.getMetadata(item, mdField, Item.ANY) != null) {
+                        // If at least one of the configured source metadata field is present in the item,
+                        // add it to valid config.
+                        validConfigurations.add(enhancer);
+                        break;
+                    }
+                }
+            });
+        logger.debug("Recovered list of config for item " + item.getID() + ": " + validConfigurations);
+        return validConfigurations;
+    }
+
+    /**
+     * Given a list of applicable configurations and a source item, this method will add an entry
+     * into the database for each related target item.
+     * Target items are found by searching for items holding the corresponding authority on the
+     * configured metadata fields.
+     * 
+     * A target item is considered valid if its metadata is different from the source it is coming from.
+     * If a target item is valid, it is added in the database table 'uclouvain_item_authority_metadata_enhancement'
+     * to be processed later by a 'poller'.
+     * 
+     * @param context The current DSpace context.
+     * @param sourceItem The source item to get the correct value from.
+     * @param validConfigurations A list of all the valid configuration used to search for valid target item.
+     */
+    public void addRelatedItemsForEnhancement(
+        Context context, Item sourceItem, List<ItemEnhancerConfiguration> validConfigurations
+    ) {
+        UUID sourceUUID = sourceItem.getID();
+        logger.debug("Found valid item to process: " + sourceItem.getID());
+
+        for (ItemEnhancerConfiguration config : validConfigurations) {
+            try {
+                for (String mdField: config.getTargetMetadataFields()) {
+                    // !! Warning: Retrieving each time the metadata field could be damaging for
+                    // !! performance. It triggers a database call.
+                    MetadataField field = metadataFieldService.findByString(context, mdField, '.');
+                    // If field is unknown, skip it.
+                    if (field == null) {
+                        logger.warn("Could not find valid MetadataField object for configured field '" + mdField + "'");
+                        continue;
+                    }
+
+                    // Find all linked items that have a metadata with the right authority.
+                    logger.debug("Searching target item for source item " + sourceUUID);
+                    List<Item> linkedItems =
+                        uclouvainItemEnhancerDAO.getAuthorityLinkedItem(context, field, sourceUUID.toString());
+                    for (Item linkedItem: linkedItems) {
+                        if (isTargetItemValid(context, linkedItem, sourceItem, config, mdField)) {
+                            // Let's use the DAO to add entry to the database
+                            logger.info("Found valid linked target item: "
+                                + linkedItem.getID() + ", inserting in DB...");
+                            uclouvainItemEnhancerDAO.addOrUpdateItemToUpdate(
+                                context, sourceUUID, linkedItem.getID()
+                            );
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                logger.error("An error occurred while posting related target item to the database.", e);
+            }
+        }
+    }
+
+    /**
+     * Check if a target item should be added to the queue by checking its validity
+     * and the state of its metadata values.
+     * 
+     * @param context The current DSpace context.
+     * @param targetItem The target item to check the validity of.
+     * @param sourceItem The source item which is holding the source value.
+     * @param config The current enhancement configuration we are processing.
+     * @param targetField The current field for which we want to check the value.
+     * @return True if the target item has the right entityType and has an outdated value for a field. False otherwise.
+     */
+    private boolean isTargetItemValid(
+        Context context, Item targetItem, Item sourceItem, ItemEnhancerConfiguration config, String targetField
+    ) {
+        String targetEntityType = itemService.getEntityType(targetItem);
+        if (!config.getTargetEntityType().equals(targetEntityType)) {
+            logger.debug(
+                "Wrong entityType for target item, wanted '"
+                + config.getTargetEntityType() + "' found '"
+                + targetEntityType + "'"
+            );
+            return false;
+        }
+
+        List<String> targetValues = itemService
+            .getMetadata(targetItem, targetField, sourceItem.getID().toString())
+            .stream().map(x -> x.getValue()).collect(Collectors.toList());
+        if (targetValues == null) {
+            return false;
+        }
+
+        logger.debug("TargetValues found for field " + targetField + ": " + targetValues);
+
+        // Flag to determine if the target item has different values compared to the source.
+        boolean didMetadataChange = false;
+
+        for (String sourceMdField: config.getSourceMetadataFields()) {
+            String sourceValue =
+                itemService.getMetadataFirstValue(sourceItem, new MetadataFieldName(sourceMdField), Item.ANY);
+            logger.debug("Source value to compare: " + sourceValue);
+            if (sourceValue == null) {
+                continue;
+            }
+            // Browse each value for the target metadata field.
+            // If one value does not match the source, toggle the 'isMetadataChanged' flag.
+            for (String targetValue: targetValues) {
+                logger.debug("Checking value changes, source = " + sourceValue + ", target = " + targetValue);
+                if (!targetValue.equals(sourceValue)) {
+                    didMetadataChange = true;
+                    break;
+                }
+            }
+            // If we found any valid metadata field in the source we can exit the loop.
+            break;
+        }
+        logger.debug(
+            "Metadata " + (didMetadataChange ? "changed" : "did not change")
+            + " for item " + targetItem.getID() + " with field " + targetField
+        );
+        return didMetadataChange;
+    }
+
+    /**
+     * Retrieve all the entries in the 'uclouvain_item_authority_metadata_enhancement' database table.
+     * Can return an empty list if nothing found or if an error occurred.
+     * 
+     * @param context The current DSpace context.
+     * @return A list of {@link ItemToEnhance} classes which might be empty.
+     */
+    public List<ItemToEnhance> retrieveAllItemsToUpdate(Context context) {
+        try {
+            // Call the DAO to get all entries from the database table.
+            return uclouvainItemEnhancerDAO.pollItemsToUpdate(context);
+        } catch (Exception e) {
+            logger.error(
+                "An error occurred while retrieving the ItemToEnhance entries from the database DAO.", e
+            );
+            return new ArrayList<>();
+        }
+    }
+
+    /**
+     * Clean ALL the entries related to an item.
+     * If the item uuid is referenced as a source or a target in a row of the table, the row is deleted.
+     * 
+     * @param context The current DSpace context.
+     * @param uuid The uuid of the item to delete entries for.
+     * @return An integer giving the number of rows that were deleted.
+     */
+    public Integer cleanForItem(Context context, UUID uuid) {
+        try {
+            return uclouvainItemEnhancerDAO.cleanTableEntriesForItem(context, uuid);
+        } catch (Exception e) {
+            logger.error("An error occured while cleaning entries for specific UUID: " + uuid + " exception: " + e);
+            return -1;
+        }
+    }
+
+    // GETTERS && SETTERS
+    public void setEnhancers(List<ItemEnhancerConfiguration> enhancers) {
+        this.enhancers = enhancers;
+    }
+
+    public List<ItemEnhancerConfiguration> getEnhancers() {
+        return enhancers;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/itemEnhancer/consumer/UCLouvainItemEnhancerConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/itemEnhancer/consumer/UCLouvainItemEnhancerConsumer.java
@@ -1,0 +1,109 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.itemEnhancer.consumer;
+
+import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.content.Item;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Context;
+import org.dspace.event.Consumer;
+import org.dspace.event.Event;
+import org.dspace.uclouvain.factories.UCLouvainServiceFactory;
+import org.dspace.uclouvain.itemEnhancer.UCLouvainItemEnhancerService;
+import org.dspace.uclouvain.itemEnhancer.enhancers.ItemEnhancerConfiguration;
+
+/**
+ * Main consumer for the item enhancer functionality.
+ * This consumer is triggered at events and checks the configuration to see if an item can be processed.
+ * 
+ * To avoid context status/version problems, we store all items uuid in a set in the 'consumer()' method.
+ * Then, in the 'end()' method, we retrieve each item using the itemService and check if we can process them.
+ * 
+ * @author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+public class UCLouvainItemEnhancerConsumer implements Consumer {
+
+    private Set<UUID> itemsToProcess = new HashSet<>();
+    private Logger logger = LogManager.getLogger(UCLouvainItemEnhancerConsumer.class);
+
+
+    ItemService itemService;
+
+    UCLouvainItemEnhancerService uclouvainItemEnhancerService;
+
+    /**
+     * Initialize the required services when the consumer is instantiated.
+     */
+    @Override
+    public void initialize() throws Exception {
+        itemService = ContentServiceFactory.getInstance().getItemService();
+        uclouvainItemEnhancerService = UCLouvainServiceFactory.getInstance().getItemEnhancerService();
+    }
+
+    /**
+     * For each event being catch, get the corresponding item and stores its uuid in the set.
+     * 
+     * @param context The current DSpace context.
+     * @param event The fired event that may be processed by the consumer.
+     */
+    @Override
+    public void consume(Context context, Event event) throws Exception {
+        Item item = (Item) event.getSubject(context);
+        if (item != null) {
+            // In this case, we need to store the item uuid and not the item.
+            // If we store the item, it could be an old version of the object.
+            // This old version would take the place of other newer version which is not a great idea.
+            // To solve this, we store the uuid and reload the item in the 'end()' method of the consumer.
+            itemsToProcess.add(item.getID());
+        }
+    }
+
+    /**
+     * Loop over the 'itemsToProcess', check for each item if it can be processed using the service.
+     * If an item can be processed, then we need to trigger a post in the table using the service.
+     * 
+     * @param context The current context.
+     * @throws Exception
+     */
+    @Override
+    public void end(Context context) throws Exception {
+        context.turnOffAuthorisationSystem();
+        // Loop over each uuid and retrieve the corresponding item.
+        for (UUID uuid: itemsToProcess) {
+            try {
+                Item item = itemService.find(context, uuid);
+                if (item == null) {
+                    logger.warn("Could not retrieve item from previously stored uuid: " + uuid);
+                    continue;
+                }
+                // Get valid configurations for the item.
+                List<ItemEnhancerConfiguration> validConfigs =
+                    uclouvainItemEnhancerService.getValidConfigurationsForItem(item);
+                if (validConfigs != null && !validConfigs.isEmpty()) {
+                    uclouvainItemEnhancerService.addRelatedItemsForEnhancement(context, item, validConfigs);
+                }
+            } catch (SQLException e) {
+                logger.warn("An error occurred while retrieving an item via uuid in the consumer", e);
+            }
+        }
+        context.restoreAuthSystemState();
+        // Clear the set for futur use.
+        itemsToProcess.clear();
+    }
+
+    @Override
+    public void finish(Context ctx) throws Exception {}
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/itemEnhancer/dao/UCLouvainItemEnhancerDAO.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/itemEnhancer/dao/UCLouvainItemEnhancerDAO.java
@@ -1,0 +1,25 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.itemEnhancer.dao;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.dspace.content.Item;
+import org.dspace.content.MetadataField;
+import org.dspace.core.Context;
+import org.dspace.uclouvain.itemEnhancer.model.ItemToEnhance;
+
+public interface UCLouvainItemEnhancerDAO {
+    public void addOrUpdateItemToUpdate(Context context, UUID sourceUUID, UUID targetUUID) throws Exception;
+    public List<ItemToEnhance> pollItemsToUpdate(Context context) throws Exception;
+    public Integer cleanTableEntriesForItem(Context context, UUID uuid) throws Exception;
+    public List<Item> getAuthorityLinkedItem(
+        Context context, MetadataField metadataField, String authority
+    ) throws Exception;
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/itemEnhancer/dao/UCLouvainItemEnhancerDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/itemEnhancer/dao/UCLouvainItemEnhancerDAOImpl.java
@@ -1,0 +1,172 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.itemEnhancer.dao;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.content.Item;
+import org.dspace.content.MetadataField;
+import org.dspace.core.AbstractHibernateDAO;
+import org.dspace.core.Context;
+import org.dspace.core.DBConnection;
+import org.dspace.services.ConfigurationService;
+import org.dspace.uclouvain.itemEnhancer.model.ItemToEnhance;
+import org.dspace.utils.DSpace;
+import org.hibernate.Session;
+import org.hibernate.query.NativeQuery;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * DAO to interact with 'uclouvain_item_authority_metadata_enhancement' table.
+ * This table is used as a queue for items that need to be updated using the
+ * custom enhancement system.
+ * The table contains 3 columns:
+ * - The source_uuid, which is the item holding the proper metadata value.
+ * - The target_uuid, which is the item to update the metadata of.
+ * - The date_queued, which is giving a hint about the queue date.
+ * 
+ * @author: Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+public class UCLouvainItemEnhancerDAOImpl extends AbstractHibernateDAO<ItemToEnhance>
+    implements UCLouvainItemEnhancerDAO {
+    private Logger logger = LogManager.getLogger(UCLouvainItemEnhancerDAOImpl.class);
+
+    @Autowired
+    ConfigurationService configurationService;
+
+    /**
+     * Try to add a new entry to the database using a uuid pair (source + target).
+     * If the pair is already present in the table, update its 'date_queued'.
+     * 
+     * @param context    The current DSpace context.
+     * @param sourceUUID The UUID of the source item.
+     * @param targetUUID The UUID of the target item.
+     */
+    @Override
+    public void addOrUpdateItemToUpdate(Context context, UUID sourceUUID, UUID targetUUID) throws Exception {
+        logger.debug("About to query the database to add an item for update (enhancement)");
+        Session session = getHibernateSession();
+        String sqlInsertOrUpdate;
+        if ("org.h2.Driver".equals(configurationService.getProperty("db.driver"))) {
+            // H2 doesn't support the INSERT OR UPDATE statement so let's use MERGE statement.
+            // Update queued date for records already in the queue.
+            sqlInsertOrUpdate = "MERGE INTO uclouvain_item_authority_metadata_enhancement as me"
+                    + " KEY (source_uuid, target_uuid)"
+                    + " VALUES (:source_uuid, :target_uuid, CURRENT_TIMESTAMP)";
+        } else {
+            sqlInsertOrUpdate =
+                "INSERT INTO uclouvain_item_authority_metadata_enhancement (source_uuid, target_uuid, date_queued)"
+                    + " VALUES (:source_uuid, :target_uuid, CURRENT_TIMESTAMP)"
+                    + " ON CONFLICT (source_uuid, target_uuid) DO UPDATE"
+                    + " SET date_queued = EXCLUDED.date_queued";
+        }
+        logger.info(
+                "Adding an item to update to the database: source = " + sourceUUID + " target = " + targetUUID);
+        NativeQuery<?> queryInsertOrUpdate = session.createNativeQuery(sqlInsertOrUpdate);
+        // Fill the query parameters
+        queryInsertOrUpdate.setParameter("source_uuid", sourceUUID);
+        queryInsertOrUpdate.setParameter("target_uuid", targetUUID);
+        queryInsertOrUpdate.executeUpdate();
+    }
+
+    /**
+     * Retrieve all the entries from the table.
+     * Those are converted in 'ItemToEnhance' objects to be used in the code.
+     * Can return an empty list if no entries are found.
+     * 
+     * @param context The current DSpace context.
+     * @return A list of 'ItemToEnhance' objects which can be empty.
+     */
+    @Override
+    public List<ItemToEnhance> pollItemsToUpdate(Context context) throws Exception {
+        Session session = getHibernateSession();
+        String sql = "SELECT source_uuid, target_uuid, date_queued"
+                + " FROM uclouvain_item_authority_metadata_enhancement"
+                + " ORDER BY date_queued ASC";
+        NativeQuery<ItemToEnhance> query = session.createNativeQuery(sql, ItemToEnhance.class);
+        return query.getResultList();
+    }
+
+    /**
+     * Delete all the entries in the table that are related to the given item uuid.
+     * 
+     * @param context The current DSpace context.
+     * @param uuid The uuid of the item.
+     * 
+     * @return An integer to indicate the number of deleted entries.
+     */
+    @Override
+    public Integer cleanTableEntriesForItem(Context context, UUID uuid) throws Exception {
+        Session session = getHibernateSession();
+        String sql = "DELETE FROM uclouvain_item_authority_metadata_enhancement"
+             + " WHERE source_uuid = :source_uuid OR target_uuid = :target_uuid";
+        NativeQuery<?> query = session.createNativeQuery(sql);
+        query.setParameter("source_uuid", uuid.toString());
+        query.setParameter("target_uuid", uuid.toString());
+        return query.executeUpdate();
+    }
+
+    /**
+     * Retrieves all the items that are linked to a source item.
+     * To find those item, we browse all the available metadata values to find one those who have an authority
+     * valid equal to the uuid of a source item.
+     * The result list is parse into a lis of Item to have an easier access.
+     * 
+     * @param context The current DSpace context.
+     * @param metadataField The metadata field to search for.
+     * @param authority The authority we are searching for.
+     * @return A list of all related items which have at least one metadata referencing the source item.
+     */
+    @Override
+    public List<Item> getAuthorityLinkedItem(
+        Context context, MetadataField metadataField, String authority
+    ) throws Exception {
+        Session session = getHibernateSession();
+        String sql = "SELECT result_item.*"
+            + " FROM"
+            + " (SELECT mv.dspace_object_id"
+                + " FROM metadatavalue as mv"
+                + " JOIN metadatafieldregistry as mf on mv.metadata_field_id = mf.metadata_field_id"
+                + " JOIN metadataschemaregistry as ms on mf.metadata_schema_id = ms.metadata_schema_id"
+                + " WHERE ms.short_id = :schema and mf.element = :element"
+                + (
+                    metadataField.getQualifier() != null
+                        ? (" and mf.qualifier = '" + metadataField.getQualifier().toString() + "'")
+                        : ""
+                )
+                + " and mv.authority = :authority"
+                + " GROUP BY mv.dspace_object_id) as result_uuids,"
+            + " (SELECT * FROM item) as result_item"
+            + " WHERE result_uuids.dspace_object_id = result_item.uuid";
+
+        NativeQuery<Item> query = session.createNativeQuery(sql, Item.class);
+        query.setParameter("schema", metadataField.getMetadataSchema().getName());
+        query.setParameter("element", metadataField.getElement());
+        query.setParameter("authority", authority);
+
+        return query.getResultList();
+    }
+
+
+    /**
+     * Returns the Hibernate Session currently opened.
+     *
+     * @return The current Session.
+     * @throws SQLException
+     */
+    private Session getHibernateSession() throws SQLException {
+        @SuppressWarnings("rawtypes")
+        DBConnection dbConnection = new DSpace().getServiceManager().getServiceByName(null, DBConnection.class);
+        return ((Session) dbConnection.getSession());
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/itemEnhancer/enhancers/ItemEnhancerConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/itemEnhancer/enhancers/ItemEnhancerConfiguration.java
@@ -1,0 +1,79 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.itemEnhancer.enhancers;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import org.dspace.content.service.MetadataFieldService;
+import org.dspace.core.Context;
+import org.dspace.uclouvain.itemEnhancer.UCLouvainItemEnhancerService;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Configuration used by the metadata enhancer service {@link UCLouvainItemEnhancerService}.
+ * 
+ * @author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+public class ItemEnhancerConfiguration {
+    private String sourceEntityType;
+    private List<String> sourceMetadataFields;
+    private String targetEntityType;
+    private List<String> targetMetadataFields;
+
+    @Autowired
+    MetadataFieldService metadataFieldService;
+
+    // GETTERS && SETTERS
+
+    public void setSourceEntityType(String type) {
+        sourceEntityType = type;
+    }
+
+    public String getSourceEntityType() {
+        return sourceEntityType;
+    }
+
+    public void setSourceMetadataFields(List<String> fields) throws SQLException {
+        validateMetadataFields(fields);
+        sourceMetadataFields = fields;
+    }
+
+    public List<String> getSourceMetadataFields() {
+        return sourceMetadataFields;
+    }
+
+    public void setTargetEntityType(String type) {
+        targetEntityType = type;
+    }
+
+    public String getTargetEntityType() {
+        return targetEntityType;
+    }
+
+    public void setTargetMetadataFields(List<String> fields) throws SQLException {
+        validateMetadataFields(fields);
+        targetMetadataFields = fields;
+    }
+
+    public List<String> getTargetMetadataFields() {
+        return targetMetadataFields;
+    }
+
+    private void validateMetadataFields(List<String> fields) throws SQLException {
+        Context context = new Context();
+        for (String field: fields) {
+            if (metadataFieldService.findByString(context, field, '.') == null) {
+                throw new RuntimeException(
+                    "Could not find metadata field '" + field + "' in the metadata registry, check if it exists."
+                );
+            }
+        }
+        context.complete();
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/itemEnhancer/model/ItemToEnhance.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/itemEnhancer/model/ItemToEnhance.java
@@ -1,0 +1,78 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.itemEnhancer.model;
+
+import java.io.Serializable;
+import java.util.Date;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+import org.dspace.content.Item;
+
+/**
+ * Representation of an update request stored in the 'uclouvain_item_authority_metadata_enhancement' table.
+ * 
+ * @author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+@Entity
+@Table(name = "uclouvain_item_authority_metadata_enhancement")
+public class ItemToEnhance implements Serializable {
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "source_uuid",
+        insertable = true, updatable = false, nullable = false, referencedColumnName = "uuid"
+    )
+    private Item sourceItem;
+
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "target_uuid",
+        insertable = true, updatable = false, nullable = false, referencedColumnName = "uuid"
+    )
+    private Item targetItem;
+
+    @Column(name = "date_queued", insertable = true, updatable = true)
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date dateQueued = new Date();
+
+    public boolean equals(ItemToEnhance ite) {
+        return sourceItem == ite.getSourceItem() && targetItem == ite.getTargetItem();
+    }
+
+    // GETTERS && SETTERS
+    public Item getSourceItem() {
+        return sourceItem;
+    }
+
+    public void setSourceItem(Item source_uuid) {
+        this.sourceItem = source_uuid;
+    }
+
+    public Item getTargetItem() {
+        return targetItem;
+    }
+
+    public void setTargetItem(Item targetItem) {
+        this.targetItem = targetItem;
+    }
+
+    public Date getDateQueued() {
+        return dateQueued;
+    }
+
+    public void setDateQueued(Date dateQueued) {
+        this.dateQueued = dateQueued;
+    }
+}

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V7.6_2024.10.24__create_table_items_metadata_enhancement.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V7.6_2024.10.24__create_table_items_metadata_enhancement.sql
@@ -1,0 +1,21 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+-- This table is used to store queued enhancement for items. This is part of the authority based metadata enhancement system.
+--
+-- @Author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+CREATE TABLE uclouvain_item_authority_metadata_enhancement
+(
+	source_uuid UUID NOT NULL,
+	target_uuid UUID NOT NULL,
+	date_queued TIMESTAMP NOT NULL,
+	CONSTRAINT item_enhancement_source_fkey FOREIGN KEY (source_uuid) REFERENCES item (uuid),
+	CONSTRAINT item_enhancement_target_fkey FOREIGN KEY (target_uuid) REFERENCES item (uuid),
+	CONSTRAINT unique_enhancement UNIQUE(source_uuid, target_uuid)
+);
+CREATE INDEX idx_enhancement_date_queued ON uclouvain_item_authority_metadata_enhancement(date_queued);

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.6_2024.10.24__create_table_items_metadata_enhancement.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.6_2024.10.24__create_table_items_metadata_enhancement.sql
@@ -1,0 +1,21 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+-- This table is used to store queued enhancement for items. This is part of the authority based metadata enhancement system.
+--
+-- @Author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+CREATE TABLE uclouvain_item_authority_metadata_enhancement
+(
+	source_uuid UUID NOT NULL,
+	target_uuid UUID NOT NULL,
+	date_queued TIMESTAMP NOT NULL,
+	CONSTRAINT item_enhancement_source_fkey FOREIGN KEY (source_uuid) REFERENCES item (uuid),
+	CONSTRAINT item_enhancement_target_fkey FOREIGN KEY (target_uuid) REFERENCES item (uuid),
+	CONSTRAINT unique_enhancement UNIQUE(source_uuid, target_uuid)
+);
+CREATE INDEX idx_enhancement_date_queued ON uclouvain_item_authority_metadata_enhancement(date_queued);

--- a/dspace-api/src/test/data/dspaceFolder/config/spring/uclouvain/uclouvain-metadata-enhancers.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/spring/uclouvain/uclouvain-metadata-enhancers.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                  http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+                  http://www.springframework.org/schema/context
+                  http://www.springframework.org/schema/context/spring-context-2.5.xsd
+                  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd"
+       xmlns:util="http://www.springframework.org/schema/util">
+    <context:annotation-config /> <!-- allows us to use spring annotations in beans -->
+    
+    <!-- Authority Based Metadata enhancers -->
+    <!-- 
+        This functionality is used to update configured metadata to be in sync with a source.
+        The source is another item that holds the correct value for the metadata.
+        For example, an author has a name (the source) and this can be also stored in a publication (the target).
+        So the source is the item that olds the right data value and the target the item to update accordingly.
+         
+        @Author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+    -->
+    <bean name="uclouvainItemEnhancerDAO" class="org.dspace.uclouvain.itemEnhancer.dao.UCLouvainItemEnhancerDAOImpl"/>
+    <bean name="uclouvainItemEnhancerService" class="org.dspace.uclouvain.itemEnhancer.UCLouvainItemEnhancerServiceImpl">
+        <property name="enhancers">
+            <util:list>
+                <ref bean="publicationAuthorEnhancer"/>
+                <ref bean="publicationAffiliationEnhancer"/>
+            </util:list>
+        </property>
+    </bean>
+
+    <!-- Enhancers configuration -->
+    <bean name="publicationAuthorEnhancer" class="org.dspace.uclouvain.itemEnhancer.enhancers.ItemEnhancerConfiguration">
+        <property name="sourceEntityType" value="Person"/>
+        <property name="sourceMetadataFields">
+            <util:list>
+                <value>dc.title</value>
+                <!-- Not really realistic, but just for test so OK -->
+                <value>person.givenName</value>
+            </util:list>
+        </property>
+        <property name="targetEntityType" value="Publication"/>
+        <property name="targetMetadataFields">
+            <util:list>
+                <value>dc.contributor.author</value>
+            </util:list>
+        </property>
+    </bean>
+    <bean name="publicationAffiliationEnhancer" class="org.dspace.uclouvain.itemEnhancer.enhancers.ItemEnhancerConfiguration">
+        <property name="sourceEntityType" value="Person"/>
+        <property name="sourceMetadataFields">
+            <util:list>
+                <value>person.affiliation.name</value>
+            </util:list>
+        </property>
+        <property name="targetEntityType" value="Publication"/>
+        <property name="targetMetadataFields">
+            <util:list>
+                <value>oairecerif.author.affiliation</value>
+            </util:list>
+        </property>
+    </bean>
+</beans>

--- a/dspace-api/src/test/java/org/dspace/uclouvain/itemEnhancer/UCLouvainItemEnhancerTest.java
+++ b/dspace-api/src/test/java/org/dspace/uclouvain/itemEnhancer/UCLouvainItemEnhancerTest.java
@@ -1,0 +1,603 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.itemEnhancer;
+
+import static org.dspace.app.matcher.MetadataValueMatcher.with;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import org.dspace.AbstractIntegrationTestWithDatabase;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.content.Collection;
+import org.dspace.content.Item;
+import org.dspace.content.authority.Choices;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.ItemService;
+import org.dspace.event.factory.EventServiceFactory;
+import org.dspace.event.service.EventService;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.uclouvain.factories.UCLouvainServiceFactory;
+import org.dspace.uclouvain.itemEnhancer.consumer.UCLouvainItemEnhancerConsumer;
+import org.dspace.uclouvain.itemEnhancer.model.ItemToEnhance;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Series of test for the authority based metadata enhancement functionality.
+ * This functionality is configured in the 'uclouvain-metadata-enhancers.xml' configuration file.
+ * 
+ * It is composed of a consumer ({@link UCLouvainItemEnhancerConsumer}) that consume events when an item is modified and
+ * adds an entry a enhancer queue if necessary.
+ * 
+ * A service ({@link UCLouvainItemEnhancerService}) holds the logic to execute the main operations of the feature.
+ * 
+ * The DAO ({@link UCLouvainItemEnhancerDAO}) interacts with the database to create, update, read and delete entries.
+ * 
+ * @author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+public class UCLouvainItemEnhancerTest extends AbstractIntegrationTestWithDatabase {
+    private ItemService itemService;
+
+    private UCLouvainItemEnhancerService uclouvainItemEnhancerService;
+
+    private Collection collection;
+
+    private static String[] consumers;
+
+    private static final ConfigurationService configurationService =
+        DSpaceServicesFactory.getInstance().getConfigurationService();
+
+    private static final EventService eventService = EventServiceFactory.getInstance().getEventService();
+
+    @BeforeClass
+    public static void initConsumers() {
+        consumers = configurationService.getArrayProperty("event.dispatcher.default.consumers");
+        Set<String> consumersSet = new HashSet<String>(Arrays.asList(consumers));
+        if (!consumersSet.contains("authoritymetadataenhancer")) {
+            consumersSet.add("authoritymetadataenhancer");
+            configurationService.setProperty("event.dispatcher.default.consumers", consumersSet.toArray());
+            eventService.reloadConfiguration();
+        }
+    }
+
+    // Code ran before test execution.
+    @Before
+    public void setup() {
+        itemService = ContentServiceFactory.getInstance().getItemService();
+        uclouvainItemEnhancerService = UCLouvainServiceFactory.getInstance().getItemEnhancerService();
+
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+
+        collection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Global")
+            .build();
+        context.restoreAuthSystemState();
+    }
+
+    /**
+     * Test a simple case where we have no metadata enhancement at all.
+     * We create a publication and a person which are not linked by any metadata authority at all.
+     * 
+     * If we update the name of the person it should not add any entry to the database.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testConsumerWithNoEnhancement() throws Exception {
+        //  1. Create a publication and a person with no link.
+        context.turnOffAuthorisationSystem();
+        Item person = ItemBuilder.createItem(context, collection)
+            .withEntityType("Person")
+            .withTitle("Pierre Kiroul")
+            .build();
+
+        Item publication = ItemBuilder.createItem(context, collection)
+            .withTitle("Test publication0")
+            .withEntityType("Publication")
+            .build();
+
+        context.restoreAuthSystemState();
+
+        context.commit();
+        person = context.reloadEntity(person);
+
+        // 2. Update the source metadata.
+        context.turnOffAuthorisationSystem();
+        itemService.setMetadataSingleValue(context, person, "dc", "title", null, null, "Jya Rivpa");
+        itemService.update(context, person);
+
+        context.restoreAuthSystemState();
+
+        context.commit();
+        person = context.reloadEntity(person);
+        publication = context.reloadEntity(publication);
+
+        // The name of the person should have changed.
+        assertThat(person.getMetadata(), hasItem(with("dc.title", "Jya Rivpa")));
+
+        // There should be no entry at all in the enhancement table.
+        List<ItemToEnhance> itemToEnhanceEntries = uclouvainItemEnhancerService.retrieveAllItemsToUpdate(context);
+        assertThat(itemToEnhanceEntries, hasSize(0));
+    }
+
+    /**
+     * Create a simple relation between a person and a publication where the person is an author of the publication.
+     * We modify a field that is not configured as a source field ('person.identifier.orcid').
+     * After we modified the field nothing should be added to the table since the modified source
+     * field is not in the config.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testConsumerWithUntrackedField() throws Exception {
+        // Create a basic relation with a person and a publication.
+        // The person is the author of the publication.
+        context.turnOffAuthorisationSystem();
+        Item person = ItemBuilder.createItem(context, collection)
+            .withEntityType("Person")
+            .withTitle("Pierre Kiroul")
+            .build();
+
+        Item publication = ItemBuilder.createItem(context, collection)
+            .withTitle("Test publication0")
+            .withEntityType("Publication")
+            .withAuthor("Pierre Kiroul", person.getID().toString())
+            .build();
+
+        context.restoreAuthSystemState();
+
+        context.commit();
+        person = context.reloadEntity(person);
+        publication = context.reloadEntity(publication);
+
+        // Update an untracked field for the person item.
+        context.turnOffAuthorisationSystem();
+        itemService.addMetadata(context, person, "person", "identifier", "orcid", null, "0000-1111-2222-3333");
+        itemService.update(context, person);
+        context.restoreAuthSystemState();
+
+        // Commit and save the changes.
+        context.commit();
+        context.reloadEntity(person);
+
+        // Check that the database table is still empty.
+        List<ItemToEnhance> itemToEnhanceEntries = uclouvainItemEnhancerService.retrieveAllItemsToUpdate(context);
+        assertThat(itemToEnhanceEntries, hasSize(0));
+    }
+
+    /**
+     * Create a simple author-publication relation and modify one entity type.
+     * Test that if we modify the entity type of one of the items to something that is not handled by
+     * the configuration, nothing is added to the database.
+     * Since the consumer checks the entity type of the source and the target item before adding an
+     * entry to the database, it should not add anything for enhancement.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testConsumerSimplePublicationAuthorRelationWithChangedEntityType() throws Exception {
+        // Create a basic relation with a person and a publication.
+        // The person is the author of the publication.
+        context.turnOffAuthorisationSystem();
+        Item person = ItemBuilder.createItem(context, collection)
+            .withEntityType("Person")
+            .withTitle("Pierre Kiroul")
+            .build();
+
+        Item publication = ItemBuilder.createItem(context, collection)
+            .withTitle("Test publication0")
+            .withEntityType("Publication")
+            .withAuthor("Pierre Kiroul", person.getID().toString())
+            .build();
+
+        context.restoreAuthSystemState();
+
+        context.commit();
+        person = context.reloadEntity(person);
+        publication = context.reloadEntity(publication);
+
+        // Change the entity type of the publication to 'Patent'.
+        context.turnOffAuthorisationSystem();
+        itemService.setMetadataSingleValue(context, publication, "dspace", "entity", "type", null, "Patent");
+        itemService.update(context, publication);
+
+        // Then change a metadata that is present in the configuration.
+        itemService.setMetadataSingleValue(context, person, "dc", "title", null, null, "Jya Rivpa");
+        itemService.update(context, person);
+        context.restoreAuthSystemState();
+
+        // Reload objects to be sure that they are up to date.
+        context.commit();
+        publication = context.reloadEntity(publication);
+        person = context.reloadEntity(person);
+
+        // Check that the database table is still empty.
+        List<ItemToEnhance> itemToEnhanceEntries = uclouvainItemEnhancerService.retrieveAllItemsToUpdate(context);
+        assertThat(itemToEnhanceEntries, hasSize(0));
+    }
+
+    /**
+     * Test a single relation between a publication and an author.
+     * When the author title is updated, a new entry should be added to the database table.
+     * 
+     * - First we add 2 items: A publication and a person. The person object has a given name of 'Pierre Kiroul'
+     *   and the publication references this name in its field 'dc.contributor.author'.
+     * - Then we change the 'dc.title' of the person to 'Jya Rivpa'. This should trigger the consumer which will
+     *   create a new entry in the itemEnhancer table. We check that this entry exists and has the correct values.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testConsumerWithSimplePublicationAuthorRelation() throws Exception {
+        //  1. Create a publication and add authority controlled metadata to it.
+        context.turnOffAuthorisationSystem();
+        Item person = ItemBuilder.createItem(context, collection)
+            .withEntityType("Person")
+            .withTitle("Pierre Kiroul")
+            .build();
+        UUID personAuthority = person.getID();
+
+        Item publication = ItemBuilder.createItem(context, collection)
+            .withTitle("Test publication0")
+            .withEntityType("Publication")
+            .withAuthor("Pierre Kiroul", personAuthority.toString())
+            .build();
+
+        context.restoreAuthSystemState();
+
+        context.commit();
+        person = context.reloadEntity(person);
+
+        // Make sure that the enhancement table is empty before updating.
+        List<ItemToEnhance> itemToEnhanceEntries = uclouvainItemEnhancerService.retrieveAllItemsToUpdate(context);
+        assertThat(itemToEnhanceEntries, hasSize(0));
+
+        // 2. Update the source metadata.
+        context.turnOffAuthorisationSystem();
+        itemService.setMetadataSingleValue(context, person, "dc", "title", null, null, "Jya Rivpa");
+        itemService.update(context, person);
+        context.restoreAuthSystemState();
+
+        context.commit();
+        person = context.reloadEntity(person);
+        publication = context.reloadEntity(publication);
+
+        assertThat(person.getMetadata(), hasItem(with("dc.title", "Jya Rivpa")));
+
+        // Check the database entries to see if something was added.
+        itemToEnhanceEntries = uclouvainItemEnhancerService.retrieveAllItemsToUpdate(context);
+
+        // Check the entry of the database.
+        assertThat(itemToEnhanceEntries, hasSize(1));
+        assertThat(itemToEnhanceEntries.get(0), not(nullValue()));
+        assertThat(itemToEnhanceEntries.get(0).getTargetItem(), equalTo(publication));
+        assertThat(itemToEnhanceEntries.get(0).getSourceItem(), equalTo(person));
+    }
+
+    /**
+     * Create two basic relations between a person (author) and a publication:
+     * - Author affiliation (person.affiliation.name) -> Publication affiliation (oairecerif.author.affiliation)
+     * - Author name (dc.title) -> Publication author (dc.contributor.author)
+     * Here we update the last relation by changing the affiliation of the author.
+     * It should create 1 entry in the database.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testConsumerWithSimplePublicationAuthorRelationMultipleFieldConfiguration() throws Exception {
+        // Create a simple author-publication relation.
+        // The publication is linked to the author via the name and the affiliation.
+        context.turnOffAuthorisationSystem();
+        Item person = ItemBuilder.createItem(context, collection)
+            .withEntityType("Person")
+            .withTitle("Pierre Kiroul")
+            .withPersonMainAffiliation("UCL")
+            .build();
+        UUID personAuthority = person.getID();
+
+        Item publication = ItemBuilder.createItem(context, collection)
+            .withTitle("Test publication0")
+            .withEntityType("Publication")
+            .withAuthor("Pierre Kiroul", personAuthority.toString())
+            .withAuthorAffiliation("UCL", personAuthority.toString())
+            .build();
+
+        context.restoreAuthSystemState();
+
+        context.commit();
+        person = context.reloadEntity(person);
+        publication = context.reloadEntity(publication);
+
+        // Modify the affiliation of the person.
+        context.turnOffAuthorisationSystem();
+        itemService.setMetadataSingleValue(context, person, "person", "affiliation", "name", null, "UCLouvain");
+        itemService.update(context, person);
+        context.restoreAuthSystemState();
+
+        context.commit();
+        person = context.reloadEntity(person);
+        publication = context.reloadEntity(publication);
+
+        // Check that the table contains 1 entry for the modified relation.
+        List<ItemToEnhance> itemToEnhanceEntries = uclouvainItemEnhancerService.retrieveAllItemsToUpdate(context);
+        assertThat(itemToEnhanceEntries, hasSize(1));
+    }
+
+    /**
+     * Test with one relation using multiple metadata field as source.
+     * 
+     * In this test we create a relation between a person and a publication.
+     * The person is the source of data and the publication is the target (which will be updated).
+     * The relation is configured to have 2 metadata source fields: 'dc.title' and 'person.givenName'.
+     * 
+     * We need to test that if we have the two metadata for one person, the first that is found is
+     * the first that is used.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testConsumerWithSimplePublicationAuthorRelationAndMultipleSourceMetadataField() throws Exception {
+        // First we create the person and the publication.
+        context.turnOffAuthorisationSystem();
+        Item person = ItemBuilder.createItem(context, collection)
+            .withEntityType("Person")
+            .withPersonIdentifierFirstName("Pierre")
+            .build();
+        UUID personAuthority = person.getID();
+
+        Item publication = ItemBuilder.createItem(context, collection)
+            .withTitle("Test publication0")
+            .withEntityType("Publication")
+            .withAuthor("Pierre", personAuthority.toString())
+            .build();
+        context.restoreAuthSystemState();
+
+        context.commit();
+        person = context.reloadEntity(person);
+        publication = context.reloadEntity(publication);
+
+        // Modify the second valid metadata for the source item 'person'.
+        context.turnOffAuthorisationSystem();
+        itemService.setMetadataSingleValue(context, person, "person", "givenName", null, null, "Jean");
+        itemService.update(context, person);
+        context.restoreAuthSystemState();
+
+        context.commit();
+        context.reloadEntity(person);
+
+        // Check that we have one entry in the database since we modified one of configured the valid
+        // source metadata field.
+        List<ItemToEnhance> itemToEnhanceEntries = uclouvainItemEnhancerService.retrieveAllItemsToUpdate(context);
+        assertThat(itemToEnhanceEntries, hasSize(1));
+    }
+
+    /**
+     * Test that when an entry is already present in the database, it updates the date when trying to insert.
+     * 
+     * - First we add 2 items: A publication and a person. The person object has a given name of 'Pierre Kiroul'
+     *   and the publication references this name in its field 'dc.contributor.author'.
+     * - Then we change the 'dc.title' of the person to 'Jya Rivpa'. This should trigger the consumer which will
+     *   create a new entry in the itemEnhancer table. We check that this entry exists and has the correct values.
+     * - Finally, we change the 'dc.title' of the person one more time to 'Jean Gloutitou'. This should once again
+     *   trigger the consumer but this time it should just modify the 'queued_date' of the existing entry.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testConsumerWithSimplePublicationAuthorRelationDateUpdate() throws Exception {
+        //  1. Create a publication and add authority controlled metadata to it.
+        context.turnOffAuthorisationSystem();
+        Item person = ItemBuilder.createItem(context, collection)
+            .withEntityType("Person")
+            .withTitle("Pierre Kiroul")
+            .build();
+        UUID personAuthority = person.getID();
+
+        Item publication = ItemBuilder.createItem(context, collection)
+            .withTitle("Test publication0")
+            .withEntityType("Publication")
+            .withAuthor("Pierre Kiroul", personAuthority.toString())
+            .build();
+
+        context.commit();
+        publication = context.reloadEntity(publication);
+        person = context.reloadEntity(person);
+
+        // 2. Update the source metadata.
+        itemService.setMetadataSingleValue(context, person, "dc", "title", null, null, "Jya Rivpa");
+        itemService.update(context, person);
+        context.restoreAuthSystemState();
+
+        context.commit();
+        person = context.reloadEntity(person);
+
+        assertThat(person.getMetadata(), hasItem(with("dc.title", "Jya Rivpa")));
+
+        // Check the database entries to see if something was added.
+        List<ItemToEnhance> itemToEnhanceEntries = uclouvainItemEnhancerService.retrieveAllItemsToUpdate(context);
+        assertThat(itemToEnhanceEntries, hasSize(1));
+        assertThat(itemToEnhanceEntries.get(0), not(nullValue()));
+        assertThat(itemToEnhanceEntries.get(0).getDateQueued(), not(nullValue()));
+
+        Date firstDate = itemToEnhanceEntries.get(0).getDateQueued();
+
+        // Update the authors name a second time, the entry date should be changed.
+        context.turnOffAuthorisationSystem();
+        itemService.setMetadataSingleValue(context, person, "dc", "title", null, null, "Jean Gloutitou");
+        itemService.update(context, person);
+        context.restoreAuthSystemState();
+
+        context.commit();
+        person = context.reloadEntity(person);
+        publication = context.reloadEntity(publication);
+
+        assertThat(person.getMetadata(), hasItem(with("dc.title", "Jean Gloutitou")));
+
+        // Check the updated version of the entry.
+        itemToEnhanceEntries = uclouvainItemEnhancerService.retrieveAllItemsToUpdate(context);
+        assertThat(itemToEnhanceEntries, hasSize(1));
+        assertThat(itemToEnhanceEntries.get(0), not(nullValue()));
+        assertThat(itemToEnhanceEntries.get(0).getDateQueued(), not(nullValue()));
+
+        // Check that the updated date is newer.
+        assertThat(itemToEnhanceEntries.get(0).getDateQueued(), greaterThan(firstDate));
+    }
+
+    /**
+     * Test the enhancement on multiple items.
+     * In this scenario, we create 4 different items:
+     * - 2 Authors both referenced in 2 publication.
+     *
+     * Both publication are linked to the persons by 2 metadata 'dc.contributor.author' and 'authors.email'.
+     * When we update authors, it should create entries in the database for each Publication-Author relation.
+     * So in this case 4 relations - 4 entries.
+     * 
+     *  person(title && affiliation) -> publication(author && affiliation)
+     *  person(title && affiliation) -> publication2(author && affiliation)
+     *  person2(title && affiliation) -> publication(author && affiliation)
+     *  person2(title && affiliation) -> publication2(author && affiliation)
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testConsumerMultipleConfigurationsAndMultipleEnhancement() throws Exception {
+        context.turnOffAuthorisationSystem();
+        // Create initial items - 2 persons and 2 publications
+        Item person = ItemBuilder.createItem(context, collection)
+            .withEntityType("Person")
+            .withTitle("Pierre Kiroul")
+            .withPersonMainAffiliation("UCL")
+            .build();
+
+        Item person2 = ItemBuilder.createItem(context, collection)
+            .withEntityType("Person")
+            .withTitle("Jean Gloutitou")
+            .withPersonMainAffiliation("UNamur")
+            .build();
+
+        Item publication = ItemBuilder.createItem(context, collection)
+            .withTitle("First publication")
+            .withAuthor("Pierre Kiroul", person.getID().toString())
+            .withAuthor("Jean Gloutitou", person2.getID().toString())
+            .withAuthorAffiliation("UCL", person.getID().toString())
+            .withAuthorAffiliation("UNamur", person2.getID().toString())
+            .withEntityType("Publication")
+            .build();
+
+        Item publication2 = ItemBuilder.createItem(context, collection)
+            .withTitle("Second publication")
+            .withAuthor("Pierre Kiroul", person.getID().toString())
+            .withAuthor("Jean Gloutitou", person2.getID().toString())
+            .withAuthorAffiliation("UCL", person.getID().toString())
+            .withAuthorAffiliation("UNamur", person2.getID().toString())
+            .withEntityType("Publication")
+            .build();
+
+        String personUUID = person.getID().toString();
+        String person2UUID = person2.getID().toString();
+        String publicationUUID = publication.getID().toString();
+        String publication2UUID = publication2.getID().toString();
+
+        context.commit();
+        person = context.reloadEntity(person);
+        person2 = context.reloadEntity(person2);
+        publication = context.reloadEntity(publication);
+        publication2 = context.reloadEntity(publication2);
+
+        // Now we should have all our metadata linked via the authority.
+        assertThat(
+            publication.getMetadata(),
+            hasItem(with("dc.contributor.author", "Pierre Kiroul", personUUID, 0, Choices.CF_ACCEPTED))
+        );
+        assertThat(
+            publication.getMetadata(),
+            hasItem(with("dc.contributor.author", "Jean Gloutitou", person2UUID, 1, Choices.CF_ACCEPTED))
+        );
+        assertThat(
+            publication2.getMetadata(),
+            hasItem(with("dc.contributor.author", "Pierre Kiroul", personUUID, 0, Choices.CF_ACCEPTED))
+        );
+        assertThat(
+            publication2.getMetadata(),
+            hasItem(with("dc.contributor.author", "Jean Gloutitou", person2UUID, 1, Choices.CF_ACCEPTED))
+        );
+
+        assertThat(
+            publication.getMetadata(),
+            hasItem(with("oairecerif.author.affiliation", "UCL", personUUID, 0, Choices.CF_ACCEPTED))
+        );
+        assertThat(
+            publication.getMetadata(),
+            hasItem(with("oairecerif.author.affiliation", "UNamur", person2UUID, 1, Choices.CF_ACCEPTED))
+        );
+        assertThat(
+            publication2.getMetadata(),
+            hasItem(with("oairecerif.author.affiliation", "UCL", personUUID, 0, Choices.CF_ACCEPTED))
+        );
+        assertThat(
+            publication2.getMetadata(),
+            hasItem(with("oairecerif.author.affiliation", "UNamur", person2UUID, 1, Choices.CF_ACCEPTED))
+        );
+
+        // Modify the title && affiliation for persons.
+        context.turnOffAuthorisationSystem();
+        itemService.setMetadataSingleValue(context, person, "dc", "title", null, null, "Jya Rivpa");
+        itemService.setMetadataSingleValue(context, person, "person", "affiliation", "name", null, "UCLouvain");
+        itemService.update(context, person);
+        itemService.setMetadataSingleValue(context, person2, "dc", "title", null, null, "Jean Prendraideu");
+        itemService.setMetadataSingleValue(context, person2, "person", "affiliation", "name", null, "UCLouvain");
+        itemService.update(context, person2);
+        context.restoreAuthSystemState();
+
+        context.commit();
+        person = context.reloadEntity(person);
+        person2 = context.reloadEntity(person2);
+        publication = context.reloadEntity(publication);
+        publication2 = context.reloadEntity(publication2);
+
+        // Check that the table has 4 entries (4 Person-Publication).
+        List<ItemToEnhance> itemToEnhanceEntries = uclouvainItemEnhancerService.retrieveAllItemsToUpdate(context);
+        assertThat(itemToEnhanceEntries, hasSize(4));
+        // At least one entry should have the 'person' as source item.
+        assertTrue(itemToEnhanceEntries.stream().anyMatch((ItemToEnhance ite) -> {
+            return ite.getSourceItem().getID().toString().equals(personUUID);
+        }));
+        // At least one entry should have the 'person2' as source item.
+        assertTrue(itemToEnhanceEntries.stream().anyMatch((ItemToEnhance ite) -> {
+            return ite.getSourceItem().getID().toString().equals(person2UUID);
+        }));
+        // At least one entry should have the 'publication' as target item.
+        assertTrue(itemToEnhanceEntries.stream().anyMatch((ItemToEnhance ite) -> {
+            return ite.getTargetItem().getID().toString().equals(publicationUUID);
+        }));
+        // At least one entry should have the 'publication2' as target item.
+        assertTrue(itemToEnhanceEntries.stream().anyMatch((ItemToEnhance ite) -> {
+            return ite.getTargetItem().getID().toString().equals(publication2UUID);
+        }));
+    }
+}

--- a/dspace/config/hibernate.cfg.xml
+++ b/dspace/config/hibernate.cfg.xml
@@ -127,5 +127,7 @@
         <mapping class="org.dspace.app.ldn.LDNMessageEntity"/>
         <mapping class="org.dspace.app.ldn.NotifyPatternToTrigger"/>
 
+        <!-- UCLouvain additions -->
+        <mapping class="org.dspace.uclouvain.itemEnhancer.model.ItemToEnhance"/>
     </session-factory>
 </hibernate-configuration>

--- a/dspace/config/log4j2.xml
+++ b/dspace/config/log4j2.xml
@@ -166,6 +166,22 @@
             </DefaultRolloverStrategy>
         </Appender>
 
+        <!-- A7 is for the custom metadata enhancer -->
+        <Appender name='A7'
+                filePattern="${log.dir}/item-enhancer.log%d{yyyy-MM-dd}"
+                type='RollingFile'
+                fileName='${log.dir}/item-enhancer.log'>
+            <Layout type='PatternLayout' pattern='%d %-5p -- %c :: %m%n'/>
+            <policies>
+                <policy type='TimeBasedTriggeringPolicy'>yyyy-MM-dd</policy>
+            </policies>
+            <DefaultRolloverStrategy>
+                <Delete basePath='${log.dir}'>
+                    <IfFileName glob='item-enhancer.log-*'/>
+                    <IfAccumulatedFileCount exceeds='${logging.server.retention-accumulated-to-keep}'/>
+                </Delete>
+            </DefaultRolloverStrategy>
+        </Appender>
     </Appenders>
 
     <Loggers>
@@ -210,6 +226,13 @@
                 level='TRACE'
                 additivity='false'>
             <AppenderRef ref='A6'/>
+        </Logger>
+
+        <!-- Custom Item Enhancer -->
+        <Logger name='org.dspace.uclouvain.itemEnhancer'
+                level='INFO'
+                additivity='false'>
+            <AppenderRef ref='A7'/>
         </Logger>
 
         <!-- Block services logging except on exceptions -->

--- a/dspace/config/modules/uclouvain.cfg
+++ b/dspace/config/modules/uclouvain.cfg
@@ -29,6 +29,9 @@ event.consumer.licensegenerator.filters = Bitstream+All
 event.consumer.accesstype.class = org.dspace.uclouvain.consumer.AccessTypeConsumer
 event.consumer.accesstype.filters = Bitstream+Create|Modify|Delete|Remove
 
+event.consumer.authoritymetadataenhancer.class = org.dspace.uclouvain.itemEnhancer.consumer.UCLouvainItemEnhancerConsumer
+event.consumer.authoritymetadataenhancer.filters = Item+All
+
 #------------------------------------------------------------------#
 #------------- Community/Collection configuration -----------------#
 #------------------------------------------------------------------#


### PR DESCRIPTION
## Description
This PR aims to add a dynamic system to update the values of some metadata from a source of data. We have a source item which is holding the correct data and a target item which needs to be kept updated with the source data. For example, a publication can have the name of an author in its metadata. This name metadata is linked to the person item using the authority field, and then updated when the source data changes.

This is the first part of the functionality, which provides a consumer that adds new entries in a database. Those entries will then be processed by a 'poller', which will update the metadata values of the target items. __The 'poller' will be in another PR.__

## Component details
New feature to update authority based values:
- 'uclouvain-metadata-enhancers.xml' allows to configure the feature. A 'source' item is where the original data is held and  'target' items are all the 'child' items referencing the metadata.
- A new database table has been defined to store the target items that need to be updated.
- Allong with the database table comes a DAO to query the DB.
- A new consumer 'UCLouvainItemEnhancerConsumer' catch events on modified items to process them and potentially add entries to the database table.

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [x] Run unitest for `dspace-uclouvain` module