### PR TITLE
[FIX] feat(consumer): Fix FileTypeMetadataEnancherConsumer

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/filetype/consumer/FileTypeMetadataEnhancerConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/app/filetype/consumer/FileTypeMetadataEnhancerConsumer.java
@@ -71,8 +71,7 @@ public class FileTypeMetadataEnhancerConsumer implements Consumer {
         if (Constants.BITSTREAM == event.getSubjectType()) {
             this.handleBitStreamConsumer(
                     ctx,
-                    Optional.ofNullable((Bitstream) event.getObject(ctx))
-                            .orElse(this.loadBitstream(ctx, event)),
+                    this.loadBitstream(ctx, event),
                     event
             );
         } else if (Constants.ITEM == event.getSubjectType() && Event.CREATE == event.getEventType()) {


### PR DESCRIPTION
When a bitstream is deleted, we now send an event with related item in "event object". This causes problem with this consumer than use this object as à Bitstream if it is present.

Authored-by: Renaud Michotte <renaud.michotte@uclouvain.be>
