### PR TITLE
[ADD] feat(gribe-data-cleaner) Consumer to clean non-valid data for selected type.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/DCInputSet.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInputSet.java
@@ -243,7 +243,8 @@ public class DCInputSet {
                         }
                     }
                 } else {
-                    if (input.isAllowedFor(documentTypeValue) && !allowedFieldNames.contains(input.getFieldName())) {
+                    // Do not check for input validity since we want to return every registered data for the item.
+                    if (!allowedFieldNames.contains(input.getFieldName())) {
                         allowedFieldNames.add(input.getFieldName());
                     }
                 }

--- a/dspace-api/src/main/java/org/dspace/uclouvain/consumer/FormFieldCleanerConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/consumer/FormFieldCleanerConsumer.java
@@ -1,0 +1,249 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.consumer;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.app.util.DCInput;
+import org.dspace.app.util.DCInputSet;
+import org.dspace.app.util.DCInputsReader;
+import org.dspace.app.util.DCInputsReaderException;
+import org.dspace.app.util.SubmissionConfig;
+import org.dspace.app.util.SubmissionStepConfig;
+import org.dspace.app.util.TypeBindUtils;
+import org.dspace.content.Collection;
+import org.dspace.content.Item;
+import org.dspace.content.MetadataValue;
+import org.dspace.content.WorkspaceItem;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.ItemService;
+import org.dspace.content.service.WorkspaceItemService;
+import org.dspace.core.Context;
+import org.dspace.core.Utils;
+import org.dspace.event.Consumer;
+import org.dspace.event.Event;
+import org.dspace.submit.factory.SubmissionServiceFactory;
+import org.dspace.submit.service.SubmissionConfigService;
+import org.dspace.xmlworkflow.factory.XmlWorkflowServiceFactory;
+import org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem;
+import org.dspace.xmlworkflow.storedcomponents.service.XmlWorkflowItemService;
+
+/**
+ * Consumer to clean fields that should not exist for a given type-bind type.
+ * This is determined by looking at the 'dc.type' of the item and by checking the current form configuration.
+ * Typically a form field that has a 'type-bind' linking to something else than the current DSpace
+ * item type should be removed. This is done to avoid having useless values for the selected type.
+ * 
+ * Mainly used to clear unwanted data coming from Grobe plugin (aka grobid).
+ * 
+ * @author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+public class FormFieldCleanerConsumer implements Consumer {
+
+    DCInputsReader dciReader;
+    ItemService itemService;
+    WorkspaceItemService workspaceItemService;
+    XmlWorkflowItemService xmlWorkflowItemService;
+    SubmissionConfigService submissionConfigService;
+    Set<UUID> itemToProcess;
+    String typeBindField;
+
+    private Logger logger = LogManager.getLogger(FormFieldCleanerConsumer.class);
+
+    @Override
+    public void initialize() throws Exception {
+        dciReader = new DCInputsReader();
+        itemService = ContentServiceFactory.getInstance().getItemService();
+        workspaceItemService = ContentServiceFactory.getInstance().getWorkspaceItemService();
+        xmlWorkflowItemService = XmlWorkflowServiceFactory.getInstance().getXmlWorkflowItemService();
+        submissionConfigService = SubmissionServiceFactory.getInstance().getSubmissionConfigService();
+        itemToProcess = new HashSet<UUID>();
+        typeBindField = TypeBindUtils.getTypeBindField();
+    }
+
+    /**
+     * Check if the item of the event is valid.
+     * An item is valid if it has a value for the 'typeBindField'.
+     * When an item is valid, we add its uuid to the set of item to process.
+     * 
+     * @param context The current DSpace context.
+     * @param event The event to process.
+     */
+    @Override
+    public void consume(Context context, Event event) throws SQLException {
+        Item item = (Item) event.getSubject(context);
+        if (item == null) {
+            return;
+        }
+
+        // Check that the item has a value for the main type field.
+        List<MetadataValue> metadataValues =  itemService.getMetadataByMetadataString(item, typeBindField);
+
+        // If no 'typeBindField' exists for the item just ignore it.
+        if (metadataValues != null && !metadataValues.isEmpty()) {
+            itemToProcess.add(item.getID());
+        }
+    }
+
+    /**
+     * Process all valid items.
+     * Get the collection of the workspace item in order to retrieve the correct submission form.
+     * Build a list of all non-valid type-bind controlled field.
+     * If the item has a metadata for one of those field: delete it.
+     * 
+     * @param context The current DSpace context.
+     */
+    @Override
+    public void end(Context context) throws Exception {
+        for (UUID itemID: itemToProcess) {
+            try {
+                Item item = itemService.find(context, itemID);
+
+                // Retrieve main type-bind field value for the item.
+                List<MetadataValue> metadataValues = itemService.getMetadataByMetadataString(item, typeBindField);
+                String currentType = metadataValues.get(0).getValue();
+
+                // Map that collects all type-bind fields.
+                HashMap<String, List<DCInput>> typeBindFields = new HashMap<>();
+
+                // Retrieve the correct collection depending on the state of the item.
+                Collection linkedCollection = getCollectionForItem(context, item);
+
+                if (linkedCollection == null) {
+                    logger.warn("Cannot process item: couldn't find a valid collection for item: " + itemID);
+                    continue;
+                }
+
+                // Load field configuration and transform it to a map.
+                SubmissionConfig config = submissionConfigService.getSubmissionConfigByCollection(linkedCollection);
+                for (int i = 0; i < config.getNumberOfSteps(); i++) {
+                    SubmissionStepConfig stepConfig = config.getStep(i);
+                    // Process only submission forms
+                    if (stepConfig.getType().equals(SubmissionStepConfig.INPUT_FORM_STEP_NAME)) {
+                        DCInputSet inputSet = dciReader.getInputsByFormName(stepConfig.getId());
+                        extractTypeBindFields(stepConfig, inputSet, typeBindFields, dciReader);
+                    }
+                }
+                // List that holds all the invalid fields for the current type.
+                List<String> invalidTypeBindInputs = extractNonValidFieldsFromMap(currentType, typeBindFields);
+
+                // Once we have the complete accepted metadata list, we check the ones of the item.
+                List<MetadataValue> metadataToRemove =  item.getMetadata().stream()
+                    .filter(mv -> invalidTypeBindInputs.contains(mv.getMetadataField().toString('.')))
+                    .collect(Collectors.toList());
+
+                // Delete all metadata that should not be present
+                if (metadataToRemove.size() != 0) {
+                    this.logger.debug("Found metadata to remove because type-bind was not valid: " + metadataToRemove);
+                    itemService.removeMetadataValues(context, item, metadataToRemove);
+                    itemService.update(context, item);
+                }
+            } catch (Exception e) {
+                logger.error(
+                    "An error occurred while trying to clear unwanted type-bind data of item: " + itemID.toString(), e
+                );
+            }
+        }
+        itemToProcess.clear();
+    }
+
+    /**
+     * Retrieve the correct collection for a given item depending on its current state.
+     * @param context The current DSpace context.
+     * @param item The item to extract the collection of.
+     * @return The collection of the item.
+     * @throws SQLException
+     */
+    private Collection getCollectionForItem(Context context, Item item) throws SQLException {
+        WorkspaceItem workspaceItem = workspaceItemService.findByItem(context, item);
+        if (workspaceItem != null) {
+            return workspaceItem.getCollection();
+        }
+        XmlWorkflowItem workflowItem = xmlWorkflowItemService.findByItem(context, item);
+        if (workflowItem != null) {
+            return workflowItem.getCollection();
+        }
+        return item.getOwningCollection();
+    }
+
+    /**
+     * Build the HashMap of type-bind fields.
+     * Each key corresponds to a metadata field name (<schema>.<element>.<qualifier>).
+     * Each value is a list of 'DCInput' for the corresponding metadata field.
+     * 
+     * @param stepConfig The step from the submission process.
+     * @param inputSet The set of inputs corresponding to a form.
+     * @param map The HashMap to fill with type-bind fields.
+     * @param inputReader A DCInput reader instance to retrieve form groups.
+     * @throws DCInputsReaderException
+     */
+    private static void extractTypeBindFields(
+        SubmissionStepConfig stepConfig,
+        DCInputSet inputSet,
+        HashMap<String, List<DCInput>> map,
+        DCInputsReader inputReader
+    ) throws DCInputsReaderException {
+        for (DCInput[] fields: inputSet.getFields()) {
+            for (DCInput input: fields) {
+                String inputName = input.getFieldName();
+
+                // If the input has a 'group-like' type, search for 'children' forms and process them.
+                if (StringUtils.equalsAny(input.getInputType().toLowerCase(),
+                    "group", "inline-group", "inline-labeled-group")) {
+                    DCInputSet inputSetGroup = inputReader.getInputsByFormName(stepConfig.getId() + "-"
+                        + Utils.standardize(input.getSchema(), input.getElement(), input.getQualifier(), "-"));
+                    extractTypeBindFields(stepConfig, inputSetGroup, map, inputReader);
+                    // Continue the loop here because we dont want to process the current input if it is of type group.
+                    continue;
+                }
+
+                // If the input has type-bind information, add it to the map.
+                if (input.getTypeBindList() != null && !input.getTypeBindList().isEmpty()) {
+                    map.computeIfAbsent(inputName, key -> new ArrayList<>()).add(input);
+                }
+            }
+        }
+    }
+
+    /**
+     * From a map of type-bind metadata fields, finds out which metadata field is not valid for the current type.
+     * A field is not valid if:
+     * -> The field has a non-valid type-bind input,
+     * -> For the key of a non-valid input, there are no valid input in the map.
+     * 
+     * For example if an entry of the map is "[key]: (nonValidDCInput, nonValidDCInput, validDCInput)",
+     * the field is considered as valid since there is one valid type-bind input in the list.
+     * However, if the entry looks like this: "[key]: (nonValidDCInput, nonValidDCInput)",
+     * then the field is considered as non-valid and is then added to the list of non valid field.
+     * 
+     * @param targetTypeBind The type of the current item being processed.
+     * @param map The map of fields and corresponding DCInput.
+     * @return A list of non-valid fields for the given type.
+     */
+    private static List<String> extractNonValidFieldsFromMap(
+        String targetType,
+        HashMap<String, List<DCInput>> map
+    ) {
+        return map.keySet().stream().filter(key -> {
+            return !map.get(key).stream().anyMatch(input -> input.isAllowedFor(targetType));
+        }).collect(Collectors.toList());
+    }
+
+    @Override
+    public void finish(Context context) throws Exception {}
+}

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -810,7 +810,7 @@ event.dispatcher.RelatedItemEnhancerUpdatePoller.class = org.dspace.event.BasicD
 # Add rdf here, if you are using dspace-rdf to export your repository content as RDF.
 # Add iiif here, if you are using dspace-iiif.
 # Add orcidqueue here, if the integration with ORCID is configured and wish to enable the synchronization queue functionality
