### PR TITLE
[ADD] feat(esb-integration): Controller for user event.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/uclouvain/core/model/PersonEventModel.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/core/model/PersonEventModel.java
@@ -1,0 +1,60 @@
+
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.core.model;
+
+import java.util.Arrays;
+import java.util.List;
+
+/** 
+ * Model representing an event on a person.
+ * @param fgs The id of the person.
+ * @param action The action that has been performed.
+ * @param information Additional information for this event.
+ * 
+ * @author Michaël Pourbaix (michael.pourbaix@uclouvain.be)
+ */
+public class PersonEventModel {
+    private String fgs;
+    private String action;
+    private String information;
+
+    public static final String ACTION_CREATE = "create";
+    public static final String ACTION_UPDATE = "update";
+    public static final String ACTION_DELETE = "delete";
+    public static final List<String> AVAILABLE_ACTIONS = Arrays.asList(
+        ACTION_CREATE,
+        ACTION_UPDATE,
+        ACTION_DELETE
+    );
+
+    // GETTERS && SETTERS
+    public String getFgs() {
+        return this.fgs;
+    }
+
+    public void setFgs(String fgs) {
+        this.fgs = fgs;
+    }
+
+    public String getAction() {
+        return action;
+    }
+
+    public void setAction(String action) {
+        this.action = action;
+    }
+
+    public String getInformation() {
+        return information;
+    }
+
+    public void setInformation(String information) {
+        this.information = information;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/factories/RabbitMQConnectionFactory.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/factories/RabbitMQConnectionFactory.java
@@ -1,0 +1,30 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.factories;
+
+import com.rabbitmq.client.ConnectionFactory;
+import org.dspace.utils.DSpace;
+
+/**
+ * Factory to return a instance of the rabbitMQFactory.
+ * 
+ * @author Michaël Pourbaix (michael.pourbaix@uclouvain.be)
+ */
+public class RabbitMQConnectionFactory {
+    protected RabbitMQConnectionFactory() {
+        throw new UnsupportedOperationException();
+    }
+    public static ConnectionFactory getInstance() {
+        return (ConnectionFactory) (
+            new DSpace()
+                .getServiceManager()
+                .getApplicationContext()
+                .getBean("rabbitConnectionFactory")
+            );
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/rabbitMQ/connectors/PersonEventConnector.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/rabbitMQ/connectors/PersonEventConnector.java
@@ -1,0 +1,40 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.rabbitMQ.connectors;
+
+import java.io.IOException;
+
+import com.rabbitmq.client.Channel;
+
+/**
+ * Specific RabbitMQ connector to work with person event queue.
+ * 
+ * @author Michaël Pourbaix (michael.pourbaix@uclouvain.be)
+ */
+public class PersonEventConnector extends RabbitMQGenericConnector {
+    protected String queueName = configService.getProperty("uclouvain.person_event.rabbit.queue");
+
+    public Channel getChannel() throws IOException {
+        Channel channel = rabbitClient.createChannel();
+        channel.queueDeclare(queueName, true, false, false, null);
+        channel.basicQos(1);
+        return channel;
+    }
+
+    protected void publishMessage(Channel channel, String message) throws IOException {
+        channel.basicPublish("", queueName, null, message.getBytes());
+    }
+
+    public String getQueueName() {
+        return queueName;
+    }
+
+    public void setQueueName(String queueName) {
+        this.queueName = queueName;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/rabbitMQ/connectors/RabbitMQGenericConnector.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/rabbitMQ/connectors/RabbitMQGenericConnector.java
@@ -1,0 +1,65 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.rabbitMQ.connectors;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.uclouvain.factories.RabbitMQConnectionFactory;
+
+/**
+ * Abstract rabbitMQ connector to perform basic action on a queue.
+ * 
+ * @author Michaël Pourbaix (michael.pourbaix@uclouvain.be)
+ */
+public abstract class RabbitMQGenericConnector {
+    protected Connection rabbitClient = getRabbitMQConnection();
+    protected ConfigurationService configService = DSpaceServicesFactory.getInstance().getConfigurationService();
+
+    /**
+     * Publish a basic JSON message to RabbitMQ queue.
+     * @param message An object that will be converted to a JSON string.
+     * @throws IOException
+     */
+    public void publishJSONMessage(Object message) throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+        String jsonEncoded = objectMapper.writeValueAsString(message);
+        // Get a channel for RabbitMQ;
+        Channel eventChannel = getChannel();
+        // Publish event into queue.
+        publishMessage(eventChannel, jsonEncoded);
+    }
+
+    /**
+     * Retrieve a channel for a rabbitMQ connection.
+     */
+    public abstract Channel getChannel() throws Exception;
+    /**
+     * Publish a message using the provided channel.
+     * @param channel The channel to use to publish the message.
+     * @param message The message string to publish to RabbitMQ.
+     */
+    protected abstract void publishMessage(Channel channel, String message) throws Exception;
+
+    /**
+     * Retrieve a connection to RabbitMQ server.
+     *
+     * @return A connection to RabbitMQ.
+     */
+    static protected Connection getRabbitMQConnection() {
+        try {
+            return RabbitMQConnectionFactory.getInstance().newConnection();
+        } catch (Exception e) {
+            throw new RuntimeException("Could not retrieve RabbitMQ client connection.", e);
+        }
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/ApplicationConfig.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/ApplicationConfig.java
@@ -29,6 +29,7 @@ import org.springframework.context.annotation.Configuration;
 // the parent, it won't be so configured in this context and you may have
 // trouble.  Be careful what you add here.
 @ComponentScan( {
+    "org.dspace.uclouvain.rest",
     "org.dspace.app.rest.converter",
     "org.dspace.app.rest.repository",
     "org.dspace.app.rest.utils",

--- a/dspace-server-webapp/src/main/java/org/dspace/uclouvain/rest/ESBController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/uclouvain/rest/ESBController.java
@@ -1,0 +1,62 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.rest;
+
+import org.apache.http.HttpStatus;
+import org.dspace.uclouvain.core.model.PersonEventModel;
+import org.dspace.uclouvain.rabbitMQ.connectors.PersonEventConnector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Main esb endpoints for interactions with our DSpace system.
+ * 
+ * @author Michaël Pourbaix (michael.pourbaix@uclouvain.be)
+ */
+@RestController
+@RequestMapping("/api/uclouvain/esb")
+public class ESBController {
+    private static final Logger logger = LoggerFactory.getLogger(ESBController.class);
+    private PersonEventConnector connector = new PersonEventConnector();
+
+    /**
+     * Handle the posting of a new event into DSpace RabbitMQ event queue.
+     * This endpoint will be used by ESB to send us a user event.
+     * After the event has been store in RabbitMQ, further more processing can be done on it.
+     * 
+     * @param event The request containing event information.
+     * @return A ResponseEntity object signaling the success or failure of the request.
+     */
+    @RequestMapping(method = RequestMethod.POST, value = "/person/event")
+    public ResponseEntity<?> postPersonEvent(@RequestBody PersonEventModel event) {
+        String action = event.getAction();
+        // Check that action is valid before processing event.
+        if (!PersonEventModel.AVAILABLE_ACTIONS.contains(action)) {
+            logger.warn("Wrong action type detected on ESB event: " + action);
+            return ResponseEntity.status(HttpStatus.SC_BAD_REQUEST).body(
+                "Only " + String.join(", ", PersonEventModel.AVAILABLE_ACTIONS) + " action types are valid."
+            );
+        }
+        try {
+            // Publish the message into rabbit.
+            connector.publishJSONMessage(event);
+            return ResponseEntity.status(HttpStatus.SC_CREATED).body("Event handled correctly.");
+        } catch (Exception e) {
+            logger.error("Cloud not process an event sent from ESB: "
+                + "Action: " + event.getAction() + " FSG: " + event.getFgs()
+                + " Information: " + event.getInformation(), e
+            );
+            return ResponseEntity.internalServerError().body("Error while processing event.");
+        }
+    }
+}

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1868,6 +1868,7 @@ item-correction.enabled = true
 
 ### CSRF configuration ####
 csrf.ignore-paths = /api/cris/orcid/{orcid:[0-9]+}/webhook/**
+csrf.ignore-paths = /api/uclouvain/esb/person/event
 
 ##Configuration of OpenAIREProjectAuthority
 openaire-project.authority.prefix = will be generated::OPENAIRE-PROJECT-ID::

--- a/dspace/config/modules/uclouvain.cfg
+++ b/dspace/config/modules/uclouvain.cfg
@@ -105,3 +105,8 @@ uclouvain.notify_authors.mail.metadata = dc.title
 uclouvain.notify_authors.mail.metadata = dc.date.issued
 uclouvain.notify_authors.mail.metadata = dc.contributor.author
 uclouvain.notify_authors.mail.metadata = dc.description.abstract
+
+#--------------------------------------------------------------#
+#--------------- ESB Person Event Configuration ---------------#
+#--------------------------------------------------------------#
+uclouvain.person_event.rabbit.queue = person_event


### PR DESCRIPTION
Added a new controller that allows ESB to notify DSpace of a user event. The received event is then pushed into a RabbitMQ queue for further processing.

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module