### PR TITLE
[UPD] feat(CLI): Manage sepcific permission for collection.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/uclouvain/administer/CollectionPermissionManagement.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/administer/CollectionPermissionManagement.java
@@ -8,13 +8,19 @@
 package org.dspace.uclouvain.administer;
 
 import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.MissingArgumentException;
 import org.apache.commons.cli.Option;
+import org.dspace.authorize.ResourcePolicy;
+import org.dspace.authorize.factory.AuthorizeServiceFactory;
+import org.dspace.authorize.service.ResourcePolicyService;
 import org.dspace.content.Collection;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.CollectionService;
+import org.dspace.core.Constants;
 import org.dspace.discovery.DiscoverQuery;
 import org.dspace.discovery.DiscoverResult;
 import org.dspace.discovery.SearchService;
@@ -29,22 +35,26 @@ import org.dspace.workflow.factory.WorkflowServiceFactory;
 
 /**
  * A command-line tool to manage permissions about a DSpace collection.
- * It allows adding/removing add/remove permission for a roleType for an ePerson group.
+ * It allows:
+ *  - Adding/removing permission for a roleType for an ePerson group.
+ *  - Adding/removing a specific permission for an ePerson group.
  * To give an ePerson some management option on this group, this ePerson must be a member of the previous-named group.
  *
  * USAGE:
  *   dspace dsrun org.dspace.uclouvain.administer.CollectionPermissionManagement -c [collection_name] \
- *     -r [role_type] -g [group_name] [--enable|--disable]
+ *     -p [permission] -g [group_name] -m [mode] [--enable|--disable]
  *
  * ARGUMENTS:
  *   -c --collection:  the collection name
- *   -r, --role:       the role type (workflow group name)
+ *   -p, --permission: the role type (workflow group name)
  *   -g, --group:      the group name to enable/disable.
+ *   -m, --mode        the mode to use for permission management ('permission' or 'role')
  *   --enable:         enable the collection management permission
  *   --disable:        disable the collection management permission
  *   -h, --help:       display collection-permission-management options.
  *
  * @author Renaud Michotte (renaud.michotte@uclouvain.be)
+ * @co-authored Michaël Pourbaix (michael.pourbaix@uclouvain.be)
  * @version $Revision$
  */
 public class CollectionPermissionManagement extends AbstractCLICommand {
@@ -54,6 +64,22 @@ public class CollectionPermissionManagement extends AbstractCLICommand {
     public static final String USAGE_DESCRIPTION = "A command-line tool for managing collection permissions";
     public static final String ACTION_ENABLE = "enable";
     public static final String ACTION_DISABLE = "disable";
+    // Available modes
+    public static final String ROLE_MODE = "role";
+    public static final String PERMISSION_MODE = "permission";
+    // Available permissions for this CLI
+    public static final Map<String, Integer> PERMISSIONS_MAP = Map.of(
+        "read", Constants.READ,
+        "write", Constants.WRITE,
+        "delete", Constants.DELETE,
+        "remove", Constants.REMOVE,
+        "add", Constants.ADD,
+        "admin", Constants.ADMIN,
+        "withdraw_read", Constants.WITHDRAWN_READ,
+        "default_bitstream_read", Constants.DEFAULT_BITSTREAM_READ,
+        "default_item_read", Constants.DEFAULT_ITEM_READ
+    );
+
     /** CLI available options */
     private static final Option OPT_COLLECTION_NAME = Option.builder("c")
             .longOpt("collection")
@@ -61,16 +87,22 @@ public class CollectionPermissionManagement extends AbstractCLICommand {
             .desc("name of the collection to manage")
             .required(true)
             .build();
-    private static final Option OPT_ROLE_TYPE = Option.builder("r")
-            .longOpt("role")
+    private static final Option OPT_ROLE_TYPE = Option.builder("p")
+            .longOpt("permission")
             .hasArg(true)
-            .desc("role type to manage (aka. workflow group)")
+            .desc("role type to manage or the permission to add")
             .required(true)
             .build();
     private static final Option OPT_GROUP_NAME = Option.builder("g")
             .longOpt("group")
             .hasArg(true)
             .desc("group name to enable/disable")
+            .required(true)
+            .build();
+    private static final Option OPT_MODE = Option.builder("m")
+            .longOpt("mode")
+            .hasArg(true)
+            .desc("The mode of permission to use ('permission' or 'role')")
             .required(true)
             .build();
     private static final Option OPT_ACTION_ENABLE = Option.builder(null)
@@ -87,6 +119,7 @@ public class CollectionPermissionManagement extends AbstractCLICommand {
     protected CollectionService collectionService;
     protected WorkflowService workflowService;
     protected SearchService searchService;
+    protected ResourcePolicyService resourcePolicyService;
 
     // CONSTRUCTOR & MAIN ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     protected CollectionPermissionManagement() {
@@ -95,6 +128,7 @@ public class CollectionPermissionManagement extends AbstractCLICommand {
         collectionService = ContentServiceFactory.getInstance().getCollectionService();
         workflowService = WorkflowServiceFactory.getInstance().getWorkflowService();
         searchService = new DSpace().getSingletonService(SearchService.class);
+        resourcePolicyService = AuthorizeServiceFactory.getInstance().getResourcePolicyService();
     }
 
     /**
@@ -109,13 +143,16 @@ public class CollectionPermissionManagement extends AbstractCLICommand {
         String action = (cl.hasOption("disable"))
                 ? CollectionPermissionManagement.ACTION_DISABLE
                 : CollectionPermissionManagement.ACTION_ENABLE;
-        cpm.managePermissions(cl.getOptionValue("c"), cl.getOptionValue("r"), cl.getOptionValue("g"), action);
+        cpm.managePermissions(
+            cl.getOptionValue("c"), cl.getOptionValue("p"), cl.getOptionValue("g"), cl.getOptionValue("m"), action
+        );
     }
 
     protected void buildOptions() {
         serviceOptions.addOption(OPT_COLLECTION_NAME);
         serviceOptions.addOption(OPT_ROLE_TYPE);
         serviceOptions.addOption(OPT_GROUP_NAME);
+        serviceOptions.addOption(OPT_MODE);
         serviceOptions.addOption(OPT_ACTION_ENABLE);
         serviceOptions.addOption(OPT_ACTION_DISABLE);
         infoOptions.addOption(OPT_HELP);
@@ -127,17 +164,89 @@ public class CollectionPermissionManagement extends AbstractCLICommand {
 
 
     // PRIVATE METHODS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    private void managePermissions(String collectionName, String workflowRole, String groupName, String action)
-            throws Exception {
+    private void managePermissions(
+        String collectionName, String permission, String groupName, String mode, String action
+    ) throws Exception {
         context.turnOffAuthorisationSystem();
         Collection c = findCollectionByName(collectionName);
-        Group workflowGroup = findWorkflowGroup(c, workflowRole);
         Group memberGroup = findGroupByName(groupName);
 
-        groupService.addMember(context, workflowGroup, memberGroup);
-        groupService.update(context, workflowGroup);
+        switch (mode) {
+            case ROLE_MODE:
+                // ROLE MODE: Find the workflow group and add the member group to it.
+                handleWorkflowRole(c, permission, memberGroup, action);
+                break;
+            case PERMISSION_MODE:
+                // PERMISSION MODE: Create a resource policy and add it to the collection.
+                handlePermission(c, permission, memberGroup, action);
+                break;
+            default:
+                throw new IllegalArgumentException(
+                    String.format("Unsupported mode \"%s\"", mode)
+                );
+        }
         collectionService.update(context, c);
         context.complete();
+    }
+
+    /**
+    * Handle workflow role management for a specific collection.
+    * 
+    * @param c The collection to modify the workflow management for.
+    * @param workflowGroupName The workflow group name to modify.
+    * @param memberGroup The member group to add/remove from the workflow group.
+    * @param action The action to do => add or remove (enable or disable).
+    * @throws Exception
+    */
+    private void handleWorkflowRole(Collection c, String workflowGroupName, Group memberGroup, String action)
+            throws Exception {
+        Group workflowGroup = findWorkflowGroup(c, workflowGroupName);
+        if (action.equals(ACTION_ENABLE)) {
+            groupService.addMember(context, workflowGroup, memberGroup);
+        } else {
+            groupService.removeMember(context, workflowGroup, memberGroup);
+        }
+        groupService.update(context, workflowGroup);
+    }
+
+    /**
+    * Handle a permission addition/removal for a specific group on a given collection.
+    * 
+    * @param c The collection to manage permission for.
+    * @param permission The permission to add/remove to/from the collection.
+    * @param memberGroup the group to add/remove a permission for.
+    * @param action The action to do => add or remove (enable or disable permission).
+    * @throws Exception
+    */
+    private void handlePermission(Collection c, String permission, Group memberGroup, String action) throws Exception {
+        if (!PERMISSIONS_MAP.containsKey(permission)) {
+            throw new IllegalArgumentException(
+                String.format("Unsupported permission \"%s\"", permission)
+            );
+        }
+        if (action.equals(ACTION_ENABLE)) {
+            ResourcePolicy policy = resourcePolicyService.create(context, null, memberGroup);
+            policy.setdSpaceObject(c);
+            policy.setAction(PERMISSIONS_MAP.get(permission));
+            resourcePolicyService.update(context, policy);
+        } else {
+            List<ResourcePolicy> policies =
+                resourcePolicyService.find(context, c, memberGroup, PERMISSIONS_MAP.get(permission));
+            if (policies.size() == 0) {
+                System.out.println(
+                    "No policies found to delete for the given group and action on the specified collection"
+                );
+                return;
+            }
+            policies.forEach((ResourcePolicy rp) -> {
+                try {
+                    resourcePolicyService.delete(context, rp);
+                } catch (Exception e) {
+                    System.out.println("Failed to delete permission policy with id " + rp.getID() + "\n");
+                    System.out.println(e);
+                }
+            });
+        }
     }
 
     /**

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -264,19 +264,21 @@ do
   permissions_length=$(jq ".collections[${i}].permissions | length" "${PERMISSIONS_FILE}")
   for (( j=0; j<permissions_length; j++))
   do
-    workflow_role=$(jq .collections[${i}].permissions[$j].type "${PERMISSIONS_FILE}")
+    permission=$(jq .collections[${i}].permissions[$j].type "${PERMISSIONS_FILE}")
+    mode=$(jq .collections[${i}].permissions[$j].mode "${PERMISSIONS_FILE}")
     groups=$(jq ".collections[${i}].permissions[$j].groups[] | @sh" "${PERMISSIONS_FILE}" \
              | tr -d \' | tr -d \" | awk '{OFS="\n"; $1=$1}1' | sort -u | tr '\n' ",")
     IFS=',' groups=($groups)
     for group_name in "${groups[@]}"
     do
-      echo -en "\tAssigning ${CYAN}${group_name}${NC} to ${CYAN}${collection_name}${NC}.${CYAN}${workflow_role}${NC}..."
+      echo -en "\tAssigning ${CYAN}${group_name}${NC} to ${CYAN}${collection_name}${NC}.${CYAN}${permission}${NC}..."
       docker exec ${BACKEND} sh -c "\
             /dspace/bin/dspace dsrun org.dspace.uclouvain.administer.CollectionPermissionManagement \
             --enable \
             --collection ${collection_name} \
-            --role ${workflow_role} \
-            --group ${group_name}" >> "${LOG_PATH}"
+            --permission ${permission} \
+            --group ${group_name} \
+            --mode ${mode}" >> "${LOG_PATH}"
       if [ $? -ne 0 ]
       then
           error_msg+exit "❌ Error during permission management"


### PR DESCRIPTION
This commit changes the behavior of 'CollectionPermissionManagement':
- Previously, we were only able to manage roles, now we can also manage specific permission for a given group.
- The cli has now a 'mode' argument with two possible values: 'role' and 'permission' which sets the behavior of the CLI.
- Also implemented the 'action' functionnality so that we can remove or add a permission.
- Finaly, updated the 'setup.sh' file to fit the new updates.

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module