### PR TITLE
[ADD] feat(affiliations): Affiliation weights for priority.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/uclouvain/administer/OrgUnitImporter.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/administer/OrgUnitImporter.java
@@ -223,6 +223,10 @@ public class OrgUnitImporter extends AbstractCLICommand {
             mdField = metadataFieldService.findByString(context, "organization.parentOrganization", '.');
             itemService.addMetadata(context, item, mdField, null, parent.getName(), parent.getID().toString(), 600);
         }
+
+        // Add a weight (priority level) to the affiliation.
+        mdField = metadataFieldService.findByString(context, "organization.weight", '.');
+        itemService.addMetadata(context, item, mdField, null, String.valueOf(entity.weight));
     }
 
     /**
@@ -257,6 +261,7 @@ class Entity {
     public boolean selectable = true;
     public List<Entity> children;
     public String type;
+    public int weight = 50;
 
     public String toString() {
         return (acronym != null)

--- a/dspace-api/src/main/java/org/dspace/uclouvain/core/model/AffiliationEntityRestModel.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/core/model/AffiliationEntityRestModel.java
@@ -18,6 +18,7 @@ public class AffiliationEntityRestModel {
     public String acronym;
     public String type;
     public boolean isSelectable;
+    public int weight;
     public UUID parent;
     public List<AffiliationEntityRestModel> children = new ArrayList<AffiliationEntityRestModel>();
 
@@ -30,6 +31,7 @@ public class AffiliationEntityRestModel {
         this.acronym = model.acronym;
         this.type = model.type;
         this.isSelectable = model.isSelectable;
+        this.weight = model.weight;
         this.parent = model.parent;
         model.children.forEach(modelChild -> this.children.add(new AffiliationEntityRestModel(modelChild)));
     }

--- a/dspace-api/src/main/java/org/dspace/uclouvain/services/UCLouvainAffiliationEntityRestServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/services/UCLouvainAffiliationEntityRestServiceImpl.java
@@ -101,6 +101,9 @@ public class UCLouvainAffiliationEntityRestServiceImpl implements UCLouvainAffil
                 String selectable = documentExtract(document, "organization.isSelectable");
                 model.isSelectable = (selectable != null) ? selectable.equals("true") : true;
 
+                String weight = documentExtract(document, "organization.weight");
+                model.weight = (weight != null && !weight.isEmpty()) ? Integer.parseInt(weight) : 50;
+
                 // Extract parent UUID
                 String parentAuthority = documentExtract(document, "organization.parentOrganization_authority");
                 try {

--- a/dspace/config/init-sample.xml
+++ b/dspace/config/init-sample.xml
@@ -11,6 +11,14 @@
             <name>OrgUnit</name>
             <entity-type>OrgUnit</entity-type>
             <submission-type>orgunit</submission-type>
+            <templateItem>
+                <metadata schema="organization" element="isSelectable">
+                    <value>true</value>
+                </metadata>
+                <metadata schema="organization" element="weight">
+                    <value>50</value>
+                </metadata>
+            </templateItem>
         </collection>
         <collection identifier="2078.5/Journal">
             <name>Journal</name>

--- a/dspace/config/registries/uclouvain-additions-types.xml
+++ b/dspace/config/registries/uclouvain-additions-types.xml
@@ -339,8 +339,12 @@
     <dc-type>
         <schema>organization</schema>
         <element>isSelectable</element>
-        <qualifier></qualifier>
         <scope_note>Is this entity could be selected when a publication is submitted</scope_note>
+    </dc-type>
+    <dc-type>
+        <schema>organization</schema>
+        <element>weight</element>
+        <scope_note>The weight of the affiliation specifying its priority level.</scope_note>
     </dc-type>
     <!-- PUBLICATION SCHEMA -->
     <dc-schema>

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -575,6 +575,28 @@
       <row>
         <field>
           <dc-schema>organization</dc-schema>
+          <dc-element>isSelectable</dc-element>
+          <label>Selectable</label>
+          <input-type>checkbox</input-type>
+          <hint>The affiliation should be selectable</hint>
+          <settings>
+            <setting name="showFieldLabel">false</setting>
+          </settings>
+        </field>
+      </row>
+      <row>
+        <field>
+          <dc-schema>organization</dc-schema>
+          <dc-element>weight</dc-element>
+          <label>Organization weight</label>
+          <input-type>number</input-type>
+          <hint>The weight of the affiliation specifying its priority level (default is 50).</hint>
+          <required>You must provide a weight for this affiliation.</required>
+        </field>
+      </row>
+      <row>
+        <field>
+          <dc-schema>organization</dc-schema>
           <dc-element>parentOrganization</dc-element>
           <label>Parent Organisation</label>
           <input-type>onebox</input-type>

--- a/scripts/config/entities.json
+++ b/scripts/config/entities.json
@@ -13,6 +13,7 @@
       {
         "name": "Anciens départements (publication pré 2010)",
         "selectable": false,
+        "weight": 60,
         "children": [
           {
             "name": "Département de biologie appliquée et des productions agricoles",
@@ -237,12 +238,14 @@
         ]
       },
       {
-        "name": "Autre"
+        "name": "Autre",
+        "weight": 50
       },
       {
         "name": "Cliniques Universitaires Saint-Luc",
         "acronym": "SLuc",
         "selectable": false,
+        "weight": 65,
         "identifiers": [
           {"type": "ror", "value": "https://ror.org/03s4khd80"},
           {"type": "isni", "value": "http://isni.org/isni/0000000404616320"},
@@ -587,6 +590,7 @@
       {
         "name": "Entités administratives UCL",
         "selectable": false,
+        "weight": 75,
         "children": [
           {
             "name": "Administration des affaires étudiantes",
@@ -644,6 +648,7 @@
         "name": "Mont-Godinne",
         "acronym": "MGD",
         "selectable": false,
+        "weight": 70,
         "identifiers": [
           {"type": "ror", "value": "https://ror.org/00ntbvq76"}
         ],
@@ -804,6 +809,7 @@
         "name": "secteur des sciences humaines",
         "acronym": "SSH",
         "selectable": false,
+        "weight": 90,
         "children": [
           {
             "name": "Institute of Analysis of Change in Contemporary and Historical Societies",
@@ -1009,6 +1015,7 @@
         "name": "Secteur des sciences de la santé",
         "acronym": "SSS",
         "selectable": false,
+        "weight": 85,
         "children": [
           {
             "name": "Institut de Duve",
@@ -1216,6 +1223,7 @@
         "name": "Secteur des sciences et technologies",
         "acronym": "SST",
         "selectable": false,
+        "weight": 80,
         "children": [
           {
             "name": "Centre de ressources du cyclotron",
@@ -1357,11 +1365,13 @@
     ],
     "children": [
       {
-        "name": "Autre"
+        "name": "Autre",
+        "weight": 50
       },
       {
         "name": "Départements",
         "selectable": false,
+        "weight": 60,
         "children": [
           {
             "name": "DRO_Centre Droits fondamentaux et Lien social (DF&amp;LS)"
@@ -1573,6 +1583,7 @@
       {
         "name": "Anciennes dénominations",
         "selectable": false,
+        "weight": 60,
         "children": [
           {
             "name": "Centre d'études sociologiques (CES)"
@@ -1586,11 +1597,13 @@
         ]
       },
       {
-        "name": "Autre"
+        "name": "Autre",
+        "weight": 50
       },
       {
         "name": "Centres et des séminaires de recherche",
         "selectable": false,
+        "weight": 70,
         "children": [
           {
             "name": "Center for Applied Public Economics (CAPE)"
@@ -1669,6 +1682,7 @@
       {
         "name": "Instituts fédérant des centres de recherche et des chercheurs",
         "selectable": false,
+        "weight": 75,
         "children": [
           {
             "name": "Institut d'études européennes (IEE)"
@@ -1684,6 +1698,7 @@
       {
         "name": "Pôle de recherche",
         "selectable": false,
+        "weight": 65,
         "children": [
           {
             "name": "Pôle de recherche en droit privé",


### PR DESCRIPTION
- Added a weight definition for each affiliation to give some priority (default value 50);
- Updated the form to add 2 fields to set the weight and wether an affiliation is selectable;
- Changed the template definition of the OrgUnit collection for weight: 50 and isSelectable: true;
- Updated the orgUnitImporter to handle weight information.

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module