### PR TITLE
[UPD] feat(Type-Bind): Type-bind can handle multiple fields.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
@@ -13,12 +13,14 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 import org.apache.commons.lang3.StringUtils;
@@ -155,7 +157,7 @@ public class DCInput {
     /**
      * allowed document types
      */
-    private List<String> typeBind = null;
+    private HashMap<String, List<String>> typeBind = null;
 
     /**
      * Settings list for this field
@@ -236,14 +238,16 @@ public class DCInput {
             || "yes".equalsIgnoreCase(closedVocabularyStr);
 
         // parsing of the <type-bind> element (using the colon as split separator)
-        typeBind = new ArrayList<>();
-        String typeBindDef = fieldMap.get("type-bind");
-        if (typeBindDef != null && typeBindDef.trim().length() > 0) {
-            String[] types = typeBindDef.split(",");
-            for (String type : types) {
-                typeBind.add(type.trim());
-            }
-        }
+        typeBind = new HashMap<>();
+        // For each entry in the map, extract the type-bind field and the list of values.
+        fieldMap.entrySet().stream()
+            .filter(entry -> entry.getKey().startsWith("type-bind."))
+            .forEach(entry -> {
+                String typeBindKey = entry.getKey().substring("type-bind.".length());
+                List<String> typeBindValues = Arrays.stream(entry.getValue().split(","))
+                    .map(String::trim).collect(Collectors.toList());
+                typeBind.put(typeBindKey, typeBindValues);
+            });
         style = fieldMap.get("style");
         isRelationshipField = fieldMap.containsKey("relationship-type");
         isMetadataField = fieldMap.containsKey("dc-schema");
@@ -595,17 +599,15 @@ public class DCInput {
     }
 
     /**
-     * Decides if this field is valid for the document type
+     * Decides if this field is valid for the current type binding.
      *
-     * @param typeName Document type name
-     * @return true when there is no type restriction or typeName is allowed
+     * @param typeFields The field name && values for the current document.
+     * @return true when there is no type restriction or when typeFields is allowed.
      */
-    public boolean isAllowedFor(String typeName) {
-        if (typeBind.isEmpty()) {
-            return true;
-        }
-
-        return typeBind.contains(typeName);
+    public boolean isAllowedFor(HashMap<String, String> typeFields) {
+        // For each field/value pair, check that it is allowed for the current configuration.
+        return typeBind.keySet().stream()
+            .allMatch(key -> typeFields.containsKey(key) && typeBind.get(key).contains(typeFields.get(key)));
     }
 
     public String getScope() {
@@ -674,9 +676,9 @@ public class DCInput {
     /**
      * Get the type bind list for use in determining whether
      * to display this field in angular dynamic form building
-     * @return list of bound types
+     * @return Map of bound types
      */
-    public List<String> getTypeBindList() {
+    public HashMap<String, List<String>> getTypeBindMap() {
         return typeBind;
     }
 

--- a/dspace-api/src/main/java/org/dspace/app/util/DCInputSet.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInputSet.java
@@ -8,6 +8,7 @@
 package org.dspace.app.util;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -166,19 +167,19 @@ public class DCInputSet {
      * Scan through every field in every page of the input set
      *
      * @param fieldName    field name
-     * @param documentType doc type
+     * @param documentTypes The current document data for the type fields
      * @return true if the current set has the named field
      */
-    public boolean isFieldPresent(String fieldName, String documentType) {
-        if (documentType == null) {
-            documentType = "";
+    public boolean isFieldPresent(String fieldName, HashMap<String, String> documentTypes) {
+        if (documentTypes == null) {
+            documentTypes = new HashMap<>();
         }
         for (int i = 0; i < inputs.length; i++) {
             for (int j = 0; j < inputs[i].length; j++) {
                 DCInput field = inputs[i][j];
                 String fullName = field.getFieldName();
                 if (fullName.equals(fieldName)) {
-                    if (field.isAllowedFor(documentType)) {
+                    if (field.isAllowedFor(documentTypes)) {
                         return true;
                     }
                 }
@@ -214,10 +215,10 @@ public class DCInputSet {
      *
      * This can be more efficient than isFieldPresent to avoid looping the input set with each check.
      *
-     * @param documentTypeValue     Document type eg. Article, Book
+     * @param documentTypeValues     Document type eg. Article, Book
      * @return                      ArrayList of field names to use in validation
      */
-    public List<String> populateAllowedFieldNames(String documentTypeValue) {
+    public List<String> populateAllowedFieldNames(HashMap<String, String> documentTypeValues) {
         List<String> allowedFieldNames = new ArrayList<>();
         // Before iterating each input for validation, run through all inputs + fields and populate a lookup
         // map with inputs for this type. Because an input can be configured repeatedly in a form (for example
@@ -231,7 +232,7 @@ public class DCInputSet {
                     // values are also in the list and before the stored values.
                     for (int i = 1; i < inputPairs.size(); i += 2) {
                         String fullFieldname = input.getFieldName() + "." + inputPairs.get(i);
-                        if (input.isAllowedFor(documentTypeValue)) {
+                        if (input.isAllowedFor(documentTypeValues)) {
                             if (!allowedFieldNames.contains(fullFieldname)) {
                                 allowedFieldNames.add(fullFieldname);
                             }
@@ -243,7 +244,7 @@ public class DCInputSet {
                         }
                     }
                 } else {
-                    if (input.isAllowedFor(documentTypeValue) && !allowedFieldNames.contains(input.getFieldName())) {
+                    if (input.isAllowedFor(documentTypeValues) && !allowedFieldNames.contains(input.getFieldName())) {
                         allowedFieldNames.add(input.getFieldName());
                     }
                 }

--- a/dspace-api/src/main/java/org/dspace/app/util/DCInputsReader.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInputsReader.java
@@ -560,6 +560,17 @@ public class DCInputsReader {
                         String settingValue = getValue(settingNode);
                         field.put("setting." + settingName, settingValue);
                     }
+                } else if (tagName.equals("type-bind")) {
+                    // Remove the previously set type-bind.
+                    field.remove("type-bind");
+                    // Case to handle "type-bind" field types and the 'type-bind-field' attribute.
+                    String typeBindAttribute = getAttribute(nd, "type-bind-field");
+                    if (typeBindAttribute == null) {
+                        throw new RuntimeException(
+                            "Every type-bind linked field should have its type-bind-field configured."
+                        );
+                    }
+                    field.put("type-bind." + typeBindAttribute, getValue(nd));
                 }
             }
         }

--- a/dspace-api/src/main/java/org/dspace/app/util/TypeBindUtils.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/TypeBindUtils.java
@@ -7,6 +7,8 @@
  */
 package org.dspace.app.util;
 
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
@@ -38,36 +40,44 @@ public class TypeBindUtils {
     private TypeBindUtils() {}
 
     /**
-     * This method gets the field used for type-bind.
+     * This method gets the fields used for type-bind.
      * @return the field used for type-bind.
      */
-    public static String getTypeBindField() {
-        return configurationService.getProperty("submit.type-bind.field", "dc.type");
+    public static List<String> getTypeBindField() {
+        return Arrays.asList(
+            configurationService.getArrayProperty("submit.type-bind.field", new String[]{"dc.type"})
+        );
     }
 
     /**
-     * This method gets the value of the type-bind field from the current item.
-     * @return the value of the type-bind field from the current item.
+     * This method gets the values of the type-bind fields from the current item.
+     * 
+     * @param obj The object to extract type-bind values from.
+     * @return the values for each type-bind fields from the current item.
      */
-    public static String getTypeBindValue(InProgressSubmission<?> obj) {
-        List<MetadataValue> documentType = itemService.getMetadataByMetadataString(
-                obj.getItem(), getTypeBindField());
+    public static HashMap<String, String> getTypeBindValues(InProgressSubmission<?> obj) {
+        HashMap<String, String> response = new HashMap<>();
+        for (String field: getTypeBindField()) {
+            List<MetadataValue> typeBindFieldValues =
+                itemService.getMetadataByMetadataString(obj.getItem(), field);
 
-        // check empty type-bind field
-        if (documentType == null || documentType.isEmpty()
-                || StringUtils.isBlank(documentType.get(0).getValue())) {
-            return null;
+            if (typeBindFieldValues == null || typeBindFieldValues.isEmpty()
+                || StringUtils.isBlank(typeBindFieldValues.get(0).getValue())) {
+                continue;
+            }
+
+            MetadataValue typeBindValue = typeBindFieldValues.get(0);
+
+            boolean isAuthorityAllowed = metadataAuthorityService.isAuthorityAllowed(
+                field.replace(".","_"), Constants.ITEM, obj.getCollection()
+            );
+            if (isAuthorityAllowed && typeBindValue.getAuthority() != null) {
+                response.put(field, typeBindValue.getAuthority());
+                continue;
+            }
+            response.put(field, typeBindValue.getValue());
         }
-
-        MetadataValue typeBindValue = documentType.get(0);
-
-        boolean isAuthorityAllowed = metadataAuthorityService.isAuthorityAllowed(
-                getTypeBindField().replace(".","_"), Constants.ITEM, obj.getCollection());
-        if (isAuthorityAllowed && typeBindValue.getAuthority() != null) {
-            return typeBindValue.getAuthority();
-        }
-
-        return typeBindValue.getValue();
+        return response;
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/validation/MetadataValidator.java
+++ b/dspace-api/src/main/java/org/dspace/validation/MetadataValidator.java
@@ -12,6 +12,7 @@ import static org.dspace.validation.util.ValidationUtils.addError;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
@@ -71,10 +72,11 @@ public class MetadataValidator implements SubmissionStepValidator {
         List<ValidationError> errors = new ArrayList<>();
 
         DCInputSet inputConfig = getDCInputSet(config);
-        String documentType = TypeBindUtils.getTypeBindValue(obj);
+        // Get the type fields and their corresponding values for the current object.
+        HashMap<String, String> typeBindFields = TypeBindUtils.getTypeBindValues(obj);
 
-        // Get list of all field names (including qualdrop names) allowed for this dc.type
-        List<String> allowedFieldNames = inputConfig.populateAllowedFieldNames(documentType);
+        // Get list of all field names (including qualdrop names) allowed for those types
+        List<String> allowedFieldNames = inputConfig.populateAllowedFieldNames(typeBindFields);
 
         for (DCInput[] row : inputConfig.getFields()) {
             for (DCInput input : row) {
@@ -95,7 +97,7 @@ public class MetadataValidator implements SubmissionStepValidator {
 
                         // Check the lookup list. If no other inputs of the same field name allow this type,
                         // then remove. This includes field name without qualifier.
-                        if (!input.isAllowedFor(documentType) &&  (!allowedFieldNames.contains(fullFieldname)
+                        if (!input.isAllowedFor(typeBindFields) &&  (!allowedFieldNames.contains(fullFieldname)
                                 && !allowedFieldNames.contains(input.getFieldName()))) {
                             removeMetadataValues(context, obj.getItem(), mdv);
                         } else {
@@ -124,18 +126,18 @@ public class MetadataValidator implements SubmissionStepValidator {
                 for (String fieldName : fieldsName) {
                     boolean valuesRemoved = false;
                     List<MetadataValue> mdv = itemService.getMetadataByMetadataString(obj.getItem(), fieldName);
-                    if (!input.isAllowedFor(documentType)) {
+                    if (!input.isAllowedFor(typeBindFields)) {
                         // Check the lookup list. If no other inputs of the same field name allow this type,
                         // then remove. Otherwise, do not
                         if (!(allowedFieldNames.contains(fieldName))) {
                             removeMetadataValues(context, obj.getItem(), mdv);
                             valuesRemoved = true;
                             log.debug("Stripping metadata values for " + input.getFieldName() + " on type "
-                                    + documentType + " as it is allowed by another input of the same field " +
+                                    + typeBindFields + " as it is allowed by another input of the same field " +
                                     "name");
                         } else {
                             log.debug("Not removing unallowed metadata values for " + input.getFieldName() + " on type "
-                                    + documentType + " as it is allowed by another input of the same field " +
+                                    + typeBindFields + " as it is allowed by another input of the same field " +
                                     "name");
                         }
                     }
@@ -147,7 +149,7 @@ public class MetadataValidator implements SubmissionStepValidator {
                             && !valuesRemoved) {
                         // Is the input required for *this* type? In other words, are we looking at a required
                         // input that is also allowed for this document type
-                        if (input.isAllowedFor(documentType)) {
+                        if (input.isAllowedFor(typeBindFields)) {
                             // since this field is missing add to list of error
                             // fields
                             addError(errors, ERROR_VALIDATION_REQUIRED,

--- a/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
@@ -140,7 +140,7 @@
          <dc-qualifier>ispartofseries</dc-qualifier>
          <repeatable>true</repeatable>
          <label>Series/Report No.</label>
-         <type-bind>Technical Report</type-bind>
+         <type-bind type-bind-field="dc.type">Technical Report</type-bind>
          <input-type>series</input-type>
          <hint>Enter the series and number assigned to this item by your community.</hint>
          <required></required>
@@ -799,7 +799,7 @@ it, please enter the types and the actual numbers or codes.</hint>
           <repeatable>false</repeatable>
           <required />
           <hint>The publication where this publication is included. E.g. a book chapter lists here the book, a contribution to a conference lists here the conference proceeding.</hint>
-          <type-bind>book part</type-bind>
+          <type-bind type-bind-field="dc.type">book part</type-bind>
         </field>
       </row>
       <row>
@@ -812,7 +812,7 @@ it, please enter the types and the actual numbers or codes.</hint>
           <repeatable>false</repeatable>
           <required />
           <hint>The ISBN of the book/report if it was not found in the system</hint>
-          <type-bind>book part</type-bind>
+          <type-bind type-bind-field="dc.type">book part</type-bind>
         </field>
       </row>
       <row>
@@ -825,7 +825,7 @@ it, please enter the types and the actual numbers or codes.</hint>
           <repeatable>false</repeatable>
           <required />
           <hint>The DOI of the book/report if it was not found in the system</hint>
-          <type-bind>book part</type-bind>
+          <type-bind type-bind-field="dc.type">book part</type-bind>
         </field>
       </row>
       <row>
@@ -874,7 +874,7 @@ it, please enter the types and the actual numbers or codes.</hint>
           <repeatable>false</repeatable>
           <required />
           <hint>The publication object of the review</hint>
-          <type-bind>review,book review</type-bind>
+          <type-bind type-bind-field="dc.type">review,book review</type-bind>
         </field>
       </row>
       <row>
@@ -887,7 +887,7 @@ it, please enter the types and the actual numbers or codes.</hint>
           <repeatable>false</repeatable>
           <required />
           <hint>The ISBN of the reviewed item if it was not found in the system</hint>
-          <type-bind>review,book review</type-bind>
+          <type-bind type-bind-field="dc.type">review,book review</type-bind>
         </field>
       </row>
       <row>
@@ -900,7 +900,7 @@ it, please enter the types and the actual numbers or codes.</hint>
           <repeatable>false</repeatable>
           <required />
           <hint>The DOI of the reviewed item if it was not found in the system</hint>
-          <type-bind>review,book review</type-bind>
+          <type-bind type-bind-field="dc.type">review,book review</type-bind>
         </field>
       </row>
       <row>
@@ -1752,7 +1752,7 @@ it, please enter the types and the actual numbers or codes.</hint>
          <dc-qualifier>isbn</dc-qualifier>
          <repeatable>true</repeatable>
          <label>ISBN</label>
-         <type-bind>Book</type-bind>
+         <type-bind type-bind-field="dc.type">Book</type-bind>
          <input-type>onebox</input-type>
          <hint>Enter the ISBN of the book.</hint>
          <required>An ISBN is required.</required>
@@ -1764,7 +1764,7 @@ it, please enter the types and the actual numbers or codes.</hint>
          <dc-qualifier>isbn</dc-qualifier>
          <repeatable>true</repeatable>
          <label>ISBN of Book</label>
-         <type-bind>Book chapter</type-bind>
+         <type-bind type-bind-field="dc.type">Book chapter</type-bind>
          <input-type>onebox</input-type>
          <hint>Enter the ISBN of the book in which this chapter appears.</hint>
          <required></required>

--- a/dspace-api/src/test/java/org/dspace/app/util/SubmissionConfigTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/SubmissionConfigTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 import org.dspace.AbstractUnitTest;
@@ -84,10 +85,16 @@ public class SubmissionConfigTest extends AbstractUnitTest {
         assertEquals(typeBindSubmissionStepName, submissionStepConfig.getId());
         // Get inputs and allowed fields
         DCInputSet inputConfig = inputReader.getInputsByFormName(submissionStepConfig.getId());
-        List<String> allowedFieldsForBook = inputConfig.populateAllowedFieldNames("Book");
-        List<String> allowedFieldsForBookChapter = inputConfig.populateAllowedFieldNames("Book chapter");
-        List<String> allowedFieldsForArticle = inputConfig.populateAllowedFieldNames("Article");
-        List<String> allowedFieldsForNoType = inputConfig.populateAllowedFieldNames(null);
+        HashMap<String, String> bookTypeBind = new HashMap<>();
+        bookTypeBind.put("dc.type", "Book");
+        List<String> allowedFieldsForBook = inputConfig.populateAllowedFieldNames(bookTypeBind);
+        HashMap<String, String> bookChapterTypeBind = new HashMap<>();
+        bookChapterTypeBind.put("dc.type", "Book chapter");
+        List<String> allowedFieldsForBookChapter = inputConfig.populateAllowedFieldNames(bookChapterTypeBind);
+        HashMap<String, String> articleTypeBind = new HashMap<>();
+        articleTypeBind.put("dc.type", "Article");
+        List<String> allowedFieldsForArticle = inputConfig.populateAllowedFieldNames(articleTypeBind);
+        List<String> allowedFieldsForNoType = inputConfig.populateAllowedFieldNames(new HashMap<>());
         // Book and book chapter should be allowed all 5 fields (each is bound to dc.identifier.isbn)
         assertEquals(allConfiguredFields, allowedFieldsForBook);
         assertEquals(allConfiguredFields, allowedFieldsForBookChapter);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionFormConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionFormConverter.java
@@ -187,7 +187,7 @@ public class SubmissionFormConverter implements DSpaceConverter<DCInputSet, Subm
         inputField.setInput(inputRest);
         if (dcinput.isMetadataField()) {
             inputField.setSelectableMetadata(selectableMetadata);
-            inputField.setTypeBind(dcinput.getTypeBindList());
+            inputField.setTypeBind(dcinput.getTypeBindMap());
         }
         if (dcinput.isRelationshipField()) {
             selectableRelationship = getSelectableRelationships(dcinput);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/SubmissionFormFieldRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/SubmissionFormFieldRest.java
@@ -9,6 +9,7 @@
 package org.dspace.app.rest.model;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -98,7 +99,7 @@ public class SubmissionFormFieldRest {
     /**
      * The list of type bind value
      */
-    private List<String> typeBind;
+    private HashMap<String, List<String>> typeBind;
 
     /**
      * A list of settings defined for this field
@@ -313,11 +314,11 @@ public class SubmissionFormFieldRest {
         this.rows = rows;
     }
 
-    public List<String> getTypeBind() {
+    public HashMap<String, List<String>> getTypeBind() {
         return typeBind;
     }
 
-    public void setTypeBind(List<String> typeBind) {
+    public void setTypeBind(HashMap<String, List<String>> typeBind) {
         this.typeBind = typeBind;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/DescribeStep.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/DescribeStep.java
@@ -8,6 +8,7 @@
 package org.dspace.app.rest.submit.step;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
@@ -85,10 +86,10 @@ public class DescribeStep extends AbstractProcessingStep {
     private void readField(InProgressSubmission obj, SubmissionStepConfig config, DataDescribe data,
                            DCInputSet inputConfig) throws DCInputsReaderException {
 
-        String documentType = TypeBindUtils.getTypeBindValue(obj);
+        HashMap<String, String> typeBindFields = TypeBindUtils.getTypeBindValues(obj);
 
         // Get list of all field names (including qualdrop names) allowed for this dc.type
-        List<String> allowedFieldNames = inputConfig.populateAllowedFieldNames(documentType);
+        List<String> allowedFieldNames = inputConfig.populateAllowedFieldNames(typeBindFields);
 
         // Loop input rows and process submitted metadata
         for (DCInput[] row : inputConfig.getFields()) {

--- a/dspace/config/submission-forms.dtd
+++ b/dspace/config/submission-forms.dtd
@@ -8,12 +8,13 @@
  <!ELEMENT row (field|relation-field)+ >
  <!ATTLIST form name NMTOKEN #REQUIRED>
 
- <!ELEMENT field (dc-schema, dc-element, dc-qualifier?, language?, repeatable?, label, style?, type-bind?, input-type, hint, required?, regex?, vocabulary?, visibility?, readonly?, help?, settings?) >
+ <!ELEMENT field (dc-schema, dc-element, dc-qualifier?, language?, repeatable?, label, style?, type-bind*, input-type, hint, required?, regex?, vocabulary?, visibility?, readonly?, help?, settings?) >
  <!ELEMENT dc-schema (#PCDATA) >
  <!ELEMENT dc-element (#PCDATA) >
  <!ELEMENT dc-qualifier (#PCDATA) >
  <!ELEMENT language (#PCDATA)>
  <!ELEMENT type-bind (#PCDATA) >
+ <!ATTLIST type-bind type-bind-field CDATA #REQUIRED>
 
  <!ELEMENT repeatable (#PCDATA) >
  <!ELEMENT label (#PCDATA) >


### PR DESCRIPTION
## Details:

New type-bind enhancement which allows to set multiple fields as 'type-bind field'.

Changes:
- New attribute in 'submission-form.xml' config file for the tag '<type-bind>'. This attribute allows to define to which field the type-bind values correspond.
- Changed the rest converter behavior for the type-bind configuration. It now returns a map of form `Map<String, List<String>>` instead of just a list of string.
- Updated the validation of fields present in some classes to suit the new system.
- Updated the test for the type-bind functionnality to work with the new system.

## Checklist:

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module