### PR TITLE
[UPD] feat(init-script): 'researcher' group can submit publications.

### DIFF
--- a/scripts/config/permissions.json
+++ b/scripts/config/permissions.json
@@ -1,5 +1,13 @@
 {
     "collections": [{
+        "collection_name": "Publication",
+        "permissions": [{
+            "type": "submitter",
+            "groups": [
+                "Researcher"
+            ]
+        }]
+    }, {
         "collection_name": "OrgUnit",
         "permissions": [{
             "type": "submitter",

--- a/scripts/config/users.json
+++ b/scripts/config/users.json
@@ -21,7 +21,7 @@
         "email": "user1@dspace.org",
         "lastname": "Affeu",
         "firstname": "Pierre",
-        "groups": [],
+        "groups": ["Researcher"],
         "password": "user"
     }, {
         "email": "user2@dspace.org",


### PR DESCRIPTION
Nobody could submit in the publication collection apart from admins. Added a new group to fix that. This group is configured to be able to submit in the 'Publication' collection. The user 'user1@dspace.org' is a member of this group by default.

Authored-by: Michaël Pourbaix <michael.pourbaix@uclouvain.be>

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module