### PR TITLE
[UPD] feat(discovery): Custom facet definition for PR.

### DIFF
--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -710,15 +710,16 @@
         <!--Which sidebar facets are to be displayed (same as defaultConfiguration above)-->
         <property name="sidebarFacets">
             <list>
-                <ref bean="searchFilterType" />
-                <ref bean="graphPublicationByType" />
-                <ref bean="graphPublicationByDate" />
                 <ref bean="searchFilterAuthor" />
-                <ref bean="searchFilterSubject" />
+                <!-- <ref bean="searchFilterType" /> -->
+                <ref bean="searchFilterPublicationType" />
+                <!-- <ref bean="graphPublicationByType" />
+                <ref bean="graphPublicationByDate" /> -->
+                <!-- <ref bean="searchFilterSubject" /> -->
                 <ref bean="searchFilterIssued" />
-                <ref bean="searchFilterContentInOriginalBundle"/>
+                <!-- <ref bean="searchFilterContentInOriginalBundle"/>
                 <ref bean="searchFilterEntityType"/>
-                <ref bean="searchFilterLanguage" />
+                <ref bean="searchFilterLanguage" /> -->
                 <ref bean="searchFilterAccessType"/>
             </list>
         </property>
@@ -728,6 +729,7 @@
         <property name="searchFilters">
             <list>
                 <ref bean="searchFilterType" />
+                <ref bean="searchFilterPublicationType" />
                 <ref bean="graphPublicationByType" />
                 <ref bean="graphPublicationByDate" />
                 <ref bean="searchFilterTitle" />
@@ -772,7 +774,8 @@
                 <!--DSpace-CRIS by default exclude communities and collections from the
 		            global search. Replace the following filter with the commented one if you
 		            prefer the default dspace behavior -->
-                <value>search.resourcetype:Item</value>
+                <!-- DISPLAY ONLY ITEMS THAT HAVE THE 'PUBLICATION' ENTITY TYPE. -->
+                <value>search.resourcetype:Item AND entityType:Publication</value>
                 <value>-withdrawn:true AND -discoverable:false</value>
             </list>
         </property>
@@ -839,7 +842,8 @@
         <property name="sidebarFacets">
             <list>
                 <ref bean="searchFilterObjectNamedType" />
-                <ref bean="searchFilterType" />
+                <!-- <ref bean="searchFilterType" /> -->
+                <ref bean="searchFilterPublicationType" />
                 <ref bean="searchFilterIssued" />
             </list>
         </property>
@@ -848,6 +852,7 @@
             <list>
                 <ref bean="searchFilterObjectNamedType" />
                 <ref bean="searchFilterType" />
+                <ref bean="searchFilterPublicationType" />
                 <ref bean="searchFilterIssued" />
             </list>
         </property>
@@ -1061,9 +1066,10 @@
         <property name="sidebarFacets">
             <list>
                 <ref bean="searchFilterObjectNamedType" />
-                <ref bean="searchFilterType" />
+                <ref bean="searchFilterAuthor" />
+                <!-- <ref bean="searchFilterType" /> -->
                 <ref bean="searchFilterIssued" />
-                <ref bean="searchFilterSubmitter" />
+                <!-- <ref bean="searchFilterSubmitter" /> -->
                 <ref bean="searchFilterAccessType"/>
             </list>
         </property>
@@ -1071,6 +1077,7 @@
         <property name="searchFilters">
             <list>
                 <ref bean="searchFilterObjectNamedType" />
+                <ref bean="searchFilterAuthor" />
                 <ref bean="searchFilterType" />
                 <ref bean="searchFilterIssued" />
                 <ref bean="searchFilterSubmitter" />
@@ -2850,6 +2857,7 @@
                 <value>dcterms.accessRights</value>
             </list>
         </property>
+        <property name="exposeFilter" value="false"/>
     </bean>
 
     <bean id="searchFilterDiscoverable" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
@@ -3200,6 +3208,16 @@
         <property name="metadataFields">
             <list/>
         </property>
+    </bean>
+
+    <bean id="searchFilterPublicationType" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
+        <property name="indexFieldName" value="itempublicationtype" />
+        <property name="metadataFields">
+            <list>
+                <value>dc.type.maintype</value>
+            </list>
+        </property>
+        <property name="exposeFilter" value="false"/>
     </bean>
 
     <bean id="searchFilterType" class="org.dspace.discovery.configuration.HierarchicalSidebarFacetConfiguration">


### PR DESCRIPTION
- Modified the facets for the global search and removed the filter option for some of them.
- Modified the displayed facets in the dashboard for the workflow configuration.
- Changed the filters for the solr query in order to just retrieve the items that have a 'Publication' entity type.

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module