### PR TITLE
[ADD] feat(comment): Allow legacy comment loading

### DIFF
--- a/dspace-api/src/main/java/org/dspace/uclouvain/content/LegacyComment.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/content/LegacyComment.java
@@ -1,0 +1,63 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.content;
+
+import java.text.ParseException;
+import java.util.Date;
+
+import org.apache.commons.lang.time.DateUtils;
+
+/**
+ * Representation model for a FedoraCommons legacy comment.
+ *
+ * @author Renaud Michotte (renaud.michotte@uclouvain.be)
+ * @version $Revision$
+ */
+public class LegacyComment {
+
+    private static final String[] DATE_PATTERNS = {
+        "yyyy-MM-dd'T'HH:mm:ss.SSSX",  // DateTimeFormatter.ISO_FORMAT
+        "yyyy-MM-dd'T'HH:mm:ssXXX",
+        "yyyy-MM-dd'T'HH:mm:ss'Z'",
+        "yyyy-MM-dd HH:mm:ss",
+        "dd/MM/yyyy HH:mm:ss",
+        "MM-dd-yyyy HH:mm:ss",
+        "yyyy-MM-dd"
+    };
+
+
+    private String writer;
+    private String content;
+    private Date created;
+
+
+    public String getWriter() {
+        return writer;
+    }
+    public void setWriter(String writer) {
+        this.writer = writer;
+    }
+
+    public String getContent() {
+        return content;
+    }
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public Date getCreated() {
+        return created;
+    }
+    public void setCreated(String created) {
+        try {
+            this.created = DateUtils.parseDate(created, DATE_PATTERNS);
+        } catch (ParseException e) {
+            this.created = new Date(0);
+        }
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/content/utils/CommentUtils.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/content/utils/CommentUtils.java
@@ -1,0 +1,70 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.content.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.content.Bitstream;
+import org.dspace.core.Context;
+import org.dspace.storage.bitstore.factory.StorageServiceFactory;
+import org.dspace.storage.bitstore.service.BitstreamStorageService;
+import org.dspace.uclouvain.content.LegacyComment;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+public class CommentUtils {
+
+    private static final Logger log = LogManager.getLogger(CommentUtils.class);
+
+    // Makes sure that utility classes (classes that contain only static methods or fields in their API) do not have
+    // a public constructor.
+    protected CommentUtils() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * This method allows getting comments stored into a FedoraCommons legacy COMMENT bitstream.
+     *
+     * @param context the dspace application context
+     * @param bitstream the COMMENT bitstream to analyze
+     * @return the list of loaded {@link org.dspace.uclouvain.content.LegacyComment}
+     */
+    public static List<LegacyComment> loadLegacyComments(Context context, Bitstream bitstream) {
+        BitstreamStorageService storageService = StorageServiceFactory.getInstance().getBitstreamStorageService();
+        List<LegacyComment> comments = new ArrayList<>();
+
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            DocumentBuilder builder = factory.newDocumentBuilder();
+            Document document = builder.parse(new InputSource(storageService.retrieve(context, bitstream)));
+            NodeList nodeList = document.getElementsByTagName("comment");
+            for (int i = 0; i < nodeList.getLength(); i++) {
+                Element element = (Element) nodeList.item(i);
+                comments.add(buildComment(element));
+            }
+        } catch (Exception e) {
+            log.error("Unable to load legacy comment :: " + e.getMessage(), e);
+        }
+        return comments;
+    }
+
+    private static LegacyComment buildComment(Element xmlElt) {
+        LegacyComment comment = new LegacyComment();
+        comment.setWriter(xmlElt.hasAttribute("writer") ? xmlElt.getAttribute("writer") : "unknown");
+        comment.setContent(xmlElt.getTextContent());
+        comment.setCreated(xmlElt.hasAttribute("timestamp") ? xmlElt.getAttribute("timestamp") : "1970-01-01");
+        return comment;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/packager/DSpaceUCLouvainMETSIngester.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/packager/DSpaceUCLouvainMETSIngester.java
@@ -8,6 +8,7 @@
 package org.dspace.uclouvain.packager;
 
 import static org.dspace.content.crosswalk.XSLTCrosswalk.DIM_NS;
+import static org.dspace.uclouvain.content.utils.CommentUtils.loadLegacyComments;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -41,11 +42,15 @@ import org.dspace.content.packager.METSManifest;
 import org.dspace.content.packager.PackageParameters;
 import org.dspace.content.packager.PackageValidationException;
 import org.dspace.content.service.BitstreamService;
+import org.dspace.content.service.DSpaceObjectService;
 import org.dspace.content.service.MetadataFieldService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.uclouvain.content.LegacyComment;
+import org.dspace.uclouvain.content.service.CommentService;
+import org.dspace.uclouvain.factories.UCLouvainServiceFactory;
 import org.dspace.workflow.WorkflowException;
 import org.jdom2.Content;
 import org.jdom2.Element;
@@ -60,6 +65,7 @@ public class DSpaceUCLouvainMETSIngester extends DSpaceMETSIngester {
     private static final MetadataFieldService metadataFieldService =
             ContentServiceFactory.getInstance().getMetadataFieldService();
     private static final BitstreamService bitstreamService = ContentServiceFactory.getInstance().getBitstreamService();
+    private final CommentService commentService = UCLouvainServiceFactory.getInstance().getCommentService();
 
     private long transformerLastModified = 0;
     private File transformFile;
@@ -203,6 +209,17 @@ public class DSpaceUCLouvainMETSIngester extends DSpaceMETSIngester {
         }
     }
 
+    @Override
+    public void finishObject(Context context, DSpaceObject dso, PackageParameters params)
+            throws PackageValidationException, CrosswalkException, AuthorizeException, SQLException, IOException {
+        // Legacy comments creation
+        //   After loading, the legacy comments are present into bitstreams from "COMMENT" bundle.
+        //   We need to extract each comment to create a corresponding `Comment` DSO into the system.
+        if (dso instanceof Item) {
+            createLegacyComment(context, (Item) dso);
+        }
+    }
+
     // PRIVATE METHODS ========================================================
     /**
      * Find the dmdSec corresponding to a file from a METS Manifest
@@ -341,6 +358,43 @@ public class DSpaceUCLouvainMETSIngester extends DSpaceMETSIngester {
                     confidence);
         } else {
             bitstreamService.addMetadata(context, bitstream, metadataField, lang, field.getText());
+        }
+    }
+
+    /**
+     * Allows creating comments from a legacy source.
+     *   During the SIP ingestion, comments are provided and stored into bitstreams stored into "COMMENT" bundle.
+     *   We need to read these XML bitstream to extract all comments and create related DSpace comments
+     *
+     * @param context the dspace application context
+     * @param item the related item
+     * @throws SQLException if any database exception occurred
+     */
+    private void createLegacyComment(Context context, Item item) throws SQLException {
+        commentService.deleteAllItemComments(context, item);
+        // Get all possible bitstreams containing comments
+        List<Bitstream> commentBitstreams = item.getBundles("COMMENT").stream()
+                .flatMap(bundle -> bundle.getBitstreams().stream())
+                .collect(Collectors.toList());
+        // Extract all comments from
+        List<LegacyComment> legacyComments = commentBitstreams.stream()
+                .flatMap(bitstream -> loadLegacyComments(context, bitstream).stream())
+                .collect(Collectors.toList());
+        for (LegacyComment comment : legacyComments) {
+            commentService.create(context, item, comment.getWriter(), comment.getContent());
+        }
+
+        // We can now safely delete all "comment" bitstream. We can also delete the related bundles
+        commentBitstreams.forEach(b -> safeDeleteDSO(context, b));
+        item.getBundles("COMMENT").forEach(b -> safeDeleteDSO(context, b));
+    }
+
+    private void safeDeleteDSO(Context context, DSpaceObject dso) {
+        try {
+            DSpaceObjectService<DSpaceObject> service = ContentServiceFactory.getInstance().getDSpaceObjectService(dso);
+            service.delete(context, dso);
+        } catch (Exception e) {
+            log.error("Error deleting comment " + dso.getClass().getName() + "@" + dso.getID(), e);
         }
     }
 }


### PR DESCRIPTION
Improves the METS packager to allow ingestion of legacy comment into the DSpace application

Authored-by: Renaud Michotte <renaud.michotte@uclouvain.be>

## Checklist

- [ ] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module