### PR TITLE
[UPD] feat(year-config) Year field config for PR.

### DIFF
--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -1465,6 +1465,11 @@
           <input-type>year</input-type>
           <hint>Enter date issued of the serial.</hint>
           <required>You need to select a date</required>
+          <settings>
+            <setting name="useCurrentYearAsDefault">false</setting>
+            <setting name="maxYearDelta">2</setting>
+            <setting name="minYear">1925</setting>
+          </settings>
         </field>
       </row>
       <row>


### PR DESCRIPTION
Added settings for year field 'publication.serial.dateIssued':
- The year can be set to maximum the current year + 2.
- There minYear is 1925.

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module