### PR TITLE
[FIX] feat(setup) Fixed consumer error at setup.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/uclouvain/consumer/JournalDefaultDeletePolicyConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/consumer/JournalDefaultDeletePolicyConsumer.java
@@ -73,6 +73,10 @@ public class JournalDefaultDeletePolicyConsumer implements Consumer {
     }
 
     public void end(Context context) throws Exception {
+        if (journalsToProcess.isEmpty()) {
+            // Ensure that we do not continue if there are no IDs to process.
+            return;
+        }
         Group journalManagerGroup = groupService.findByName(context, jmgName);
         Assert.notNull(journalManagerGroup, "Unable to load group " + jmgName);
         for (UUID journalID: journalsToProcess) {


### PR DESCRIPTION
The consumer was triggered at the setup phase when the 'Journal' collection does not already exist and it throws an error.
To fix that I have added a check for the list of IDs to process in 'JournalDefaultDeletePolicyConsumer'. This prevents from entering the 'end()' method when no journals need to be processed.
So 'No journals => No collection' is OK but 'Some Jourals => No collection' throws an error.

## Checklist

- [ ] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module