### PR TITLE
[UPD] feat(profile-creation): IDM filter before Shib profile creation.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/ShibAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/ShibAuthentication.java
@@ -806,12 +806,14 @@ public class ShibAuthentication implements AuthenticationMethod {
         String fnameHeader = configurationService.getProperty("authentication-shibboleth.firstname-header");
         String lnameHeader = configurationService.getProperty("authentication-shibboleth.lastname-header");
         String fgsHeader = configurationService.getProperty("authentication-shibboleth.fgs-header");
+        String idmIdHeader = configurationService.getProperty("authentication-shibboleth.idm-id-header");
 
         String netid = findSingleAttribute(request, netidHeader);
         String email = findSingleAttribute(request, emailHeader);
         String fname = findSingleAttribute(request, fnameHeader);
         String lname = findSingleAttribute(request, lnameHeader);
         String fgs = findSingleAttribute(request, fgsHeader);
+        List<String> idmIds = findMultipleAttributes(request, idmIdHeader);
 
         // Truncate values of parameters that are too big.
         if (fname != null && fname.length() > NAME_MAX_SIZE) {
@@ -847,6 +849,18 @@ public class ShibAuthentication implements AuthenticationMethod {
 
         if (fgs != null) {
             ePersonService.setMetadataSingleValue(context, eperson, "eperson", "identifier", "fgs", null, fgs);
+        }
+
+        if (idmIds != null && !idmIds.isEmpty()) {
+            idmIds.stream().forEach((idmId) -> {
+                try {
+                    ePersonService.setMetadataSingleValue(
+                        context, eperson, "eperson", "idm", "id", null, idmId.toString()
+                    );
+                } catch (SQLException e) {
+                    log.warn("Could not set idm id of person: " + idmId);
+                }
+            });
         }
 
         if (log.isDebugEnabled()) {

--- a/dspace-api/src/main/java/org/dspace/uclouvain/profileIngester/services/IDMPersonValidityService.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/profileIngester/services/IDMPersonValidityService.java
@@ -7,6 +7,9 @@
  */
 package org.dspace.uclouvain.profileIngester.services;
 
+import java.util.List;
+
 public interface IDMPersonValidityService {
     public boolean isPersonIDMValid(String fgs);
+    public boolean isPersonIDMValid(List<Integer> idmRows);
 }

--- a/dspace-api/src/main/java/org/dspace/uclouvain/profileIngester/services/IDMPersonValidityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/profileIngester/services/IDMPersonValidityServiceImpl.java
@@ -42,6 +42,10 @@ public class IDMPersonValidityServiceImpl implements IDMPersonValidityService {
      */
     public boolean isPersonIDMValid(String fgs) {
         List<Integer> idmEntries = getIDMEntriesForFGS(fgs);
+        return isPersonIDMValid(idmEntries);
+    }
+
+    public boolean isPersonIDMValid(List<Integer> idmEntries) {
         if (!idmEntries.isEmpty()) {
             try {
                 List<Integer> filters = idmPersonFilterConfigurationFile.getData();

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/login/impl/ResearcherProfileAutomaticClaim.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/login/impl/ResearcherProfileAutomaticClaim.java
@@ -30,6 +30,7 @@ import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.service.EPersonService;
 import org.dspace.profile.service.ResearcherProfileService;
+import org.dspace.uclouvain.profileIngester.services.IDMPersonValidityService;
 import org.dspace.uclouvain.services.UCLouvainProfileService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.Assert;
@@ -58,6 +59,9 @@ public class ResearcherProfileAutomaticClaim implements PostLoggedInAction {
 
     @Autowired
     private UCLouvainProfileService uclouvainProfileService;
+
+    @Autowired
+    private IDMPersonValidityService idmService;
 
     /**
      * The field of the eperson to search for.
@@ -153,6 +157,7 @@ public class ResearcherProfileAutomaticClaim implements PostLoggedInAction {
 
     /**
      * Create a fresh new profile for a user that just connected and has no matching profile.
+     * Use the metadata present in the given 'currentUser' object to fill the metadata of the profile.
      * @param context The current DSpace context.
      * @param currentUser The current user to create a profile for.
      * @return The created profile for the given user.
@@ -160,32 +165,38 @@ public class ResearcherProfileAutomaticClaim implements PostLoggedInAction {
     private Item createNewProfile(Context context, EPerson currentUser) throws Exception {
         String fgs = ePersonService.getMetadataFirstValue(currentUser, "eperson", "identifier", "fgs", null);
         LOGGER.debug("Found person fgs form EPerson metadata: " + fgs);
-        if (fgs != null) {
-            // Create an empty profile with the fgs
-            Item profile = uclouvainProfileService.createEmptyProfile(context, fgs);
-            // Add required metadata: 'email' + concatenate first and last name to create 'dc.title'.
-            String email = currentUser.getEmail();
-            LOGGER.debug("Found person email form EPerson metadata: " + email);
-            itemService.addSecuredMetadata(context, profile, "person", "email", "official", null, email, null, 0, 1);
-            itemService.addSecuredMetadata(context, profile, "person", "email", null, null, email, null, 0, 1);
-
-            String fullName = Stream.of(currentUser.getLastName(), currentUser.getFirstName())
-                .filter(StringUtils::isNotEmpty)
-                .reduce((a, b) -> a + ", " + b)
-                .orElse(null);
-            LOGGER.debug("Found person fullname form EPerson metadata: " + fullName);
-            if (fullName != null) {
-                itemService.addSecuredMetadata(context, profile, "crisrp", "name", null, null, fullName, null, 0, 1);
-                itemService.addSecuredMetadata(context, profile, "dc", "title", null, null, fullName, null, 0, 0);
-            }
-
-            return profile;
-        } else {
+        if (fgs == null) {
             throw new IllegalArgumentException(
                 "Missing fgs identifier (employeeNumber) to create profile at login. EPersonId: " + currentUser.getID()
             );
         }
+        // Retrieve all the idm entries of the logged person and check if we can create a profile.
+        List<Integer> idmEntries =
+            ePersonService.getMetadata(currentUser, "eperson", "idm", "id", null).stream()
+                .map(mv -> Integer.parseInt(mv.getValue())).toList();
+        if (!idmService.isPersonIDMValid(idmEntries)) {
+            LOGGER.info("Canceled profile creation for fgs '" + fgs + "' because no IDM entry is valid.");
+            return null;
+        }
+        // Create an empty profile with the fgs
+        Item profile = uclouvainProfileService.createEmptyProfile(context, fgs);
+        // Add required metadata: 'email' + concatenate first and last name to create 'dc.title'.
+        String email = currentUser.getEmail();
+        LOGGER.debug("Found person email form EPerson metadata: " + email);
+        itemService.addSecuredMetadata(context, profile, "person", "email", "official", null, email, null, 0, 1);
+        itemService.addSecuredMetadata(context, profile, "person", "email", null, null, email, null, 0, 1);
 
+        String fullName = Stream.of(currentUser.getLastName(), currentUser.getFirstName())
+            .filter(StringUtils::isNotEmpty)
+            .reduce((a, b) -> a + ", " + b)
+            .orElse(null);
+        LOGGER.debug("Found person fullname form EPerson metadata: " + fullName);
+        if (fullName != null) {
+            itemService.addSecuredMetadata(context, profile, "crisrp", "name", null, null, fullName, null, 0, 1);
+            itemService.addSecuredMetadata(context, profile, "dc", "title", null, null, fullName, null, 0, 0);
+        }
+
+        return profile;
     }
 
     private String getValueToSearchFor(Context context, EPerson currentUser) {

--- a/dspace/config/modules/authentication-shibboleth.cfg
+++ b/dspace/config/modules/authentication-shibboleth.cfg
@@ -194,3 +194,4 @@ authentication-shibboleth.role.student = Authenticated users
 
 # Header to extract fgs from.
 authentication-shibboleth.fgs-header = employeeNumber
+authentication-shibboleth.idm-id-header = uclstatusid

--- a/dspace/config/registries/uclouvain-additions-types.xml
+++ b/dspace/config/registries/uclouvain-additions-types.xml
@@ -603,6 +603,11 @@
         <element>identifier</element>
         <qualifier>fgs</qualifier>
     </dc-type>
+    <dc-type>
+        <schema>eperson</schema>
+        <element>idm</element>
+        <qualifier>id</qualifier>
+    </dc-type>
     <!-- JOURNAL SCHEMA -->
     <dc-schema>
         <name>journal</name>


### PR DESCRIPTION
## Description
Added an idm filter when creating a profile for a user connecting through Shibboleth.
The idm row id is retrieved from the Shibboleth attributes and used to check if the profile should be created.

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module