### PR TITLE
[ADD] feat(journals) Consumer to set default policies for journal item.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/uclouvain/consumer/JournalDefaultDeletePolicyConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/consumer/JournalDefaultDeletePolicyConsumer.java
@@ -1,0 +1,100 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.consumer;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.authorize.ResourcePolicy;
+import org.dspace.authorize.factory.AuthorizeServiceFactory;
+import org.dspace.authorize.service.ResourcePolicyService;
+import org.dspace.content.Item;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.dspace.eperson.Group;
+import org.dspace.eperson.factory.EPersonServiceFactory;
+import org.dspace.eperson.service.GroupService;
+import org.dspace.event.Consumer;
+import org.dspace.event.Event;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.springframework.util.Assert;
+
+/**
+ * Consumer to add default policies to any created Journal item.
+ * This policies allows the journal managers to delete any Journal item.
+ * 
+ * @author Michaël Pourbaix (michael.pourbaix@uclouvain.be)
+ */
+public class JournalDefaultDeletePolicyConsumer implements Consumer {
+
+    private static final String JOURNAL_ENTITY_TYPE = "Journal";
+
+    // List of action for policies to add to the item when installed.
+    private static final List<Integer> actionsToAdd = Arrays.asList(Constants.DELETE, Constants.REMOVE);
+
+    private ItemService itemService;
+    private ResourcePolicyService resourcePolicyService;
+    private GroupService groupService;
+
+    private String jmgName;
+    private Set<UUID> journalsToProcess = new HashSet<>();
+    private static final Logger logger = LogManager.getLogger(JournalDefaultDeletePolicyConsumer.class);
+
+    @Override
+    public void initialize() throws Exception {
+        itemService = ContentServiceFactory.getInstance().getItemService();
+        resourcePolicyService = AuthorizeServiceFactory.getInstance().getResourcePolicyService();
+        groupService = EPersonServiceFactory.getInstance().getGroupService();
+        ConfigurationService configService = DSpaceServicesFactory.getInstance().getConfigurationService();
+        jmgName = configService.getProperty("event.consumer.journaldefaultdeletepolicy.group");
+        Assert.notNull(jmgName, "Missing setting 'event.consumer.journaldefaultdeletepolicy.group'");
+    }
+
+    @Override
+    public void consume(Context context, Event event) throws Exception {
+        Item item = (Item) event.getSubject(context);
+        // If the created item is a Journal, add its id to the Id to process set.
+        if (JOURNAL_ENTITY_TYPE.equalsIgnoreCase(itemService.getEntityType(item))) {
+            journalsToProcess.add(item.getID());
+        }
+    }
+
+    public void end(Context context) throws Exception {
+        Group journalManagerGroup = groupService.findByName(context, jmgName);
+        Assert.notNull(journalManagerGroup, "Unable to load group " + jmgName);
+        for (UUID journalID: journalsToProcess) {
+            Item journal = itemService.find(context, journalID);
+            for (Integer action: actionsToAdd) {
+                try {
+                    ResourcePolicy deletePolicy = resourcePolicyService.create(context, null, journalManagerGroup);
+                    deletePolicy.setdSpaceObject(journal);
+                    deletePolicy.setAction(action);
+                    resourcePolicyService.update(context, deletePolicy);
+                } catch (Exception e) {
+                    logger.error(
+                        "Could not set default resource policy with id " + action
+                        + " on Journal Item " + journal.getID(),
+                        e
+                    );
+                    continue;
+                }
+            }
+        }
+        journalsToProcess.clear();
+    }
+
+    public void finish(Context ctx) throws Exception {}
+}

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -823,8 +823,8 @@ event.dispatcher.RelatedItemEnhancerUpdatePoller.class = org.dspace.event.BasicD
 # Add rdf here, if you are using dspace-rdf to export your repository content as RDF.
 # Add iiif here, if you are using dspace-iiif.
 # Add orcidqueue here, if the integration with ORCID is configured and wish to enable the synchronization queue functionality
-event.dispatcher.default.consumers = versioning, discovery, eperson, dedup, crisconsumer, orcidqueue, audit, qaeventsdelete, referenceresolver, orcidwebhook, itemenhancer, customurl, iiif, reciprocal, filetypemetadataenhancer, authoritylink, ldnmessage,  licensegenerator, accesstype, authoritymetadataenhancer, formfieldcleaner, fillervalueremover, dissertationyearextract
-event.dispatcher.RelatedItemEnhancerUpdatePoller.consumers = versioning, discovery, eperson, dedup, crisconsumer, orcidqueue, audit, qaeventsdelete, referenceresolver, orcidwebhook, itemenhancer, customurl, iiif, reciprocal, filetypemetadataenhancer, authoritylink, ldnmessage
+event.dispatcher.default.consumers = versioning, discovery, eperson, dedup, crisconsumer, orcidqueue, audit, qaeventsdelete, referenceresolver, orcidwebhook, itemenhancer, customurl, iiif, reciprocal, filetypemetadataenhancer, authoritylink, ldnmessage,  licensegenerator, accesstype, authoritymetadataenhancer, formfieldcleaner, fillervalueremover, dissertationyearextract, journaldefaultdeletepolicy
+event.dispatcher.RelatedItemEnhancerUpdatePoller.consumers = versioning, discovery, eperson, dedup, crisconsumer, orcidqueue, audit, qaeventsdelete, referenceresolver, orcidwebhook, itemenhancer, customurl, iiif, reciprocal, filetypemetadataenhancer, authoritylink, ldnmessage, journaldefaultdeletepolicy
 
 # enable the item enhancer poller
 related-item-enhancer-poller.enabled = true

--- a/dspace/config/modules/uclouvain.cfg
+++ b/dspace/config/modules/uclouvain.cfg
@@ -68,6 +68,11 @@ event.consumer.fillervalueremover.fillers = ^\s*(?i)(n\/?a|not specified|no(t|n)
 event.consumer.dissertationyearextract.class = org.dspace.uclouvain.consumer.DissertationExtractYearConsumer
 event.consumer.dissertationyearextract.filters = Item+Modify_Metadata
 
+event.consumer.journaldefaultdeletepolicy.class = org.dspace.uclouvain.consumer.JournalDefaultDeletePolicyConsumer
+event.consumer.journaldefaultdeletepolicy.filters = Item+Install
+# The group that will be authorized to delete a Journal.
+event.consumer.journaldefaultdeletepolicy.group = Journal manager
+
 #------------------------------------------------------------------#
 #------------- Community/Collection configuration -----------------#
 #------------------------------------------------------------------#


### PR DESCRIPTION
## Description

Added a consumer that sets the required policies to a created journal. This is done to allow a journal manager to delete a journal.

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module