### PR TITLE
[ADD] feat(sentry): Sentry integration for DSpace log4j2.

### DIFF
--- a/dspace-server-webapp/pom.xml
+++ b/dspace-server-webapp/pom.xml
@@ -575,6 +575,11 @@
             <version>${log4j.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>io.sentry</groupId>
+            <artifactId>sentry-log4j2</artifactId>
+        </dependency>
+
         <!-- DSpace dependencies -->
         <dependency>
             <groupId>org.dspace</groupId>

--- a/dspace/config/log4j2.xml
+++ b/dspace/config/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Logging configuration for DSpace command line tools -->
 <Configuration strict='true'
-               xmlns='http://logging.apache.org/log4j/2.0/config'>
+               xmlns='http://logging.apache.org/log4j/2.0/config' packages="io.sentry.log4j2">
 
     <Properties>
         <!-- Default log file directory for DSpace.
@@ -200,6 +200,7 @@
                 </Delete>
             </DefaultRolloverStrategy>
         </Appender>
+        <Sentry name="Sentry" dsn="${sys:SENTRY_DSN}" minimumBreadcrumbLevel="INFO" minimumEventLevel="ERROR"/>
     </Appenders>
 
     <Loggers>
@@ -209,6 +210,7 @@
                 level='${loglevel.dspace}'
                 additivity='false'>
             <AppenderRef ref='A1'/>
+            <AppenderRef ref='Sentry'/>
         </Logger>
 
         <!-- The checksum checker -->

--- a/pom.xml
+++ b/pom.xml
@@ -1719,6 +1719,22 @@
                 <artifactId>log4j-jul</artifactId>
                 <version>${log4j.version}</version>
             </dependency>
+            <!-- Custom UCLouvain dependencies -->
+            <dependency>
+                <groupId>io.sentry</groupId>
+                <artifactId>sentry-log4j2</artifactId>
+                <version>5.6.1</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.code.gson</groupId>
+                        <artifactId>gson</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>jul-to-slf4j</artifactId>


### PR DESCRIPTION
## Description

Updated the configuration of DSpace logging to be able to use sentry. This allows us to consult the logs on the sentry instance.

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module