### PR TITLE
[ADD] feat(consumer): Consumer to clear 'filler' values like NA or N/A

### DIFF
--- a/dspace-api/src/main/java/org/dspace/uclouvain/consumer/FillerValueRemoverConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/consumer/FillerValueRemoverConsumer.java
@@ -1,0 +1,242 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.consumer;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.app.util.DCInput;
+import org.dspace.app.util.DCInputSet;
+import org.dspace.app.util.DCInputsReader;
+import org.dspace.app.util.DCInputsReaderException;
+import org.dspace.app.util.SubmissionConfig;
+import org.dspace.app.util.SubmissionStepConfig;
+import org.dspace.content.Collection;
+import org.dspace.content.Item;
+import org.dspace.content.MetadataValue;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Context;
+import org.dspace.core.CrisConstants;
+import org.dspace.core.Utils;
+import org.dspace.event.Consumer;
+import org.dspace.event.Event;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.submit.factory.SubmissionServiceFactory;
+import org.dspace.submit.service.SubmissionConfigService;
+import org.dspace.uclouvain.core.utils.ItemUtils;
+
+/**
+ * Consumer to remove the 'filler' values from an item's metadata.
+ * Filler values are values added by the user which are there just to fill the field.
+ * For example: NA, N/A , non-applicable or not specified
+ * 
+ * This consumer aims to clean those fields by:
+ *  - Deleting them (for most fields)
+ * or
+ *  - Replacing them with a placeholder (for fields in a form group)
+ * 
+ * @author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+public class FillerValueRemoverConsumer implements Consumer {
+
+    private ItemService itemService;
+    private SubmissionConfigService submissionConfigService;
+    private DCInputsReader dciReader;
+
+    // List of string values to clean from the item values.
+    private List<String> valuesToClear;
+    private Set<UUID> itemToProcess;
+    private Logger logger;
+
+    /** Initialize the necessary resource for this consumer */
+    @Override
+    public void initialize() throws Exception {
+        // Get the list of regexp filler values to clean from the configuration.
+        valuesToClear = Arrays.asList(
+            DSpaceServicesFactory
+                .getInstance()
+                .getConfigurationService()
+                .getArrayProperty("event.consumer.fillervalueremover.fillers", new String[0])
+        );
+        itemService = ContentServiceFactory.getInstance().getItemService();
+        submissionConfigService = SubmissionServiceFactory.getInstance().getSubmissionConfigService();
+        dciReader = new DCInputsReader();
+        itemToProcess = new HashSet<>();
+        logger = LogManager.getLogger(FillerValueRemoverConsumer.class);
+    }
+
+    /**
+     * Check if the given event subject can be processed by this consumer.
+     * 
+     * @param context The current DSpace context.
+     * @param event The event to handle in the consumer.
+     * @throws Exception
+     */
+    @Override
+    public void consume(Context context, Event event) throws Exception {
+        // Check that item can be processed (in archive).
+        Item item = (Item) event.getSubject(context);
+        if (item != null && !ItemUtils.isWorkspace(context, item)) {
+            itemToProcess.add(item.getID());
+        }
+    }
+
+    /**
+     * For each item to process:
+     *  1. Get the full form configuration for the item using its collection.
+     *  2. For the all the fields in the form, if it has a 'filler' value:
+     *      - If its in a 'form-group', replace the value by CrisConstants.PLACEHOLDER_PARENT_METADATA_VALUE.
+     *      - If its a regular form field, just delete the value.
+     * 
+     * @param context The current DSpace context.
+     * @throws Exception
+     */
+    @Override
+    public void end(Context context) throws Exception {
+        for (UUID uuid: itemToProcess) {
+            try {
+                Item item = itemService.find(context, uuid);
+                Collection linkedCollection = ItemUtils.getMainCollection(context, item);
+                if (linkedCollection == null) {
+                    logger.warn("Found no collection for given item: [" + item.getID() + "]");
+                    continue;
+                }
+
+                SubmissionConfig config = submissionConfigService.getSubmissionConfigByCollection(linkedCollection);
+                if (config == null) {
+                    logger.warn(
+                        "Found no submission configuration for collection: [" + linkedCollection.getID() + "]"
+                    );
+                    continue;
+                }
+
+                List<String> formGroupFields = new ArrayList<>();
+                for (int i = 0; i < config.getNumberOfSteps(); i++) {
+                    SubmissionStepConfig stepConfig = config.getStep(i);
+                    // Process only submission forms
+                    if (stepConfig.getType().equals(SubmissionStepConfig.INPUT_FORM_STEP_NAME)) {
+                        DCInputSet inputSet = dciReader.getInputsByFormName(stepConfig.getId());
+                        // Extract only fields that are from a formGroup.
+                        extractFormGroupFields(stepConfig, inputSet, formGroupFields, dciReader, false);
+                    }
+                }
+
+                // Metadata to remove.
+                List<MetadataValue> mvsToClear = new ArrayList<>();
+                // Metadata to replace with a placeholder.
+                List<MetadataValue> mvsToReplace = new ArrayList<>();
+
+                item.getMetadata().stream()
+                    .filter(metadata -> {
+                        String valueToCheck = metadata.getValue();
+                        return valueToCheck.isBlank() || valuesToClear.stream().anyMatch(regex -> valueToCheck.matches(regex));
+                    })
+                    .forEach(md -> {
+                        if (formGroupFields.contains(md.getMetadataField().toString('.'))) {
+                            mvsToReplace.add(md);
+                        } else {
+                            mvsToClear.add(md);
+                        }
+                    });
+
+                if (!mvsToClear.isEmpty()) {
+                    try {
+                        itemService.removeMetadataValues(
+                            context,
+                            item,
+                            mvsToClear
+                        );
+                    } catch (SQLException e) {
+                        logger.warn("Could not remove unwanted metadata values from item with id: " + uuid, e);
+                    }
+                }
+
+                for (MetadataValue mv: mvsToReplace) {
+                    try {
+                        // Replace the given metadata with a placeholder.
+                        itemService.replaceMetadata(
+                            context,
+                            item,
+                            mv.getSchema(),
+                            mv.getElement(),
+                            mv.getQualifier(),
+                            mv.getLanguage(),
+                            CrisConstants.PLACEHOLDER_PARENT_METADATA_VALUE,
+                            mv.getAuthority(),
+                            mv.getConfidence(),
+                            mv.getPlace()
+                        );
+                    } catch (SQLException e) {
+                        logger.warn(
+                            "Could not replace with placeholder for metadata "
+                            + mv.getMetadataField() + " of item: " + uuid,
+                            e
+                        );
+                    }
+                }
+
+                if (!(mvsToClear.isEmpty() && mvsToReplace.isEmpty())) {
+                    itemService.update(context, item);
+                }
+            } catch (Exception e) {
+                logger.error("An error occurred while cleaning filler values for item: [" + uuid + "]", e);
+            }
+        }
+        itemToProcess.clear();
+    }
+
+    /**
+     * Given a specific inputSet, extract all DCInput that are in a form group in the given list.
+     * 
+     * @param stepConfig The current submission step.
+     * @param inputSet The set containing all the DCInput.
+     * @param groupFields The list to fill with DCInput.
+     * @param dciReader The reader used to get the inputs that are inside a given form group.
+     * @param isFormGroup A flag to indicate if we are processing a form group.
+     * @throws DCInputsReaderException If we could not get the desired form group.
+     */
+    private void extractFormGroupFields(
+        SubmissionStepConfig stepConfig,
+        DCInputSet inputSet,
+        List<String> groupFields,
+        DCInputsReader dciReader,
+        boolean isFormGroup
+    ) throws DCInputsReaderException {
+        for (DCInput[] fields: inputSet.getFields()) {
+            for (DCInput input: fields) {
+                // If the input has a 'group-like' type, search for 'children' fields and process them.
+                if (input.getInputType() != null && StringUtils.equalsAny(input.getInputType().toLowerCase(),
+                    "group", "inline-group", "inline-labeled-group")) {
+                    // Get the form corresponding to the group field.
+                    DCInputSet inputSetGroup = dciReader.getInputsByFormName(stepConfig.getId() + "-"
+                        + Utils.standardize(input.getSchema(), input.getElement(), input.getQualifier(), "-"));
+                    // Extract the fields in the map by putting the 'inGroup' flag to true.
+                    extractFormGroupFields(stepConfig, inputSetGroup, groupFields, dciReader, true);
+                    // Skip below code because we dont want to process the current input if it is of type group.
+                    continue;
+                }
+
+                if (isFormGroup) {
+                    groupFields.add(input.getFieldName());
+                }
+            }
+        }
+    }
+
+    @Override
+    public void finish(Context context) throws Exception {}
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/core/utils/ItemUtils.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/core/utils/ItemUtils.java
@@ -18,12 +18,13 @@ import org.dspace.content.Collection;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.WorkspaceItem;
+import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.BitstreamService;
-import org.dspace.content.service.WorkspaceItemService;
 import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.xmlworkflow.factory.XmlWorkflowServiceFactory;
 import org.dspace.xmlworkflow.storedcomponents.CollectionRole;
 import org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem;
 import org.dspace.xmlworkflow.storedcomponents.service.CollectionRoleService;
