### PR TITLE
[ADD] feat(submission): Allow help url for submission field

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
@@ -9,6 +9,9 @@ package org.dspace.app.util;
 
 import static org.apache.commons.lang3.StringUtils.equalsAnyIgnoreCase;
 
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -102,6 +105,11 @@ public class DCInput {
      * 'hint' text to display
      */
     private String hint = null;
+
+    /**
+     * specific URL where to find 'help' for the field
+     */
+    private String help = null;
 
     /**
      * if input list-controlled, name of list
@@ -210,6 +218,7 @@ public class DCInput {
             valueList = listMap.get(valueListName);
         }
         hint = fieldMap.get("hint");
+        help = fieldMap.get("help");
         warning = fieldMap.get("required");
         required = warning != null && warning.length() > 0;
         visibility = fieldMap.get("visibility");
@@ -388,6 +397,20 @@ public class DCInput {
      */
     public String getHints() {
         return hint;
+    }
+
+    /**
+     * Get the help URL for this form field
+     *
+     * @return the help URL
+     */
+    public String getHelp() {
+        // only return valid URL, otherwise return null
+        try {
+            return new URL(help).toURI().toString();
+        } catch (MalformedURLException | URISyntaxException e) {
+            return null;
+        }
     }
 
     /**

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionFormConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionFormConverter.java
@@ -98,6 +98,7 @@ public class SubmissionFormConverter implements DSpaceConverter<DCInputSet, Subm
         inputField.setMandatory(dcinput.isRequired());
         inputField.setVisibility(getVisibility(dcinput));
         inputField.setRepeatable(dcinput.isRepeatable());
+        inputField.setHelp(dcinput.getHelp());
         if (dcinput.getLanguage()) {
             int idx = 1;
             //list contains: at even position the code, at odd position the label

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/SubmissionFormFieldRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/SubmissionFormFieldRest.java
@@ -72,6 +72,11 @@ public class SubmissionFormFieldRest {
     private String hints;
 
     /**
+     * A URL where to find help about the input field
+     */
+    private String help;
+
+    /**
      * Extra information to be used by the UI to customize the presentation of the field. The format is dependent from
      * the UI implementation, the default Angular UI expects whitespace separated CSS class to add to the field
      */
@@ -194,6 +199,23 @@ public class SubmissionFormFieldRest {
      */
     public void setHints(String hints) {
         this.hints = hints;
+    }
+
+    /**
+     * Getter for {@link #help}
+     *
+     * @return {@link #help}
+     */
+    public String getHelp() {
+        return help;
+    }
+
+    /**
+     * Setter for {@link #help}
+     *
+     */
+    public void setHelp(String help) {
+        this.help = help;
     }
 
     /**

--- a/dspace/config/submission-forms.dtd
+++ b/dspace/config/submission-forms.dtd
@@ -8,7 +8,7 @@
  <!ELEMENT row (field|relation-field)+ >
  <!ATTLIST form name NMTOKEN #REQUIRED>
 
- <!ELEMENT field (dc-schema, dc-element, dc-qualifier?, language?, repeatable?, label, style?, type-bind?, input-type, hint, required?, regex?, vocabulary?, visibility?, readonly?) >
+ <!ELEMENT field (dc-schema, dc-element, dc-qualifier?, language?, repeatable?, label, style?, type-bind?, input-type, hint, required?, regex?, vocabulary?, visibility?, readonly?, help?) >
  <!ELEMENT dc-schema (#PCDATA) >
  <!ELEMENT dc-element (#PCDATA) >
  <!ELEMENT dc-qualifier (#PCDATA) >
@@ -21,6 +21,7 @@
  <!ELEMENT input-type (#PCDATA)>
 
  <!ELEMENT hint (#PCDATA) >
+ <!ELEMENT help (#PCDATA)>
  <!ELEMENT required (#PCDATA)>
  <!ELEMENT name-variants (#PCDATA)>
  <!ELEMENT regex (#PCDATA) >


### PR DESCRIPTION
Adds an optional 'help' tag for each submission field. This tag allow to encode an URL where a full documentation could be handle.

Authored-by: Renaud Michotte <renaud.michotte@uclouvain.be>