-event.dispatcher.default.consumers = versioning, discovery, eperson, dedup, crisconsumer, orcidqueue, audit, qaeventsdelete, referenceresolver, orcidwebhook, itemenhancer, customurl, iiif, reciprocal, filetypemetadataenhancer, authoritylink, licensegenerator, accesstype, authoritymetadataenhancer
+event.dispatcher.default.consumers = versioning, discovery, eperson, dedup, crisconsumer, orcidqueue, audit, qaeventsdelete, referenceresolver, orcidwebhook, itemenhancer, customurl, iiif, reciprocal, filetypemetadataenhancer, authoritylink, licensegenerator, accesstype, authoritymetadataenhancer, formfieldcleaner
 event.dispatcher.RelatedItemEnhancerUpdatePoller.consumers = versioning, discovery, eperson, dedup, crisconsumer, orcidqueue, audit, qaeventsdelete, referenceresolver, orcidwebhook, itemenhancer, customurl, iiif, reciprocal, filetypemetadataenhancer, authoritylink
 
 # enable the item enhancer poller

--- a/dspace/config/modules/uclouvain.cfg
+++ b/dspace/config/modules/uclouvain.cfg
@@ -32,6 +32,8 @@ event.consumer.accesstype.filters = Bitstream+Create|Modify|Delete|Remove
 event.consumer.authoritymetadataenhancer.class = org.dspace.uclouvain.itemEnhancer.consumer.UCLouvainItemEnhancerConsumer
 event.consumer.authoritymetadataenhancer.filters = Item+All
 
+event.consumer.formfieldcleaner.class = org.dspace.uclouvain.consumer.FormFieldCleanerConsumer
+event.consumer.formfieldcleaner.filters = Item+All
 #------------------------------------------------------------------#
 #------------- Community/Collection configuration -----------------#
 #------------------------------------------------------------------#


### PR DESCRIPTION
## Description

A new consumer is triggered when saving a workspace item. The consumer cleans metadata linked to a field which should not be displayed following the type-bind configuration.

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module