### PR TITLE
[ADD] feat(default-license) default license when uploading file.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/uclouvain/consumer/LicenseConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/consumer/LicenseConsumer.java
@@ -31,42 +31,47 @@ import org.dspace.services.factory.DSpaceServicesFactory;
  */
 public class LicenseConsumer implements Consumer {
 
-    static List<Integer> acceptedEvents = Arrays.asList(Event.MODIFY_METADATA, Event.MODIFY);
-    private MetadataFieldName licenseMetadataFieldName;
+    static List<Integer> acceptedEvents = Arrays.asList(Event.CREATE, Event.MODIFY_METADATA, Event.MODIFY);
+    private MetadataFieldName licenseField;
     private String defaultLicenseUrl;
+    private boolean enableDefault;
+
     // Services
     private BitstreamService bitstreamService;
     private ConfigurationService configurationService;
 
     @Override
-    public void finish(Context context) throws Exception {}
-
-    @Override
     public void initialize() throws Exception {
         // Retrieve services
-        this.bitstreamService = ContentServiceFactory.getInstance().getBitstreamService();
-        this.configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
+        bitstreamService = ContentServiceFactory.getInstance().getBitstreamService();
+        configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
 
-        this.defaultLicenseUrl = this.configurationService.getProperty("uclouvain.global.metadata.license.default",
-                "https://creativecommons.org/licenses/by/4.0/");
-        String fieldName = this.configurationService.getProperty("uclouvain.global.metadata.license.field",
+        defaultLicenseUrl = configurationService.getProperty("bitstream.upload.default.license.url");
+        enableDefault = configurationService.getBooleanProperty("bitstream.upload.default.license.enabled", false);
+        String fieldName = configurationService.getProperty("uclouvain.global.metadata.license.field",
                 "dc.rights.license");
-        this.licenseMetadataFieldName = new MetadataFieldName(fieldName);
+        licenseField = new MetadataFieldName(fieldName);
     }
 
     @Override
     public void consume(Context context, Event event) throws Exception {
         // Only process bitstreams that have no license && are being modified
-        if (event.getSubjectType() == Constants.BITSTREAM && acceptedEvents.contains(event.getEventType())) {
+        if (isEventValid(event) && enableDefault && defaultLicenseUrl != null) {
             Bitstream bitstream = (Bitstream) event.getSubject(context);
-            if (bitstreamService.getMetadataFirstValue(bitstream, this.licenseMetadataFieldName, null) == null) {
-                bitstreamService.setMetadataSingleValue(context, bitstream, this.licenseMetadataFieldName, null,
+            if (bitstreamService.getMetadataFirstValue(bitstream, licenseField, null) == null) {
+                bitstreamService.setMetadataSingleValue(context, bitstream, licenseField, null,
                         defaultLicenseUrl);
             }
         }
     }
 
     @Override
-    public void end(Context context) throws Exception {
+    public void end(Context context) throws Exception {}
+
+    @Override
+    public void finish(Context context) throws Exception {}
+
+    private boolean isEventValid(Event event) {
+        return event.getSubjectType() == Constants.BITSTREAM && acceptedEvents.contains(event.getEventType());
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/UploadStep.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/UploadStep.java
@@ -35,6 +35,7 @@ import org.dspace.content.InProgressSubmission;
 import org.dspace.content.Item;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
+import org.dspace.uclouvain.core.model.MetadataField;
 import org.springframework.web.multipart.MultipartFile;
 
 /**
@@ -133,6 +134,21 @@ public class UploadStep extends AbstractProcessingStep
             // Identify the format
             bf = bitstreamFormatService.guessFormat(context, source);
             source.setFormat(context, bf);
+
+            String defaultLicense = configurationService.getProperty("bitstream.upload.default.license.url");
+            // Add a default license to a newly created bitstream.
+            if (
+                configurationService.getBooleanProperty("bitstream.upload.default.license.enabled", false)
+                    && defaultLicense != null
+            ) {
+                bitstreamService.setMetadataSingleValue(
+                    context,
+                    source,
+                    new MetadataField("dc.rights.license"),
+                    null,
+                    defaultLicense
+                );
+            }
 
             // Update to DB
             bitstreamService.update(context, source);

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -810,7 +810,7 @@ event.dispatcher.RelatedItemEnhancerUpdatePoller.class = org.dspace.event.BasicD
 # Add rdf here, if you are using dspace-rdf to export your repository content as RDF.
 # Add iiif here, if you are using dspace-iiif.
 # Add orcidqueue here, if the integration with ORCID is configured and wish to enable the synchronization queue functionality
-event.dispatcher.default.consumers = versioning, discovery, eperson, dedup, crisconsumer, orcidqueue, audit, qaeventsdelete, referenceresolver, orcidwebhook, itemenhancer, customurl, iiif, reciprocal, filetypemetadataenhancer, authoritylink
+event.dispatcher.default.consumers = versioning, discovery, eperson, dedup, crisconsumer, orcidqueue, audit, qaeventsdelete, referenceresolver, orcidwebhook, itemenhancer, customurl, iiif, reciprocal, licensegenerator, filetypemetadataenhancer, authoritylink
 event.dispatcher.RelatedItemEnhancerUpdatePoller.consumers = versioning, discovery, eperson, dedup, crisconsumer, orcidqueue, audit, qaeventsdelete, referenceresolver, orcidwebhook, itemenhancer, customurl, iiif, reciprocal, filetypemetadataenhancer, authoritylink
 
 # enable the item enhancer poller
@@ -2051,3 +2051,5 @@ include = ${module_dir}/ldn.cfg
 include = ${module_dir}/networklab.cfg
 # Import uclouvain configuration
 include = ${module_dir}/uclouvain.cfg
+# Bitstream specific configuration
+include = ${module_dir}/bitstream.cfg

--- a/dspace/config/modules/bitstream.cfg
+++ b/dspace/config/modules/bitstream.cfg
@@ -1,0 +1,5 @@
+#---------------------------------------------------------#
+#----------------- License configuration -----------------#
+#---------------------------------------------------------#
+bitstream.upload.default.license.enabled = true
+bitstream.upload.default.license.url = https://creativecommons.org/licenses/by/4.0/


### PR DESCRIPTION
## Description

Modified the 'UploadStep' to add a default license to an uploaded file (bitstream). This is better than the previously implemented consumer because default value is directly visible on the frontend.

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module