### PR TITLE
[UPD] feat(init-script): 'authenticated-users' group can submit publications.

### DIFF
--- a/scripts/config/permissions.json
+++ b/scripts/config/permissions.json
@@ -1,5 +1,13 @@
 {
     "collections": [{
+        "collection_name": "Publication",
+        "permissions": [{
+            "type": "submitter",
+            "groups": [
+                "authenticated_users"
+            ]
+        }]
+    }, {
         "collection_name": "OrgUnit",
         "permissions": [{
             "type": "submitter",

--- a/scripts/config/users.json
+++ b/scripts/config/users.json
@@ -4,6 +4,11 @@
         "lastname": "Bambelle",
         "firstname": "Larry",
         "password": "admin"
+    }, {
+        "email": "import@dspace.org",
+        "lastname": "Importer",
+        "firstname": "Batch",
+        "password": "import"
     }],
     "users":[{
         "email": "manager@dspace.org",
@@ -21,7 +26,7 @@
         "email": "user1@dspace.org",
         "lastname": "Affeu",
         "firstname": "Pierre",
-        "groups": [],
+        "groups": ["authenticated_users"],
         "password": "user"
     }, {
         "email": "user2@dspace.org",


### PR DESCRIPTION
Nobody could submit in the publication collection appart from admins. Added a new group to fix that. This group is configured to be able to submit in the 'Publication' collection. The user 'user1@dspace.org' is a member of this group by default. Also added an admin user to use for imports (import@dspace.org).

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module

### Rewritting of https://github.com/bibsys/DSpace/pull/174