### PR TITLE
[ADD] feat(authz): Creates `CanCreateWorkspace` feature

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/AuthorizeUtil.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/AuthorizeUtil.java
@@ -35,6 +35,7 @@ import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.GroupService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.utils.DSpace;
+import org.dspace.workflow.WorkflowItemService;
 import org.dspace.xmlworkflow.factory.XmlWorkflowServiceFactory;
 import org.dspace.xmlworkflow.storedcomponents.CollectionRole;
 import org.dspace.xmlworkflow.storedcomponents.service.CollectionRoleService;
@@ -711,5 +712,34 @@ public class AuthorizeUtil {
             isAble = true;
         }
         return isAble;
+    }
+
+    public static boolean canCreateNewWorkspaceInCollection(Context context, Collection collection)
+        throws SQLException {
+        // 1) Check UNRESTRICTED_SUBMISSION group exists
+        //    If such a group with this name exists, then some restriction could be applicable.
+        //    If not, then no limitation could be determined.
+        GroupService groupService = EPersonServiceFactory.getInstance().getGroupService();
+        String groupName = "COLLECTION_" + collection.getID() + "_UNRESTRICTED_SUBMISSION";
+        Group group = groupService.findByName(context, groupName);
+        if (group == null) {
+            return true;
+        }
+        // 2) Check current user is member of the group
+        //    If the current-logged user is member of the previously found group, we can stop additional check.
+        if (groupService.isMember(context, group)) {
+            return true;
+        }
+        // 3) Is any workflow item exists?
+        //    At this time, the current-logged user is allowed to submit only one not-archived object.
+        //    Check any workflow item exists for the current-logged user in this collection.
+        //    No need to check about workspace item (if any exists, then the API should return it).
+        WorkflowItemService<?> workflowService = XmlWorkflowServiceFactory.getInstance().getWorkflowItemService();
+        boolean workflowExists = workflowService
+            .findBySubmitter(context, context.getCurrentUser())
+            .stream()
+            .anyMatch(i -> i.getCollection().equals(collection));
+        return !workflowExists;
+
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CreateCollectionWorkspaceFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CreateCollectionWorkspaceFeature.java
@@ -1,0 +1,53 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization.impl;
+
+import java.sql.SQLException;
+
+import org.dspace.app.rest.authorization.AuthorizationFeature;
+import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;
+import org.dspace.app.rest.model.BaseObjectRest;
+import org.dspace.app.rest.model.CollectionRest;
+import org.dspace.app.rest.utils.Utils;
+import org.dspace.app.util.AuthorizeUtil;
+import org.dspace.content.Collection;
+import org.dspace.core.Context;
+import org.dspace.discovery.SearchServiceException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+@AuthorizationFeatureDocumentation(
+    name = CreateCollectionWorkspaceFeature.NAME,
+    description = "It can be used to verify if a user can create a new workspace into a specific collection."
+)
+public class CreateCollectionWorkspaceFeature implements AuthorizationFeature {
+
+    public static final String NAME = "canCreateCollectionWorkspace";
+
+    @Autowired
+    private Utils utils;
+
+    @Override
+    public boolean isAuthorized(Context context, BaseObjectRest object) throws SQLException, SearchServiceException {
+        if (object instanceof CollectionRest) {
+            try {
+                Collection collection = (Collection)utils.getDSpaceAPIObjectFromRest(context, object);
+                return AuthorizeUtil.canCreateNewWorkspaceInCollection(context, collection);
+            } catch (Exception e) {
+                return false;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String[] getSupportedTypes() {
+        return new String[] { CollectionRest.CATEGORY + "." + CollectionRest.NAME };
+    }
+}


### PR DESCRIPTION
* Dissallows creation of new workspace item if current-logged user already have a submitted item not yet validated.
* Closes bibsys/DSpace#198

Authored-by: Renaud Michotte <renaud.michotte@uclouvain.be>

## Checklist

- [ ] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module