### PR TITLE
[ADD] feat(profile-import): Batch import CLI for user profile.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/uclouvain/core/model/PersonEventModel.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/core/model/PersonEventModel.java
@@ -11,6 +11,8 @@ package org.dspace.uclouvain.core.model;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.commons.lang.StringUtils;
+
 /** 
  * Model representing an event on a person.
  * @param fgs The id of the person.
@@ -44,7 +46,7 @@ public class PersonEventModel {
     }
 
     public void setFgs(String fgs) {
-        this.fgs = fgs;
+        this.fgs = StringUtils.stripStart(fgs, "0");
     }
 
     public String getAction() {

--- a/dspace-api/src/main/java/org/dspace/uclouvain/profileIngester/ProfileBatchImportCLI.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/profileIngester/ProfileBatchImportCLI.java
@@ -1,0 +1,111 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.profileIngester;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.dspace.uclouvain.administer.AbstractCLICommand;
+import org.dspace.uclouvain.core.model.PersonEventModel;
+import org.dspace.uclouvain.rabbitMQ.connectors.PersonEventConnector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * CLI to import a batch of fgs in RabbitMQ for profile ingestion.
+ * The CLI takes a file containing fgs identifiers and pushes events with the given action type in RabbitMQ.
+ * 
+ * @author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+public class ProfileBatchImportCLI extends AbstractCLICommand {
+    private static final Option OPT_FILE = Option.builder("f")
+        .longOpt("file")
+        .hasArg(true)
+        .desc("File path containing fgs to import")
+        .required(true)
+        .build();
+    private static final Option OPT_EVENT_ACTION = Option.builder("ea")
+        .longOpt("event_action")
+        .hasArg(true)
+        .desc("Optional event action to send for each fgs ('create', 'update' or 'delete'). Default is 'create'")
+        .required(false)
+        .build();
+    private static final Option OPT_EVENT_INFORMATION = Option.builder("ei")
+        .longOpt("event_information")
+        .hasArg(true)
+        .desc("Optional event information string to send for each fgs. Default is null")
+        .required(false)
+        .build();
+    public static final String USAGE_DESCRIPTION =
+        "A command-line tool to create events for profile ingester from a file containing fsg identifiers.";
+
+    private static final Logger logger = LoggerFactory.getLogger(ProfileBatchImportCLI.class);
+
+    @Override
+    protected String getUsageDescription() {
+        return USAGE_DESCRIPTION;
+    }
+
+    @Override
+    protected void buildOptions() {
+        serviceOptions.addOption(OPT_FILE);
+        serviceOptions.addOption(OPT_EVENT_ACTION);
+        serviceOptions.addOption(OPT_EVENT_INFORMATION);
+        infoOptions.addOption(OPT_HELP);
+    }
+
+    public static void main(String[] arguments) throws Exception {
+        ProfileBatchImportCLI profileBatchImport = new ProfileBatchImportCLI();
+        CommandLine CLI = profileBatchImport.validateCLIArgument(arguments);
+
+        PersonEventConnector connector = new PersonEventConnector();
+
+        String filePath = CLI.getOptionValue("f");
+        String action = CLI.getOptionValue("ea", PersonEventModel.ACTION_CREATE);
+        String information = CLI.getOptionValue("ei");
+
+        if (!PersonEventModel.AVAILABLE_ACTIONS.contains(action)) {
+            throw new IllegalArgumentException("Invalid event action type :: " + action);
+        }
+
+        profileBatchImport.run(connector, filePath, action, information);
+    }
+
+    /**
+     * Use provided file path to extract the fgs identifiers and create/push events for each one in RabbitMQ.
+     * 
+     * @param connector The RabbitMQ connection to push events to the queue.
+     * @param filePath The path of the file containing the fgs identifiers.
+     * @param action The action to use to craft the event.
+     * @param info Any information to add to the event 'information' property.
+     */
+    public void run(PersonEventConnector connector, String filePath, String action, String info) throws Exception {
+        BufferedReader reader = new BufferedReader(new FileReader(filePath));
+        logger.info("Found file, pushing entries to RabbitMQ...");
+
+        String line;
+        long pushed = 0;
+        while ((line = reader.readLine()) != null) {
+            PersonEventModel event = new PersonEventModel();
+            event.setFgs(line);
+            event.setAction(action);
+            event.setInformation(info);
+            try {
+                connector.publishJSONMessage(event);
+                pushed++;
+            } catch (Exception e) {
+                logger.error("Could not push event in rabbitMQ. " + event + " :"  + e.getLocalizedMessage());
+            }
+        }
+        logger.info("Finished execution, pushed " + pushed + " events to RabbitMQ.");
+        reader.close();
+        connector.closeChannel();
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/profileIngester/actions/CreateOrUpdateProfileAction.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/profileIngester/actions/CreateOrUpdateProfileAction.java
@@ -39,7 +39,7 @@ public class CreateOrUpdateProfileAction extends ProfileAction {
 
     /**
      * Extract the fgs from the provided event:
-     * - If no other profile exist with the fgs, create one using the provided data.
+     * - If no other profile exist with the email, create one by using the provided data.
      * - If a profile already exists, exit the action.
      * Perform a commit in the database only if a change occurred.
      * 
@@ -50,12 +50,14 @@ public class CreateOrUpdateProfileAction extends ProfileAction {
     public void process(Context context, PersonEventModel event) throws ProfileActionException {
         String fgs = event.getFgs();
         try {
-            Item profile = uclouvainProfileService.findById(context, fgs);
             ESBPersonProfile profileData = esbClient.getProfileForFGS(fgs);
             if (profileData.getEmail() == null) {
                 logger.info("[CANCEL PROCESSING] No email found for the fgs \"" + fgs + "\" aborting processing...");
                 return;
             }
+            // Try to find an existing profile with the user email.
+            Item profile = uclouvainProfileService.findByEmail(context, profileData.getEmail());
+
             boolean changed = false;
             if (profile == null) {
                 profile = uclouvainProfileService.createEmptyProfile(context, fgs);

--- a/dspace-api/src/main/java/org/dspace/uclouvain/rabbitMQ/connectors/RabbitMQGenericConnector.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/rabbitMQ/connectors/RabbitMQGenericConnector.java
@@ -8,6 +8,7 @@
 package org.dspace.uclouvain.rabbitMQ.connectors;
 
 import java.io.IOException;
+import java.util.concurrent.TimeoutException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rabbitmq.client.Channel;
@@ -25,8 +26,10 @@ public abstract class RabbitMQGenericConnector {
     protected Connection rabbitClient = getRabbitMQConnection();
     protected ConfigurationService configService = DSpaceServicesFactory.getInstance().getConfigurationService();
 
+    private Channel channel;
+
     /**
-     * Publish a basic JSON message to RabbitMQ queue.
+     * Publish a basic JSON message to a RabbitMQ queue.
      * @param message An object that will be converted to a JSON string.
      * @throws IOException
      */
@@ -34,7 +37,16 @@ public abstract class RabbitMQGenericConnector {
         ObjectMapper objectMapper = new ObjectMapper();
         String jsonEncoded = objectMapper.writeValueAsString(message);
         // Get a channel for RabbitMQ and publish the message into queue.
-        publishMessage(getChannel(), jsonEncoded);
+        if (channel == null || !channel.isOpen()) {
+            channel = getChannel();
+        }
+        publishMessage(channel, jsonEncoded);
+    }
+
+    public void closeChannel() throws IOException, TimeoutException {
+        if (channel != null && channel.isOpen()) {
+            channel.close();
+        }
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/uclouvain/services/UCLouvainProfileService.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/services/UCLouvainProfileService.java
@@ -14,6 +14,7 @@ import org.dspace.core.Context;
 
 public interface UCLouvainProfileService {
     public Item findById(Context context, String fgs) throws Exception;
+    public Item findByEmail(Context context, String email) throws Exception;
     public List<Item> findLinkedPublications(Context context, Item profile) throws Exception;
     public Item createEmptyProfile(Context context, String fgs) throws Exception;
 }

--- a/dspace-api/src/main/java/org/dspace/uclouvain/services/UCLouvainProfileServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/services/UCLouvainProfileServiceImpl.java
@@ -61,12 +61,36 @@ public class UCLouvainProfileServiceImpl implements UCLouvainProfileService {
      * @return Returns the profile that has the given identifier, null otherwise.
      */
     public Item findById(Context context, String fgs) throws Exception {
+        // Add the fgs as a filter
+        return findOneByAttribute(context, "person.identifier.fgs:" + fgs);
+    }
+
+    /**
+     * Find a profile item using an email. Returns null if nothing is found.
+     * 
+     * @param context The current DSpace context.
+     * @param email The email to use in order to find the right profile.
+     * @return Returns the profile that has the given email, null otherwise.
+     */
+    public Item findByEmail(Context context, String email) throws Exception {
+        // Add the email as a filter
+        return findOneByAttribute(context, "person.email:" + email);
+    }
+
+    /**
+     * Find a profile item using a given attribute filter. Returns null if nothing is found.
+     * 
+     * @param context The current DSpace context.
+     * @param attributeFilter The filter to use to find a specific profile item.
+     * @return Returns the profile that passes the given filter, null if nothing found.
+     */
+    private Item findOneByAttribute(Context context, String attributeFilter) throws Exception {
         DiscoverQuery dq = new DiscoverQuery();
         // Take only archived items.
         dq.addDSpaceObjectFilter(IndexableItem.TYPE);
         dq.addFilterQueries("search.entitytype:" + PROFILE_ENTITY_TYPE);
-        // Add the fgs as a filter
-        dq.addFilterQueries("person.identifier.fgs:" + fgs);
+        // Add the attribute filter
+        dq.addFilterQueries(attributeFilter);
         dq.setMaxResults(1);
         // Convert the search result into a list of item and only keep the first one.
         return searchService.search(context, dq)


### PR DESCRIPTION
## Description
A new CLI allows to import all users specified in a file using their fgs identifiers.

Also improved some things in the profile import system:
- The RabbitMQConnector stores the chanel reference in memory to avoid recreating one each time 'publishJSONMessage' is called.
- A new method 'closeChannel' allows to close the remaining channel using the connector.
- We now search for a user having a provided email rather than a provided fgs for more consistancy.
- An additional logic in the 'PersonEventModel' prevents fgs identifiers starting with zeros.

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module