@@ -41,8 +42,6 @@ public class ItemUtils {
     private BitstreamService bitstreamService;
     @Autowired
     private XmlWorkflowItemService xmlWorkflowItemService;
-    @Autowired
-    private WorkspaceItemService workspaceItemService;
     @Autowired
     private CollectionRoleService collectionRoleService;
 
@@ -123,13 +122,15 @@ public class ItemUtils {
      * @param item    The DSpace Item to analyze.
      * @return The main collection to which the item belongs. Returns null if not found.
      */
-    public Collection getMainCollection(Context context, Item item) {
+    public static Collection getMainCollection(Context context, Item item) {
         try {
-            WorkspaceItem wsItem = workspaceItemService.findByItem(context, item);
+            WorkspaceItem wsItem =
+                ContentServiceFactory.getInstance().getWorkspaceItemService().findByItem(context, item);
             if (wsItem != null) {
                 return wsItem.getCollection();
             }
-            XmlWorkflowItem wfItem = (XmlWorkflowItem) xmlWorkflowItemService.findByItem(context, item);
+            XmlWorkflowItem wfItem =
+                XmlWorkflowServiceFactory.getInstance().getXmlWorkflowItemService().findByItem(context, item);
             if (wfItem != null) {
                 return wfItem.getCollection();
             }
@@ -147,8 +148,8 @@ public class ItemUtils {
      * @throws SQLException for any database exception
      * 
      */
-    public boolean isWorkflow(Context context, Item item) throws SQLException {
-        return this.xmlWorkflowItemService.findByItem(context, item) != null;
+    public static boolean isWorkflow(Context context, Item item) throws SQLException {
+        return XmlWorkflowServiceFactory.getInstance().getWorkflowItemService().findByItem(context, item) != null;
     }
 
     /**
@@ -158,7 +159,7 @@ public class ItemUtils {
      * @return True if the item is in workspace false otherwise.
      * @throws SQLException for any database exception
      */
-    public boolean isWorkspace(Context context, Item item) throws SQLException {
-        return this.workspaceItemService.findByItem(context, item) != null;
+    public static boolean isWorkspace(Context context, Item item) throws SQLException {
+        return ContentServiceFactory.getInstance().getWorkspaceItemService().findByItem(context, item) != null;
     }
 }

--- a/dspace-api/src/test/java/org/dspace/uclouvain/consumer/FillerValueRemoverConsumerIT.java
+++ b/dspace-api/src/test/java/org/dspace/uclouvain/consumer/FillerValueRemoverConsumerIT.java
@@ -1,0 +1,265 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.consumer;
+
+import static org.dspace.app.matcher.MetadataValueMatcher.with;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.dspace.AbstractIntegrationTestWithDatabase;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.WorkspaceItemBuilder;
+import org.dspace.content.Collection;
+import org.dspace.content.MetadataValue;
+import org.dspace.content.WorkspaceItem;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.InstallItemService;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.CrisConstants;
+import org.dspace.event.factory.EventServiceFactory;
+import org.dspace.event.service.EventService;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class FillerValueRemoverConsumerIT extends AbstractIntegrationTestWithDatabase {
+    private ItemService itemService;
+    private InstallItemService installItemService;
+    private Collection collection;
+    private static String[] consumers;
+
+    private static final ConfigurationService configurationService =
+        DSpaceServicesFactory.getInstance().getConfigurationService();
+    private static final EventService eventService = EventServiceFactory.getInstance().getEventService();
+
+    /**
+     * Load the consumer into the configuration if it is not yet present.
+     */
+    @BeforeClass
+    public static void loadConsumers() {
+        consumers = configurationService.getArrayProperty("event.dispatcher.default.consumers");
+        Set<String> consumersSet = new HashSet<>(Arrays.asList(consumers));
+        if (!consumersSet.contains("fillervalueremover")) {
+            consumersSet.add("fillervalueremover");
+            configurationService.setProperty("event.dispatcher.default.consumers", consumersSet.toArray());
+        }
+        // Set the values to clear to 'N/A', 'NA', 'na' ...
+        configurationService.setProperty("event.consumer.fillervalueremover.fillers", "^\\s*(?i)(n\\/?a)\\s*$");
+        configurationService.addPropertyValue("event.consumer.fillervalueremover.fillers", "^\\s*(?i)(no(t|n) applicable)\\s*$");
+
+        eventService.reloadConfiguration();
+    }
+
+    /**
+     * Reset the event.dispatcher.default.consumers property value.
+     */
+    @AfterClass
+    public static void resetDefaultConsumers() {
+        configurationService.setProperty("event.dispatcher.default.consumers", consumers);
+        eventService.reloadConfiguration();
+    }
+
+    @Before
+    public void setup() {
+        itemService = ContentServiceFactory.getInstance().getItemService();
+        installItemService = ContentServiceFactory.getInstance().getInstallItemService();
+
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+
+        collection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Publication")
+            .withSubmissionDefinition("publication")
+            .build();
+        context.restoreAuthSystemState();
+    }
+
+    /**
+     * Test a the case where a simple "onebox" field value is "N/A".
+     * This field should be remove from the items metadata once the item is in the archive.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testSimpleFillerField() throws Exception {
+        context.turnOffAuthorisationSystem();
+        // Create the base workspace item with the required metadata.
+        WorkspaceItem publication = WorkspaceItemBuilder.createWorkspaceItem(context, collection)
+            .withTitle("This is a test publication")
+            .withAbstract("N/A")
+            .build();
+        // Check that no modifications were made by the consumer since we are still in workspace.
+        assertThat(
+            publication.getItem().getMetadata(),
+            hasItem(with("dc.description.abstract", "N/A"))
+        );
+
+        installItemService.installItem(context, publication);
+        context.dispatchEvents();
+        context.restoreAuthSystemState();
+
+        // Once the item is in the archive, the consumer should modify the abstract.
+        String publicationAbstract = itemService.getMetadataFirstValue(
+            publication.getItem(), "dc", "description", "abstract", null
+        );
+        String publicationTitle = itemService.getMetadataFirstValue(
+            publication.getItem(), "dc", "title", null, null
+        );
+        assertThat(publicationAbstract, nullValue());
+        assertThat(publicationTitle, equalTo("This is a test publication"));
+    }
+
+    /**
+     * Test a case where we set a 'N/A' value to a field in a form group.
+     * The consumer should replace the field value by the default placeholder.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testSimpleFillerFieldInGroup() throws Exception {
+        context.turnOffAuthorisationSystem();
+        // Create the base workspace item with the required metadata.
+        WorkspaceItem publication = WorkspaceItemBuilder.createWorkspaceItem(context, collection)
+            .withTitle("This is a test publication")
+            .withAuthor("Mikel Theunis")
+            .withAuthorAffilitation("N/A")
+            .build();
+        // Check that no modifications were made by the consumer since we are still in workspace.
+        assertThat(
+            publication.getItem().getMetadata(),
+            hasItem(with("oairecerif.author.affiliation", "N/A"))
+        );
+
+        installItemService.installItem(context, publication);
+        context.dispatchEvents();
+        context.restoreAuthSystemState();
+
+        // Once the item is in the archive, the consumer should modify the affiliation and set it to placeholder.
+        String publicationAuthor = itemService.getMetadataFirstValue(
+            publication.getItem(), "dc", "contributor", "author", null
+        );
+        // The author name should not have changed.
+        assertThat(publicationAuthor, equalTo("Mikel Theunis"));
+        String publicationAffiliation = itemService.getMetadataFirstValue(
+            publication.getItem(), "oairecerif", "author", "affiliation", null
+        );
+        // The affiliation should have a value set to the default placeholder.
+        assertThat(publicationAffiliation, equalTo(CrisConstants.PLACEHOLDER_PARENT_METADATA_VALUE));
+    }
+
+    /**
+     * Mix between normal fields and in group fields.
+     * We have 2 authors and 2 affiliations:
+     * - 1. 'Jean Gloutitou' as author name with a 'NA' affiliation,
+     * - 2. 'N/A' as author name with a 'UCLouvain' affiliation
+     * 
+     * The first affiliation has to be changed to a placeholder since it is in a group field.
+     * The second author name has to be changed to a placeholder since it is in a a group field.
+     * 
+     * Also, we have a 'Not applicable' abstract and a 'NA' url.
+     * Those to field should be removed by the consumer.
+     * 
+     * Finally, we have a dc.title that has NA and N/A in it but should not be counted as filler:
+     * "Why are 'N/A' and 'Not applicable' useful in publication deposits ?"
+     * This should not change even after the consumer has processed the item.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testClearBothGroupFieldAndNormalField() throws Exception {
+        context.turnOffAuthorisationSystem();
+        WorkspaceItem publication = WorkspaceItemBuilder.createWorkspaceItem(context, collection)
+            .withAuthor("Jean Gloutitou")
+            .withAuthorAffilitation("NA")
+            .withAuthor("N/A")
+            .withAuthorAffilitation("UCLouvain")
+            .withTitle("Why are 'N/A' and 'Not applicable' useful in publication deposits ?")
+            .withAbstract("Not applicable")
+            .withCustomUrl("NA")
+            .build();
+        // Check that no modifications have been made since the publication is still in workspace.
+        assertThat(
+            publication.getItem().getMetadata(),
+            hasItem(with("oairecerif.author.affiliation", "NA", 0))
+        );
+        assertThat(
+            publication.getItem().getMetadata(),
+            hasItem(with("dc.contributor.author", "N/A", 1))
+        );
+        assertThat(
+            publication.getItem().getMetadata(),
+            hasItem(with("dc.description.abstract", "Not applicable"))
+        );
+        assertThat(
+            publication.getItem().getMetadata(),
+            hasItem(with("cris.customurl", "NA"))
+        );
+        // Trigger item deposit.
+        installItemService.installItem(context, publication);
+        context.dispatchEvents();
+        context.restoreAuthSystemState();
+
+        // Check that the fields containing the 'fillers' were cleared.
+        List<MetadataValue> publicationAuthors = itemService.getMetadata(
+            publication.getItem(), "dc", "contributor", "author", null
+        );
+        List<MetadataValue> publicationAuthorsAffiliations = itemService.getMetadata(
+            publication.getItem(), "oairecerif", "author", "affiliation", null
+        );
+        // The first author name should not have changed, the second one should be a placeholder.
+        assertThat(
+            publicationAuthors,
+            hasItem(with("dc.contributor.author", "Jean Gloutitou", 0))
+        );
+        assertThat(
+            publicationAuthors,
+            hasItem(with("dc.contributor.author", CrisConstants.PLACEHOLDER_PARENT_METADATA_VALUE, 1))
+        );
+
+        // The first affiliation should be a placeholder, the second one should not have been changed.
+        assertThat(
+            publicationAuthorsAffiliations,
+            hasItem(with("oairecerif.author.affiliation", CrisConstants.PLACEHOLDER_PARENT_METADATA_VALUE, 0))
+        );
+        assertThat(
+            publicationAuthorsAffiliations,
+            hasItem(with("oairecerif.author.affiliation", "UCLouvain", 1))
+        );
+
+        // The abstract 'filler' should have been removed.
+        String publicationAbstract = itemService.getMetadataFirstValue(
+            publication.getItem(), "dc", "description", "abstract", null
+        );
+        assertThat(publicationAbstract, nullValue());
+
+        // The custom url 'filler' should have been removed.
+        String publicationCustomUrl = itemService.getMetadataFirstValue(
+            publication.getItem(), "dc", "description", "abstract", null
+        );
+        assertThat(publicationCustomUrl, nullValue());
+
+        // Check that the title has not been change even if it contains 'N/A' and 'NA'
+        String publicationTitle = itemService.getMetadataFirstValue(
+            publication.getItem(), "dc", "title", null, null
+        );
+        assertThat(publicationTitle, equalTo("Why are 'N/A' and 'Not applicable' useful in publication deposits ?"));
+    }
+}

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -810,7 +810,7 @@ event.dispatcher.RelatedItemEnhancerUpdatePoller.class = org.dspace.event.BasicD
 # Add rdf here, if you are using dspace-rdf to export your repository content as RDF.
 # Add iiif here, if you are using dspace-iiif.
 # Add orcidqueue here, if the integration with ORCID is configured and wish to enable the synchronization queue functionality
-event.dispatcher.default.consumers = versioning, discovery, eperson, dedup, crisconsumer, orcidqueue, audit, qaeventsdelete, referenceresolver, orcidwebhook, itemenhancer, customurl, iiif, reciprocal, filetypemetadataenhancer, authoritylink, licensegenerator, accesstype, authoritymetadataenhancer, formfieldcleaner
+event.dispatcher.default.consumers = versioning, discovery, eperson, dedup, crisconsumer, orcidqueue, audit, qaeventsdelete, referenceresolver, orcidwebhook, itemenhancer, customurl, iiif, reciprocal, filetypemetadataenhancer, authoritylink, licensegenerator, accesstype, authoritymetadataenhancer, formfieldcleaner, fillervalueremover
 event.dispatcher.RelatedItemEnhancerUpdatePoller.consumers = versioning, discovery, eperson, dedup, crisconsumer, orcidqueue, audit, qaeventsdelete, referenceresolver, orcidwebhook, itemenhancer, customurl, iiif, reciprocal, filetypemetadataenhancer, authoritylink
 
 # enable the item enhancer poller

--- a/dspace/config/modules/uclouvain.cfg
+++ b/dspace/config/modules/uclouvain.cfg
@@ -34,6 +34,12 @@ event.consumer.authoritymetadataenhancer.filters = Item+All
 
 event.consumer.formfieldcleaner.class = org.dspace.uclouvain.consumer.FormFieldCleanerConsumer
 event.consumer.formfieldcleaner.filters = Item+All
+
+event.consumer.fillervalueremover.class = org.dspace.uclouvain.consumer.FillerValueRemoverConsumer
+event.consumer.fillervalueremover.filters = Item+Modify|Modify_Metadata
+# Regex to get the fillers values.
+event.consumer.fillervalueremover.fillers = ^\s*(?i)(n\/?a|not specified|no(t|n) applicable)\s*$
+
 #------------------------------------------------------------------#
 #------------- Community/Collection configuration -----------------#
 #------------------------------------------------------------------#


### PR DESCRIPTION
A configurable consumer has been added that will check for values like NA or N/A in the item's metadata. It is only triggered when the item is not in workspace. In general, it will remove the 'filler' metadata values but if the field is in a form group, it will replace them with a placeholder value.

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module