### PR TITLE
[FIX] feat(general): Fix access type calculation

### DIFF
--- a/dspace-api/src/main/java/org/dspace/uclouvain/plugins/UCLouvainAccessStatusHelper.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/plugins/UCLouvainAccessStatusHelper.java
@@ -8,6 +8,7 @@
 package org.dspace.uclouvain.plugins;
 
 import java.sql.SQLException;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
@@ -63,9 +64,8 @@ public class UCLouvainAccessStatusHelper implements AccessStatusHelper {
 
 
     public UCLouvainAccessStatusHelper() {
-        String fieldName = configurationService
-                .getProperty("uclouvain.global.metadata.accesstype.field", "dcterms.accessRights");
-        this.accessMetadataFieldName = new MetadataFieldName(fieldName);
+        this.accessMetadataFieldName = new MetadataFieldName(configurationService
+                .getProperty("uclouvain.global.metadata.accesstype.field", "dcterms.accessRights"));
     }
 
     /**
@@ -83,7 +83,7 @@ public class UCLouvainAccessStatusHelper implements AccessStatusHelper {
         if (item == null) {
             return UNKNOWN;
         }
-        Bitstream masterBitstream = this.getMasterBitstreamForItem(item);
+        Bitstream masterBitstream = this.getMasterBitstreamForItem(context, item);
         return (masterBitstream != null)
                 ? calculateAccessStatusForDso(context, masterBitstream)
                 : getAccessFromMetadata(item);
@@ -105,7 +105,7 @@ public class UCLouvainAccessStatusHelper implements AccessStatusHelper {
             return null;
         }
         // Get the master bitstream about this item... it should return an embargoed bitstream.
-        Bitstream masterBitstream = getMasterBitstreamForItem(item);
+        Bitstream masterBitstream = getMasterBitstreamForItem(context, item);
         if (masterBitstream == null) {
             return null;
         }
@@ -119,27 +119,50 @@ public class UCLouvainAccessStatusHelper implements AccessStatusHelper {
      * Get the master bitstream for an Item. Master bitstream is either the
      * defined item primary bitstream, either the first bitstream of the default bundle.
      *
+     * @param context the application context
      * @param item the item to analyze
      * @return the master item bitstream if exists, otherwise return null.
      */
-    private Bitstream getMasterBitstreamForItem(@NotNull Item item) {
+    private Bitstream getMasterBitstreamForItem(Context context, @NotNull Item item) {
         List<Bundle> bundles = item.getBundles(Constants.DEFAULT_BUNDLE_NAME);
-        Bitstream bitstream = bundles
+
+        // 1) Try to find a bitstream flagged as `primary`.
+        //    If we find one, then use it!
+        Bitstream primaryBitstream = bundles
                 .stream()
                 .map(Bundle::getPrimaryBitstream)
                 .filter(Objects::nonNull)
                 .findFirst()
                 .orElse(null);
-        if (bitstream == null) {
-            bitstream = bundles
-                    .stream()
-                    .map(Bundle::getBitstreams)
-                    .flatMap(List::stream)
-                    .findFirst()
-                    .orElse(null);
+        if (primaryBitstream != null) {
+            return primaryBitstream;
         }
-        return bitstream;
+
+        // 2) No primary bitstream has been found.
+        //    So we need to find the most permissive bitstream
+        return bundles
+                .stream()
+                .flatMap(bundle -> bundle.getBitstreams().stream())
+                .max(Comparator.comparingInt(b -> getBitstreamPriority(context, b)))
+                .orElse(null);
     }
+
+    /**
+     * Find the bitstream priority based on bitstream related resource policy.
+     *
+     * @param context the application context
+     * @param bitstream the bitstream to analyze
+     * @return the bitstream priority; larger number = higher priority.
+     */
+    private int getBitstreamPriority(Context context, Bitstream bitstream) {
+        try {
+            String accessStatus = calculateAccessStatusForDso(context, bitstream);
+            return uclouvainResourcePolicyService.getPolicyWeight(accessStatus);
+        } catch (SQLException sqle) {
+            return Integer.MIN_VALUE;
+        }
+    }
+
 
     /**
      * Look at the DSpace object's policies to determine an access status value.
@@ -163,9 +186,14 @@ public class UCLouvainAccessStatusHelper implements AccessStatusHelper {
             }
         }
         String accessValue = getAccessFromMetadata(dso);
-        return (accessValue != null)
-            ? getControlledAccessValue(accessValue)
-            : OPEN_ACCESS;
+
+        // Special case for `Bitstream`:
+        //   If nor policies are found, nor specific metadata,
+        //   then the access status isn't UNKNOWN but OPEN_ACCESS
+        if (accessValue.equals(UNKNOWN) && dso instanceof Bitstream) {
+            return OPEN_ACCESS;
+        }
+        return getControlledAccessValue(accessValue);
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/uclouvain/services/UCLouvainResourcePolicyService.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/services/UCLouvainResourcePolicyService.java
@@ -39,4 +39,11 @@ public interface UCLouvainResourcePolicyService {
      * @return the master resource policy into this list. Could be `null` if `policies` argument is an empty list.
      */
     ResourcePolicy getMasterPolicy(List<ResourcePolicy> policies);
+
+    /** Get the policy weight based on a policy name
+     *
+     * @param policyName the resource policy name
+     * @return the priority weight
+     */
+    int getPolicyWeight(String policyName);
 }

--- a/dspace-api/src/main/java/org/dspace/uclouvain/services/UCLouvainResourcePolicyServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/services/UCLouvainResourcePolicyServiceImpl.java
@@ -35,9 +35,10 @@ public class UCLouvainResourcePolicyServiceImpl implements UCLouvainResourcePoli
     @Autowired
     private ResourcePolicyService resourcePolicyService;
     @Autowired
-    private List<ResourcePolicyPriority> resourcePolicyPriorities;
-    @Autowired
     private ResourcePolicyPriority defaultResourcePolicyPriority;
+
+    private List<ResourcePolicyPriority> resourcePolicyPriorities;
+
 
     /** Find all valid resource policies specifically created on a DSpace object.
      *
@@ -65,7 +66,7 @@ public class UCLouvainResourcePolicyServiceImpl implements UCLouvainResourcePoli
         ResourcePolicy masterPolicy = null;
         int currentMaxWeight = Integer.MIN_VALUE;
         for (ResourcePolicy policy : policies) {
-            int policyWeight = getPolicyWeight(policy);
+            int policyWeight = getPolicyWeight(policy.getRpName());
             if (policyWeight > currentMaxWeight) {
                 currentMaxWeight = policyWeight;
                 masterPolicy = policy;
@@ -75,7 +76,7 @@ public class UCLouvainResourcePolicyServiceImpl implements UCLouvainResourcePoli
     }
 
     private boolean isValidDateInterval(ResourcePolicy policy) {
-        // in a resourcePolicy, the `startDate` field is used to expose "start date where access is granted" ;
+        // In a resourcePolicy, the `startDate` field is used to expose "start date where access is granted";
         // opposite, the `endDate` field is used to expose "date where access is revoked". So to test if the
         // policy is valid, we need to check endDate <= currentDate <= startDate
         long currentTime = new Date().getTime();
@@ -84,11 +85,22 @@ public class UCLouvainResourcePolicyServiceImpl implements UCLouvainResourcePoli
         return endDate <= currentTime && currentTime <= startDate;
     }
 
-    private int getPolicyWeight(ResourcePolicy policy) {
+    /** Get the policy weight based on a policy name
+     *
+     * @param rpName the resource policy name
+     * @return the priority weight
+     */
+    public int getPolicyWeight(String rpName) {
         return this.resourcePolicyPriorities
                 .stream()
-                .filter(p -> p.getRpName().equalsIgnoreCase(policy.getRpName()))
-                .findFirst().orElse(defaultResourcePolicyPriority)
+                .filter(p -> p.getRpName().equalsIgnoreCase(rpName))
+                .findFirst()
+                .orElse(defaultResourcePolicyPriority)
                 .getWeight();
+    }
+
+    // GETTER & SETTER =================================================================================================
+    public void setResourcePolicyPriorities(List<ResourcePolicyPriority> resourcePolicyPriorities) {
+        this.resourcePolicyPriorities = resourcePolicyPriorities;
     }
 }

--- a/dspace/config/spring/uclouvain/uclouvain-services.xml
+++ b/dspace/config/spring/uclouvain/uclouvain-services.xml
@@ -25,7 +25,9 @@
 
     <!-- SERVICES ========================================================= -->
     <bean id="uclouvainEntityService" class="org.dspace.uclouvain.services.UCLouvainEntityServiceImpl"/>
-    <bean id="uclouvainResourcePolicyService" class="org.dspace.uclouvain.services.UCLouvainResourcePolicyServiceImpl"/>
+    <bean id="uclouvainResourcePolicyService" class="org.dspace.uclouvain.services.UCLouvainResourcePolicyServiceImpl">
+        <property name="resourcePolicyPriorities" ref="resourcePolicyPriorities"/>
+    </bean>
 
     <!-- UTILS ============================================================ -->
     <bean id="itemUtils" class="org.dspace.uclouvain.core.utils.ItemUtils" />


### PR DESCRIPTION
Fixes wrong access type calculation if no policies are defined for any bitstream of an item. In this specific case, the return value was "restricted" for item.

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module