### PR TITLE
[ADD] feat(person-ingest): CLI to ingest events from a rabbit queue to DSpace.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/uclouvain/profileIngester/ProfileIngesterCLI.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/profileIngester/ProfileIngesterCLI.java
@@ -1,0 +1,195 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.profileIngester;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import java.util.concurrent.TimeoutException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.DeliverCallback;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.logging.log4j.ThreadContext;
+import org.dspace.core.Context;
+import org.dspace.eperson.EPerson;
+import org.dspace.eperson.factory.EPersonServiceFactory;
+import org.dspace.eperson.service.EPersonService;
+import org.dspace.profile.service.ResearcherProfileService;
+import org.dspace.services.ConfigurationService;
+import org.dspace.uclouvain.administer.AbstractCLICommand;
+import org.dspace.uclouvain.core.model.PersonEventModel;
+import org.dspace.uclouvain.exceptions.UserNotFoundException;
+import org.dspace.uclouvain.rabbitMQ.connectors.PersonEventConnector;
+import org.dspace.uclouvain.rabbitMQ.connectors.PersonEventErrorConnector;
+import org.dspace.utils.DSpace;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * CLI to track user events from RabbitMQ and update corresponding researcher profile.
+ * The event action type present in Rabbit determines the action to perform on the researcher profile.
+ * This CLI can be executed multiple times together to increased processing rate.
+ * 
+ * @author Michaël Pourbaix (michael.pourbaix@uclouvain.be)
+ */
+public class ProfileIngesterCLI extends AbstractCLICommand {
+
+    private static final Option OPT_PERSON = Option.builder("e")
+        .longOpt("eperson")
+        .hasArg(true)
+        .desc("email address of eperson doing importing.")
+        .required(true)
+        .build();
+    private static final Option OPT_ERROR_QUEUE_NAME = Option.builder("eq")
+        .longOpt("error_queue")
+        .hasArg(true)
+        .desc("RabbitMQ error queue name to store potential errors. (Defaults to {queue_name + '_error'})")
+        .required(false)
+        .build();
+    public static final String USAGE_DESCRIPTION =
+        "A command-line tool to listen for person event and process corresponding action in DSpace.";
+
+    private static final Logger logger = LoggerFactory.getLogger(ProfileIngesterCLI.class);
+
+    // EXTERNAL SERVICES
+    protected EPersonService ePersonService;
+    protected ResearcherProfileService researcherProfileService;
+    protected ConfigurationService configService;
+    protected PersonEventConnector personEventConnector;
+
+    // CONSTRUCTOR------------------------------------------------
+    ProfileIngesterCLI() throws IOException, TimeoutException {
+        researcherProfileService = new DSpace().getSingletonService(ResearcherProfileService.class);
+    }
+
+    // COMMON CLICommand METHODS----------------------------------
+    @Override
+    protected void buildOptions() {
+        serviceOptions.addOption(OPT_PERSON);
+        serviceOptions.addOption(OPT_ERROR_QUEUE_NAME);
+        infoOptions.addOption(OPT_HELP);
+    }
+
+    @Override
+    protected String getUsageDescription() {
+        return USAGE_DESCRIPTION;
+    }
+
+    // METHODS----------------------------------------------------
+    public static void main(String[] arguments) throws Exception {
+        ProfileIngesterCLI profileIngester = new ProfileIngesterCLI();
+        CommandLine cli = profileIngester.validateCLIArgument(arguments);
+
+        PersonEventConnector connector = new PersonEventConnector();
+
+        String epersonEmail = cli.getOptionValue("e");
+        String errorQueueName = cli.getOptionValue("eq", connector.getQueueName() + "_error");
+
+        Context context = new Context();
+        // Get the eperson to use as initiator.
+        EPerson ePerson = EPersonServiceFactory.getInstance().getEPersonService().findByEmail(context, epersonEmail);
+        if (ePerson == null) {
+            throw new UserNotFoundException(epersonEmail);
+        }
+        context.setCurrentUser(ePerson);
+
+        while (true) {
+            try {
+                profileIngester.ingestEvent(context, connector, errorQueueName);
+            } catch (InterruptedException ie) {
+                logger.info("Execution interrupted manually");
+                Thread.currentThread().interrupt();
+                break;
+            } catch (Exception e) {
+                logger.error(e.getMessage(), e);
+            }
+        }
+    }
+
+    /**
+     * Launches the cli ingest process: wait for events in the rabbit queue and do the required action.
+     * @param context The current DSpace context.
+     * @param connector The RabbitMQ connector to use to get event messages from queue.
+     * @param errorQueueName The queue name to post potential error message to.
+     * @throws Exception
+     */
+    private void ingestEvent(Context context, PersonEventConnector connector, String errorQueueName)
+        throws Exception {
+        // Set a random uuid to this thread context to identify this job in the logs.
+        String jobId = UUID.randomUUID().toString();
+        ThreadContext.put("jobId", jobId);
+
+        // Instantiate a rabbit channel to pull events from.
+        Channel channel = connector.getChannel();
+        logger.info("[WAITING FOR MESSAGES] - Press CTRL+C to exit");
+
+        // Create a delivery callback that will be executed for each event that is red.
+        DeliverCallback deliverCallback = (consumerTag, delivery) -> {
+            // Put the jobId again since rabbitMQ creates a new thread context.
+            ThreadContext.put("jobId", jobId);
+            // Extract event data from message.
+            String eventString = new String(delivery.getBody(), StandardCharsets.UTF_8);
+            logger.info("[RECEIVED EVENT] Received '" + eventString + "', started processing...");
+            try {
+                ObjectMapper objectMapper = new ObjectMapper();
+                PersonEventModel event = objectMapper.readValue(eventString, PersonEventModel.class);
+                processEvent(context, event);
+            } catch (Exception e) {
+                logError(errorQueueName, eventString, e);
+            } finally {
+                channel.basicAck(delivery.getEnvelope().getDeliveryTag(), false);
+                ThreadContext.remove("jobId");
+            }
+        };
+        // Use the created callback to consume events on the queue.
+        channel.basicConsume(connector.getQueueName(), false, deliverCallback, consumerTag -> { });
+
+        // Block to keep the application running after the consume.
+        synchronized (this) {
+            try {
+                this.wait();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                context.complete();
+            }
+        }
+    }
+
+    /**
+     * Using the recovered event, try to find and execute a profile action class.
+     * 
+     * @param context The current DSpace context.
+     * @param event The event to get a profile action class for.
+     */
+    private void processEvent(Context context, PersonEventModel event) {
+        // TODO: Process the correct action.
+        System.out.println("Processing event for action: " + event.getAction());
+    }
+
+    /**
+     * Log an error in a specific rabbitMQ queue.
+     * @param queueName The queue to log the error in.
+     * @param event The event that caused the error.
+     * @param cause The error itself.
+     * @throws IOException
+     */
+    private void logError(String queueName, String event, Exception cause) throws IOException {
+        PersonEventErrorConnector errorConnector = new PersonEventErrorConnector(queueName);
+        try {
+            // Push error into specific queue.
+            errorConnector.publishErrorMessage(event, cause);
+        } catch (Exception ignored) {
+            // Ignore this exception if occurs.
+        }
+        logger.error("Cannot process event: " + event, cause);
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/rabbitMQ/connectors/PersonEventErrorConnector.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/rabbitMQ/connectors/PersonEventErrorConnector.java
@@ -1,0 +1,33 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.rabbitMQ.connectors;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Sub-class of {@link PersonEventConnector} to push a potential error to rabbitMQ.
+ */
+public class PersonEventErrorConnector extends PersonEventConnector {
+    public PersonEventErrorConnector(String errorQueueName) {
+        this.queueName = errorQueueName;
+    }
+
+    /**
+     * Publish an error message into the configured rabbit mq error queue.
+     * @param event The event that caused the error.
+     * @param cause The error itself.
+     * @throws Exception
+     */
+    public void publishErrorMessage(String event, Exception cause) throws Exception {
+        Map<String, String> message = new HashMap<>();
+        message.put("event", event);
+        message.put("error", cause.getMessage());
+        this.publishJSONMessage(message);
+    }
+}

--- a/dspace/config/log4j2-cli.xml
+++ b/dspace/config/log4j2-cli.xml
@@ -62,6 +62,26 @@
             </DefaultRolloverStrategy>
             -->
         </Appender>
+
+        <!-- A3 is for person ingester CLI -->
+        <Appender name="A3"
+                  filePattern="${log.dir}/person-ingester.log%d{yyyy-MM-dd}"
+                  type="RollingFile"
+                  fileName="${log.dir}/person-ingester.log">
+            <Layout type='PatternLayout' pattern='%d %-5p (jobID=%X{jobId}{unknown}) -- %c :: %m%n'/>
+            <policies>
+                <policy type='TimeBasedTriggeringPolicy'>yyyy-MM-dd</policy>
+            </policies>
+            <DefaultRolloverStrategy>
+                <Delete basePath='${log.dir}'>
+                    <IfFileName glob='person-ingester.log-*'/>
+                    <IfAccumulatedFileCount exceeds='${logging.server.retention-accumulated-to-keep}'/>
+                </Delete>
+            </DefaultRolloverStrategy>
+        </Appender>
+        <Appender name='Console' type='Console' follow='true'>
+            <Layout type='PatternLayout' pattern='%d %-5p @ %m%n'/>
+        </Appender>
     </Appenders>
 
     <Loggers>
@@ -95,6 +115,15 @@
         <!-- Block passwords from being exposed in Axis logs. (DEBUG exposes passwords in Basic Auth) -->
         <Logger name='org.apache.axis.handlers.http.HTTPAuthHandler'
                 level='INFO'/>
+
+        <!-- Person Event Ingester -->
+        <Logger name="org.dspace.uclouvain.profileIngester"
+                level='INFO'
+                additivity='true'>
+            <AppenderRef ref='A3'/>
+            <!-- <AppenderRef ref='Sentry'/> -->
+            <AppenderRef ref='Console'/>
+        </Logger>
         <!-- Anything not a part of DSpace -->
         <Root level='${loglevel.other}'>
             <AppenderRef ref='A1'/>


### PR DESCRIPTION
## Description

- New CLI to listen for events in a Rabbit queue and process them in DSpace depending on their action type.
- New configuration in log4j2 to log class log messages in both a file and the console.

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module