### PR TITLE
[ADD] feat(authority): System to unlink all authorities when an item is deleted.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -1090,7 +1090,8 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
 
         // remore authority references
         if (configurationService.getBooleanProperty("item-deletion.authority-cleanup.enabled", false)) {
-            removeAuthorityReferences(context, item);
+            // removeAuthorityReferences(context, item);
+            metadataValueService.clearAuthorityReferences(context, item.getID().toString());
         }
 
         // Clear any enhancement scheduled for this item.

--- a/dspace-api/src/main/java/org/dspace/content/MetadataValueServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/MetadataValueServiceImpl.java
@@ -7,10 +7,15 @@
  */
 package org.dspace.content;
 
+import static org.dspace.content.authority.Choices.CF_UNSET;
+
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
@@ -22,6 +27,8 @@ import org.dspace.content.service.MetadataValueService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.core.LogHelper;
+import org.hibernate.Hibernate;
+import org.hibernate.LazyInitializationException;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -71,6 +78,19 @@ public class MetadataValueServiceImpl implements MetadataValueService {
     public List<MetadataValue> findByField(Context context, MetadataField metadataField)
         throws IOException, SQLException {
         return metadataValueDAO.findByField(context, metadataField);
+    }
+
+    @Override
+    public List<MetadataValue> findByAuthority(Context context, String authority) throws SQLException {
+        return metadataValueDAO.findByAuthority(context, authority);
+    }
+
+    @Override
+    public List<MetadataValue> findByAuthority(Context context, String authority, Integer confidence)
+        throws SQLException {
+        return this.findByAuthority(context, authority).stream()
+            .filter(mdValue -> mdValue.getConfidence() == confidence)
+            .collect(Collectors.toList());
     }
 
     @Override
@@ -129,5 +149,45 @@ public class MetadataValueServiceImpl implements MetadataValueService {
     @Override
     public int countTotal(Context context) throws SQLException {
         return metadataValueDAO.countRows(context);
+    }
+
+    @Override
+    public void clearAuthorityReferences(Context context, String uuid) throws AuthorizeException, SQLException {
+        // Retrieve all metadata values that matches the item uuid.
+        List<MetadataValue> matchingValues = findByAuthority(context, uuid);
+
+        if (matchingValues.isEmpty()) {
+            return;
+        }
+        Set<DSpaceObject> objectsToUpdate = new HashSet<>();
+        // For each metadata value, clear its authority and add its item to the 'to update list'.
+        matchingValues.forEach(mdValue -> {
+            mdValue.setAuthority(null);
+            mdValue.setConfidence(CF_UNSET);
+            objectsToUpdate.add(mdValue.getDSpaceObject());
+        });
+
+        // Finally, update all modified DSpaceObjects by finding the related service.
+        for (DSpaceObject dso: objectsToUpdate) {
+            DSpaceObjectService<? extends DSpaceObject> relatedService =
+                ContentServiceFactory.getInstance().getDSpaceObjectService(dso);
+            // NOTE: Here we can have a 'proxyfied' version of a DSpaceObject which can cause problem with casting.
+            // Try to 'de-proxify' the dso before using it.
+            // If 'de-proxify' fails, call the corresponding service to get the object from the database.
+            try {
+                dso = (DSpaceObject) Hibernate.unproxy(dso);
+            } catch (LazyInitializationException e) {
+                dso = relatedService.find(context, dso.getID());
+            }
+            updateDSpaceObject(context, relatedService, dso);
+        }
+    }
+
+    // We can suppress the 'Unchecked type warning' since we know that T extends DSpaceObject.
+    @SuppressWarnings("unchecked")
+    private <T extends DSpaceObject> void updateDSpaceObject(
+        Context context, DSpaceObjectService<T> service, DSpaceObject dso
+    ) throws SQLException, AuthorizeException {
+        service.update(context, (T) dso);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/content/dao/MetadataValueDAO.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/MetadataValueDAO.java
@@ -28,6 +28,8 @@ public interface MetadataValueDAO extends GenericDAO<MetadataValue> {
 
     public List<MetadataValue> findByField(Context context, MetadataField fieldId) throws SQLException;
 
+    public List<MetadataValue> findByAuthority(Context context, String authority) throws SQLException;
+
     public Iterator<MetadataValue> findItemValuesByFieldAndValue(Context context,
                                                                  MetadataField metadataField, String value)
             throws SQLException;

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/MetadataValueDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/MetadataValueDAOImpl.java
@@ -49,6 +49,14 @@ public class MetadataValueDAOImpl extends AbstractHibernateDAO<MetadataValue> im
     }
 
     @Override
+    public List<MetadataValue> findByAuthority(Context context, String authority) throws SQLException {
+        String queryString = "SELECT m from MetadataValue m WHERE m.authority = :metadata_authority";
+        Query query = createQuery(context, queryString);
+        query.setParameter("metadata_authority", authority);
+        return list(query);
+    }
+
+    @Override
     public Iterator<MetadataValue> findItemValuesByFieldAndValue(Context context,
                                                                  MetadataField metadataField, String value)
             throws SQLException {

--- a/dspace-api/src/main/java/org/dspace/content/service/MetadataValueService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/MetadataValueService.java
@@ -64,6 +64,28 @@ public interface MetadataValueService {
         throws IOException, SQLException;
 
     /**
+     * Retrieve the metadata values for a given authority from the database.
+     * 
+     * @param context The current DSpace context.
+     * @param authority The authority to find metadata value for.
+     * @return A list of all the metadata values using the provided authority.
+     * @throws SQLException if database error
+     */
+    public List<MetadataValue> findByAuthority(Context context, String authority) throws SQLException;
+
+    /**
+     * Retrieve the metadata values for a given authority and confidence from the database.
+     * 
+     * @param context The current DSpace context.
+     * @param authority The authority to find metadata value for.
+     * @param confidence The confidence to find metadata value for.
+     * @return A list of all the metadata values using the provided authority and confidence.
+     * @throws SQLException if database error
+     */
+    public List<MetadataValue> findByAuthority(Context context, String authority, Integer confidence)
+            throws SQLException;
+
+    /**
      * Retrieves matching MetadataValues for a given field and value.
      *
      * @param context dspace context
@@ -112,4 +134,13 @@ public interface MetadataValueService {
         throws SQLException;
 
     int countTotal(Context context) throws SQLException;
+
+    /**
+     * Clear all the metadata values authority that references the provided item authority.
+     * @param context The current DSpace context.
+     * @param uuid The uuid of the object to clear references of.
+     * @throws AuthorizeException
+     * @throws SQLException
+     */
+    public void clearAuthorityReferences(Context context, String uuid) throws SQLException, AuthorizeException;
 }

--- a/dspace/config/modules/cleanup-authority-metadata-relation.cfg
+++ b/dspace/config/modules/cleanup-authority-metadata-relation.cfg
@@ -14,7 +14,7 @@
 #--------------------------------------------------------------------------------------------#
 
 # by default cleanup of authority is turned off, to enable it, set the following parameter to true.
-item-deletion.authority-cleanup.enabled = false
+item-deletion.authority-cleanup.enabled = true
 
 # Default cleanup mode
 item-deletion.authority-cleanup.mode.default = business-identifier


### PR DESCRIPTION
## Description

When an item is deleted, we search for all metadata values referencing the uuid. Every found metadatavalue needs to be cleaned from the authority reference.

## Checklist

- [ ] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module