### PR TITLE
[FIX] feat(consumer): Fix bitstream delete behavior

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
@@ -282,11 +282,17 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
         // When consumers get a DELETE event about a bitstream, this bitstream is already deleted.
         // Then it's impossible to get the related parent object using `getParentObject` method.
         // To prevent this issue, we send the parent object UUID as `Object` of this event.
+        int parentObjectType = Event.NONE;
+        UUID parentObjectID = null;
         DSpaceObject parentObject = getParentObject(context, bitstream);
+        if (parentObject != null) {
+            parentObjectID = parentObject.getID();
+            parentObjectType = parentObject.getType();
+        }
         context.addEvent(new Event(
                 Event.DELETE,
                 Constants.BITSTREAM, bitstream.getID(),
-                parentObject.getType(), parentObject.getID(),
+                parentObjectType, parentObjectID,
                 String.valueOf(bitstream.getSequenceID()),
                 getIdentifiers(context, bitstream)));
 

--- a/dspace-api/src/main/java/org/dspace/event/Event.java
+++ b/dspace-api/src/main/java/org/dspace/event/Event.java
@@ -87,7 +87,7 @@ public class Event implements Serializable {
     /**
      * XXX NOTE: with ALL_OBJECTS_MASK *AND* objTypeToMask hash *
      */
-    protected static final int NONE = 0;
+    public static final int NONE = 0;
 
     protected static final int BITSTREAM = 1 << Constants.BITSTREAM; // 0
 

--- a/dspace-api/src/main/java/org/dspace/uclouvain/consumer/LicenseConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/consumer/LicenseConsumer.java
@@ -7,14 +7,10 @@
  */
 package org.dspace.uclouvain.consumer;
 
-import java.util.Arrays;
-import java.util.List;
-
 import org.dspace.content.Bitstream;
 import org.dspace.content.MetadataFieldName;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.BitstreamService;
-import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.event.Consumer;
 import org.dspace.event.Event;
@@ -31,10 +27,9 @@ import org.dspace.services.factory.DSpaceServicesFactory;
  */
 public class LicenseConsumer implements Consumer {
 
-    static List<Integer> acceptedEvents = Arrays.asList(Event.CREATE, Event.MODIFY_METADATA, Event.MODIFY);
     private MetadataFieldName licenseField;
     private String defaultLicenseUrl;
-    private boolean enableDefault;
+    private boolean defaultLicenseEnabled;
     private BitstreamService bitstreamService;
 
     @Override
@@ -43,7 +38,7 @@ public class LicenseConsumer implements Consumer {
 
         ConfigurationService configService = DSpaceServicesFactory.getInstance().getConfigurationService();
         defaultLicenseUrl = configService.getProperty("bitstream.upload.default.license.url");
-        enableDefault = configService.getBooleanProperty("bitstream.upload.default.license.enabled", false);
+        defaultLicenseEnabled = configService.getBooleanProperty("bitstream.upload.default.license.enabled", false);
         licenseField = new MetadataFieldName(configService.getProperty(
                 "uclouvain.global.metadata.license.field", "dc.rights.license"));
     }
@@ -51,7 +46,7 @@ public class LicenseConsumer implements Consumer {
     @Override
     public void consume(Context context, Event event) throws Exception {
         // Only process bitstreams that have no license && are being modified
-        if (isEventValid(event) && enableDefault && defaultLicenseUrl != null) {
+        if (defaultLicenseEnabled && defaultLicenseUrl != null) {
             Bitstream bitstream = (Bitstream) event.getSubject(context);
             if (bitstreamService.getMetadataFirstValue(bitstream, licenseField, null) == null) {
                 bitstreamService.setMetadataSingleValue(context, bitstream, licenseField, null, defaultLicenseUrl);
@@ -64,8 +59,4 @@ public class LicenseConsumer implements Consumer {
 
     @Override
     public void finish(Context context) throws Exception {}
-
-    private boolean isEventValid(Event event) {
-        return event.getSubjectType() == Constants.BITSTREAM && acceptedEvents.contains(event.getEventType());
-    }
 }

--- a/dspace/config/modules/uclouvain.cfg
+++ b/dspace/config/modules/uclouvain.cfg
@@ -96,7 +96,7 @@ uclouvain.feature.send_back_to_submitter.store_reason = true
 #-------------- UCLouvain consumers configuration -----------------#
 #------------------------------------------------------------------#
 event.consumer.licensegenerator.class = org.dspace.uclouvain.consumer.LicenseConsumer
-event.consumer.licensegenerator.filters = Bitstream+All
+event.consumer.licensegenerator.filters = Bitstream+Create|Modify_Metadata|Modify
 
 event.consumer.accesstype.class = org.dspace.uclouvain.consumer.AccessTypeConsumer
 event.consumer.accesstype.filters = Bitstream+All


### PR DESCRIPTION
When a bitstream is deleted, this bitstream doesn't always have any parent object (Bitstream related to Process are in this case).

Authored-by: Renaud Michotte <renaud.michotte@uclouvain.be>

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module