### PR TITLE
[ADD] feat(general): Store metadata life cycle date.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/WorkspaceItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/WorkspaceItemServiceImpl.java
@@ -131,6 +131,13 @@ public class WorkspaceItemServiceImpl implements WorkspaceItemService {
         }
         item.setSubmitter(context.getCurrentUser());
 
+        // Add `dc.date.created` metadata
+        itemService.setMetadataSingleValue(
+            context, item,
+            MetadataSchemaEnum.DC.getName(), "date", "created", null,
+            DCDate.getCurrent().toString()
+        );
+
         // Now create the policies for the submitter to modify item and contents (bitstreams, bundles)
         int[] actionIds = { Constants.READ, Constants.WRITE, Constants.ADD, Constants.REMOVE, Constants.DELETE };
         for (int actionId : actionIds) {

--- a/dspace-api/src/main/java/org/dspace/uclouvain/xmlworkflow/actions/UCLouvainThesisReviewAction.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/xmlworkflow/actions/UCLouvainThesisReviewAction.java
@@ -26,7 +26,6 @@ import org.dspace.content.Item;
 import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.content.service.BitstreamService;
 import org.dspace.content.service.InstallItemService;
-import org.dspace.content.service.ItemService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.eperson.Group;
@@ -36,7 +35,6 @@ import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.uclouvain.core.mails.ThesisChangeRequestEmail;
 import org.dspace.uclouvain.core.model.MetadataField;
 import org.dspace.uclouvain.plugins.UCLouvainAccessStatusHelper;
-import org.dspace.xmlworkflow.factory.XmlWorkflowServiceFactory;
 import org.dspace.xmlworkflow.service.WorkflowRequirementsService;
 import org.dspace.xmlworkflow.state.Step;
 import org.dspace.xmlworkflow.state.actions.ActionResult;
@@ -61,7 +59,7 @@ public class UCLouvainThesisReviewAction extends ReviewAction {
 
     private Logger logger = LogManager.getLogger(UCLouvainThesisReviewAction.class);
 
-    private ConfigurationService configService = DSpaceServicesFactory.getInstance().getConfigurationService();
+    private final ConfigurationService configService = DSpaceServicesFactory.getInstance().getConfigurationService();
 
     private static final String SUBMITTER_IS_DELETED_PAGE = "submitter_deleted";
     private static final String SUBMIT_APPROVE = "submit_confirm_approve";
@@ -69,7 +67,7 @@ public class UCLouvainThesisReviewAction extends ReviewAction {
     private static final String SUBMIT_WITHDRAW_REJECT = "submit_withdraw_reject";
     private static final String RETURN_TO_SUBMITTER = "submit_return_to_submitter";
 
-    private MetadataField activeRequestField = new MetadataField(this.configService
+    private MetadataField activeRequestField = new MetadataField(configService
             .getProperty("uclouvain.global.metadata.activerequestchange.field"));
 
     @Autowired(required = true)
@@ -82,8 +80,6 @@ public class UCLouvainThesisReviewAction extends ReviewAction {
     private GroupService groupService;
     @Autowired
     private BitstreamService bitstreamService;
-    @Autowired
-    private ItemService itemService;
 
     /**
      * Method executed to map each option to a specific action.
@@ -97,9 +93,9 @@ public class UCLouvainThesisReviewAction extends ReviewAction {
                 case SUBMIT_APPROVE:
                     return processAccept(c, wfi);
                 case SUBMIT_APPROVE_WITHOUT_DIFFUSION:
-                    return this.processAcceptWithoutDiffusion(c, wfi, request);
+                    return processAcceptWithoutDiffusion(c, wfi);
                 case SUBMIT_WITHDRAW_REJECT:
-                    return this.processRejectPage(c, wfi, request);
+                    return processRejectPage(c, wfi, request);
                 case SUBMITTER_IS_DELETED_PAGE:
                     return processSubmitterIsDeletedPage(c, wfi, request);
                 case RETURN_TO_SUBMITTER:
@@ -128,27 +124,38 @@ public class UCLouvainThesisReviewAction extends ReviewAction {
         return options;
     }
 
+    public ActionResult processAccept(Context ctx, XmlWorkflowItem wfi)
+            throws SQLException, AuthorizeException {
+        Item currentItem = wfi.getItem();
+        addValidationDate(ctx, currentItem);
+        return super.processAccept(ctx, wfi);
+    }
+
     /**
      * Process result when option 'SUBMIT_APPROVE_WITHOUT_DIFFUSION' is selected.
      * - First delete all bitstream restrictions and add only administrator access.
      * - Add a new tag to keep a trace of the operation in the 'dc.description.X' metadata field.
-     * If reason is not given => error
+     * @param ctx the application context
+     * @param wfi the workflow item to manage
+     * @return the action to perform to continue item life cycle
      */
-    public ActionResult processAcceptWithoutDiffusion(Context ctx, XmlWorkflowItem wfi, HttpServletRequest request)
+    public ActionResult processAcceptWithoutDiffusion(Context ctx, XmlWorkflowItem wfi)
             throws SQLException, AuthorizeException {
+        // When a manager chooses to approve a publication without any diffusion, we need:
+        //   1) Change bitstreams access restriction: force "admin only" restriction for all bitstreams from ORIGINAL
+        //      bundle
+        //   2) add the "dc.date.validated" metadata
+        //   3) add the "dc.description.provenance" to store item history
         Item currentItem = wfi.getItem();
-        // 1. Change bitstreams access to admin only
-        Group adminGroup = this.groupService.findByName(ctx, "Administrator");
+        Group adminGroup = groupService.findByName(ctx, "Administrator");
         if (adminGroup != null) {
-            // For all bitstream of the bundle 'ORIGINAL' replace the policies to 'ADMIN ONLY'
-            for (Bitstream bitstream: this.bitstreamService.getBitstreamByBundleName(currentItem, "ORIGINAL")) {
+            for (Bitstream bitstream: bitstreamService.getBitstreamByBundleName(currentItem, "ORIGINAL")) {
                 this.restrictBitstream(ctx, bitstream, adminGroup);
             }
         }
-        // 2. Add provenance with the name of the user that performed the action.
-        this.addProvenance(ctx, currentItem,
+        addValidationDate(ctx, currentItem);
+        addProvenance(ctx, currentItem,
                 "Approved with no diffusion for entry into archive by user: '" + ctx.getCurrentUser().getEmail() + "'");
-        this.itemService.update(ctx, currentItem);
         return new ActionResult(ActionResult.TYPE.TYPE_OUTCOME, ActionResult.OUTCOME_COMPLETE);
     }
 
@@ -157,24 +164,25 @@ public class UCLouvainThesisReviewAction extends ReviewAction {
      * - First archive the item.
      * - Once archived, withdrawn it, to be only visible by administrators.
      * 
-     * @param context   The current DSpace context.
-     * @param wfi       The workflow item that is being operated.
-     * @param request   The current request object.
+     * @param ctx the current application context.
+     * @param wfi the workflow item that is being operated.
+     * @param request the current request object.
      * @return An ActionResult object which represents the output of the action.
      * @throws SQLException if any database exception occurred
      * @throws AuthorizeException if any authorization occurred
      */
     @Override
-    public ActionResult processRejectPage(Context context, XmlWorkflowItem wfi, HttpServletRequest request)
+    public ActionResult processRejectPage(Context ctx, XmlWorkflowItem wfi, HttpServletRequest request)
             throws SQLException, AuthorizeException {
-        this.addProvenance(context, wfi.getItem(),
-                "Rejected for entry into archive and placed into withdrawn state by user: '" +
-                        context.getCurrentUser().getEmail() + "'");
-        context.turnOffAuthorisationSystem();
+        Item item = wfi.getItem();
+        addValidationDate(ctx, item);
+        addProvenance(ctx, item, "Rejected for entry into archive and placed into withdrawn state by user: '" +
+            ctx.getCurrentUser().getEmail() + "'");
+        ctx.turnOffAuthorisationSystem();
         // Archive the item, then instantly withdraw it
-        Item archivedItem = this.archive(context, wfi);
-        this.itemService.withdraw(context, archivedItem);
-        context.restoreAuthSystemState();
+        archive(ctx, wfi);
+        itemService.withdraw(ctx, item);
+        ctx.restoreAuthSystemState();
         return new ActionResult(ActionResult.TYPE.TYPE_PAGE);
     }
 
@@ -193,7 +201,7 @@ public class UCLouvainThesisReviewAction extends ReviewAction {
         try {
             context.turnOffAuthorisationSystem();
             // Send the item back to submission state.
-            this.xmlWorkflowService.sendWorkflowItemBackSubmission(
+            xmlWorkflowService.sendWorkflowItemBackSubmission(
                     context, wfi, context.getCurrentUser(), "", "Send back to submitter for modifications");
             // Get the mandatory reason from the request object
             String reason = request.getParameter("reason");
@@ -201,8 +209,8 @@ public class UCLouvainThesisReviewAction extends ReviewAction {
                 return new ActionResult(ActionResult.TYPE.TYPE_CANCEL);
             }
             // Encode the reason in the metadata field
-            this.itemService.setMetadataSingleValue(context, wfi.getItem(), activeRequestField, null, reason);
-            // Send an email to submitter to notify for the change request.
+            itemService.setMetadataSingleValue(context, wfi.getItem(), activeRequestField, null, reason);
+            // Send email to submitter to notify for the change request.
             new ThesisChangeRequestEmail(context, wfi.getItem(), reason).sendEmail();
             context.restoreAuthSystemState();
             return new ActionResult(ActionResult.TYPE.TYPE_SUBMISSION_PAGE);
@@ -214,20 +222,17 @@ public class UCLouvainThesisReviewAction extends ReviewAction {
 
     /**
      * Used to archive an item and remove all metadata related to the workflow.
-     * @param context The current DSpace context.
-     * @param wfi     The workflow item to archive.
-     * @return The archived item.
+     * @param ctx the current application context.
+     * @param wfi the workflow item to archive.
      * @throws SQLException if any database exception occurred
      * @throws AuthorizeException if any authorization occurred
      */
-    private Item archive(Context context, XmlWorkflowItem wfi) throws SQLException, AuthorizeException {
+    private void archive(Context ctx, XmlWorkflowItem wfi) throws SQLException, AuthorizeException {
         Item item = wfi.getItem();
-        workflowItemRoleService.deleteForWorkflowItem(context, wfi);
-        installItemService.installItem(context, wfi);
-        this.itemService.clearMetadata(
-                context, item, WorkflowRequirementsService.WORKFLOW_SCHEMA, Item.ANY, Item.ANY, Item.ANY);
-        this.itemService.update(context, item);
-        return item;
+        workflowItemRoleService.deleteForWorkflowItem(ctx, wfi);
+        installItemService.installItem(ctx, wfi);
+        itemService.clearMetadata(ctx, item, WorkflowRequirementsService.WORKFLOW_SCHEMA, Item.ANY, Item.ANY, Item.ANY);
+        itemService.update(ctx, item);
     }
 
     /**
@@ -263,11 +268,9 @@ public class UCLouvainThesisReviewAction extends ReviewAction {
      */
     private void addProvenance(Context context, Item item, String message) throws SQLException, AuthorizeException {
         String now = DCDate.getCurrent().toString();
-        // Build the message
-        String usersName = XmlWorkflowServiceFactory
-                .getInstance().getXmlWorkflowService().getEPersonName(context.getCurrentUser());
-        String provDescription = getProvenanceStartId() + " " + message + " " + usersName + " on " + now + " (GMT) ";
-        // Add provenance info in the 'dc.description.provenance' field
+        String userName = xmlWorkflowService.getEPersonName(context.getCurrentUser());
+        String provDescription = getProvenanceStartId() + " " + message + " " + userName + " on " + now + " (GMT) ";
+
         context.turnOffAuthorisationSystem();
         this.itemService.addMetadata(
                 context,
@@ -277,6 +280,17 @@ public class UCLouvainThesisReviewAction extends ReviewAction {
                 provDescription
         );
         this.itemService.update(context, item);
+        context.restoreAuthSystemState();
+    }
+
+    private void addValidationDate(Context context, Item item) throws SQLException, AuthorizeException {
+        context.turnOffAuthorisationSystem();
+        itemService.setMetadataSingleValue(
+                context, item,
+                MetadataSchemaEnum.DC.getName(), "date", "validated", null,
+                DCDate.getCurrent().toString()
+        );
+        itemService.update(context, item);
         context.restoreAuthSystemState();
     }
 }

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
@@ -217,6 +217,13 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
             wfi.setPublishedBefore(wsi.isPublishedBefore());
             xmlWorkflowItemService.update(context, wfi);
 
+            // Force to add "dc.date.submitted" metadata into the item. If a value already exists, override it.
+            itemService.setMetadataSingleValue(
+                context, myitem,
+                MetadataSchemaEnum.DC.getName(), "date", "submitted", null,
+                DCDate.getCurrent().toString()
+            );
+
             removeUserItemPolicies(context, myitem, myitem.getSubmitter());
             if (collectionService.isSharedWorkspace(context, collection)) {
                 removeGroupItemPolicies(context, myitem, collection.getSubmitters());

--- a/dspace/config/registries/uclouvain-additions-types.xml
+++ b/dspace/config/registries/uclouvain-additions-types.xml
@@ -7,9 +7,9 @@
     <!-- DUBLIN CORE SCHEMA -->
     <dc-type>
         <schema>dc</schema>
-        <element>language</element>
-        <qualifier>iso-639-2</qualifier>
-        <scope_note>ISO 639-2 code language</scope_note>
+        <element>date</element>
+        <qualifier>validated</qualifier>
+        <scope_note>Field to store date when a publication is approved/reject by a reviewer</scope_note>
     </dc-type>
     <dc-type>
         <schema>dc</schema>
@@ -28,6 +28,12 @@
         <element>identifier</element>
         <qualifier>fedora</qualifier>
         <scope_note>To store original FedoraCommons PID</scope_note>
+    </dc-type>
+    <dc-type>
+        <schema>dc</schema>
+        <element>language</element>
+        <qualifier>iso-639-2</qualifier>
+        <scope_note>ISO 639-2 code language</scope_note>
     </dc-type>
     <!-- AUTHORS SCHEMA -->
     <dc-schema>

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -806,6 +806,10 @@
                         <ref bean="sortDateIssuedDesc" />
                         <ref bean="sortDateAccessionedAsc" />
                         <ref bean="sortDateAccessionedDesc" />
+                        <!-- Create fake sort fields to create corresponding "*_dt" keys -->
+                        <ref bean="sortDateCreatedDesc"/>
+                        <ref bean="sortDateSubmittedDesc"/>
+                        <ref bean="sortDateValidatedDesc"/>
                     </list>
                 </property>
             </bean>
@@ -4152,6 +4156,24 @@
 		<property name="type" value="date" />
         <property name="defaultSortOrder" value="desc"/>
 	</bean>
+
+    <bean id="sortDateCreatedDesc" class="org.dspace.discovery.configuration.DiscoverySortFieldConfiguration">
+        <property name="metadataField" value="dc.date.created"/>
+        <property name="type" value="date"/>
+        <property name="defaultSortOrder" value="desc"/>
+    </bean>
+
+    <bean id="sortDateSubmittedDesc" class="org.dspace.discovery.configuration.DiscoverySortFieldConfiguration">
+        <property name="metadataField" value="dc.date.submitted"/>
+        <property name="type" value="date"/>
+        <property name="defaultSortOrder" value="desc"/>
+    </bean>
+
+    <bean id="sortDateValidatedDesc" class="org.dspace.discovery.configuration.DiscoverySortFieldConfiguration">
+        <property name="metadataField" value="dc.date.validated"/>
+        <property name="type" value="date"/>
+        <property name="defaultSortOrder" value="desc"/>
+    </bean>
 
     <bean id="sortFamilyName" class="org.dspace.discovery.configuration.DiscoverySortFieldConfiguration">
         <property name="metadataField" value="person.familyName"/>


### PR DESCRIPTION
Stored some timestamp corresponding to object life cycle into the object metadata:
  * dc.date.create: When an workspace is created.
  * dc.date.submitted: When a workspace is submitted into the review workflow process.
  * dc.date.validated: When a workflow is validated and publication is published in public archive.

Authored-by: Renaud Michotte <renaud.mochotte@uclouvain.be>

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module