### PR TITLE
[ADD] feat(profile-link) Linking profile with unlinked author of publication.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -2439,4 +2439,37 @@ prevent the generation of resource policy entry values with null dspace_object a
     private void clearItemEnhancers(Context context, Item item) {
         uclouvainItemEnhancerService.cleanForItem(context, item.getID());
     }
+
+    /**
+     * Set a metadata value for a specific place.
+     * If a metadata value already exists at the given place, update its data.
+     * If no metadata value exists at the given place, just create a new metadata value at that place.
+     * 
+     * @param context The current DSpace context.
+     * @param item The item to set a metadata of.
+     * @param mdString The metadata field to use to set the metadata.
+     * @param lang The new language of the metadata.
+     * @param value The new value of the metadata.
+     * @param authority The new authority of the metadata.
+     * @param place The new place of the metadata.
+     * @param confidence The new confidence of the metadata.
+     */
+    public void setMetadataInPlace(
+        Context context, Item item, String mdString, String lang, String value,
+        String authority, Integer place, Integer confidence
+    ) throws SQLException {
+        MetadataValue existing = getMetadataByMetadataStringAndPlace(item, mdString, place);
+        if (existing != null) {
+            existing.setValue(value);
+            existing.setAuthority(authority);
+            existing.setLanguage(lang);
+            existing.setConfidence((confidence != null) ? confidence : CF_UNSET);
+        } else {
+            String[] metadataField = getElementsFilled(mdString);
+            addMetadata(
+                context, item, metadataField[0], metadataField[1], metadataField[2],
+                lang, value, authority, place, confidence
+            );
+        }
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/content/MetadataValueServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/MetadataValueServiceImpl.java
@@ -11,18 +11,22 @@ import static org.dspace.content.authority.Choices.CF_UNSET;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.dao.MetadataValueDAO;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.DSpaceObjectService;
+import org.dspace.content.service.MetadataFieldService;
 import org.dspace.content.service.MetadataValueService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
@@ -48,6 +52,8 @@ public class MetadataValueServiceImpl implements MetadataValueService {
     protected MetadataValueDAO metadataValueDAO;
     @Autowired(required = true)
     protected ContentServiceFactory contentServiceFactory;
+    @Autowired(required = true)
+    protected MetadataFieldService metadataFieldService;
 
     protected MetadataValueServiceImpl() {
 
@@ -97,6 +103,30 @@ public class MetadataValueServiceImpl implements MetadataValueService {
     public Iterator<MetadataValue> findByFieldAndValue(Context context, MetadataField metadataField, String value)
             throws SQLException {
         return metadataValueDAO.findItemValuesByFieldAndValue(context, metadataField, value);
+    }
+
+    @Override
+    public List<Pair<DSpaceObject, Integer>> findByFieldAndValue(
+        Context context, Map<String, String> fieldsValues, boolean keepAuthorityLinked
+    ) throws SQLException, IllegalArgumentException {
+        Map<Integer, String> fieldsMap = new HashMap<>();
+        // Convert each metadata field string into the corresponding metadata field id.
+        for (Map.Entry<String, String> entry : fieldsValues.entrySet()) {
+            MetadataField metadataField = metadataFieldService.findByString(context, entry.getKey(), '.');
+            if (metadataField != null) {
+                fieldsMap.put(
+                    metadataField.getID(),
+                    entry.getValue()
+                );
+            } else {
+                log.error(String.format(
+                    "Could not find specified metadata field [%s]",
+                    entry.getKey()
+                ));
+            }
+
+        }
+        return metadataValueDAO.findByFieldAndValue(context, fieldsMap, keepAuthorityLinked);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/content/dao/MetadataValueDAO.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/MetadataValueDAO.java
@@ -10,7 +10,10 @@ package org.dspace.content.dao;
 import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
+import org.apache.commons.lang3.tuple.Pair;
+import org.dspace.content.DSpaceObject;
 import org.dspace.content.MetadataField;
 import org.dspace.content.MetadataValue;
 import org.dspace.core.Context;
@@ -29,6 +32,20 @@ public interface MetadataValueDAO extends GenericDAO<MetadataValue> {
     public List<MetadataValue> findByField(Context context, MetadataField fieldId) throws SQLException;
 
     public List<MetadataValue> findByAuthority(Context context, String authority) throws SQLException;
+
+    /**
+     * Get all the items that are supposedly connected to the given metadata values.
+     * A match is processed using a 'OR' logic. If an item has at least one corresponding value from the given fields,
+     * it is considered matching and it will be returned.
+     * 
+     * @param context The current DSpace context.
+     * @param fieldsValues A map of each field to use to retrieve matching items.
+     * @param keepAuthorityLinked Whenever to keep authority linked metadata values or not.
+     * False means only metadata values with no authority.
+     */
+    public List<Pair<DSpaceObject, Integer>> findByFieldAndValue(
+        Context context, Map<Integer, String> fieldsValues, boolean keepAuthorityLinked
+    ) throws SQLException, IllegalArgumentException;
 
     public Iterator<MetadataValue> findItemValuesByFieldAndValue(Context context,
                                                                  MetadataField metadataField, String value)

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/MetadataValueDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/MetadataValueDAOImpl.java
@@ -10,12 +10,17 @@ package org.dspace.content.dao.impl;
 import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import jakarta.persistence.Query;
+import jakarta.persistence.Tuple;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.Root;
+import org.apache.commons.lang3.tuple.Pair;
+import org.dspace.content.DSpaceObject;
 import org.dspace.content.MetadataField;
 import org.dspace.content.MetadataField_;
 import org.dspace.content.MetadataValue;
@@ -54,6 +59,44 @@ public class MetadataValueDAOImpl extends AbstractHibernateDAO<MetadataValue> im
         Query query = createQuery(context, queryString);
         query.setParameter("metadata_authority", authority);
         return list(query);
+    }
+
+    /**
+     * Get all the items that are supposedly connected to the given metadata values.
+     * A match is processed using a 'OR' logic. If an item has at least one corresponding value from the given fields,
+     * it is considered matching and it will be returned.
+     * 
+     * @param context The current DSpace context.
+     * @param fieldsValues A map of each field to use to retrieve matching items.
+     * @param keepAuthorityLinked Whenever to get authority linked metadata values or not.
+     * False means only metadata values with no authority.
+     */
+    @Override
+    public List<Pair<DSpaceObject, Integer>> findByFieldAndValue(
+        Context context, Map<Integer, String> fieldsValues, boolean keepAuthorityLinked
+    ) throws SQLException, IllegalArgumentException {
+        if (fieldsValues.isEmpty()) {
+            throw new IllegalArgumentException("fieldsValues should have at least one value");
+        }
+        String metadataCondition = fieldsValues.entrySet()
+            .stream()
+            .map(entry -> String.format(
+                    "(mv.metadataField.id = %d and mv.value = '%s')",
+                    entry.getKey(), entry.getValue()
+                )
+            ).collect(Collectors.joining(" or "));
+        String metadataAuthority = keepAuthorityLinked ? "" : " and mv.authority is NULL";
+        String query = "SELECT DISTINCT mv.dSpaceObject, mv.place FROM MetadataValue mv WHERE (%s)%s".formatted(
+            metadataCondition,
+            metadataAuthority
+        );
+        // Use Tuples to return a List of Pairs.
+        return getHibernateSession(context)
+            .createQuery(query, Tuple.class)
+            .getResultList()
+            .stream()
+            .map(t -> Pair.of(t.get(0, DSpaceObject.class), t.get(1, Integer.class)))
+            .collect(Collectors.toList());
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/content/service/ItemService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/ItemService.java
@@ -1097,4 +1097,9 @@ public interface ItemService
      * @return         true if the item is the latest version, false otherwise.
      */
     public boolean isLatestVersion(Context context, Item item) throws SQLException;
+
+    public void setMetadataInPlace(
+        Context context, Item item, String mdString, String lang, String value,
+        String authority, Integer place, Integer confidence
+    ) throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/content/service/MetadataValueService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/MetadataValueService.java
@@ -11,7 +11,9 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.MetadataField;
@@ -96,6 +98,20 @@ public interface MetadataValueService {
      */
     public Iterator<MetadataValue> findByFieldAndValue(Context context, MetadataField metadataField, String value)
             throws SQLException;
+
+    /**
+     * Find matching dspace object for a given map of metadata field and value.
+     * 
+     * @param context The current DSpace context.
+     * @param fieldsValues The map of field ids and values.
+     * @param keepAuthorityLinked Whenever to keep or not the metadata values that already have an authority.
+     * @return A list of matching pairs of DSpace Object and place.
+     * @throws SQLException
+     * @throws IllegalArgumentException
+     */
+    public List<Pair<DSpaceObject, Integer>> findByFieldAndValue(
+        Context context, Map<String, String> fieldsValues, boolean keepAuthorityLinked
+    ) throws SQLException, IllegalArgumentException;
 
     /**
      * Update the metadata value in the database.

--- a/dspace-api/src/main/java/org/dspace/profile/ResearcherProfile.java
+++ b/dspace-api/src/main/java/org/dspace/profile/ResearcherProfile.java
@@ -31,6 +31,8 @@ public class ResearcherProfile {
 
     private final MetadataValue dspaceObjectOwner;
 
+    public static final String ENTITY_TYPE = "Person";
+
     /**
      * Create a new ResearcherProfile object from the given item.
      *
@@ -39,9 +41,21 @@ public class ResearcherProfile {
      *                                  metadata with a valid authority
      */
     public ResearcherProfile(Item item) {
+        this(item, true);
+    }
+
+    /**
+     * Create a new ResearcherProfile object from the given item.
+     *
+     * @param item The item to use as profile
+     * @param hasOwner Whenever to assign an owner to the profile item.
+     * @throws IllegalArgumentException if the given item has no dspace.object.owner
+     *                                  metadata with a valid authority
+     */
+    public ResearcherProfile(Item item, boolean hasOwner) {
         Assert.notNull(item, "A researcher profile requires an item");
         this.item = item;
-        this.dspaceObjectOwner = getDspaceObjectOwnerMetadata(item);
+        this.dspaceObjectOwner = hasOwner ? getDspaceObjectOwnerMetadata(item) : null;
     }
 
     public UUID getId() {
@@ -63,9 +77,29 @@ public class ResearcherProfile {
         return item;
     }
 
+    public Optional<String> getName() {
+        return getMetadataValue(item, "dc.title")
+            .map(MetadataValue::getValue);
+    }
+
     public Optional<String> getOrcid() {
         return getMetadataValue(item, "person.identifier.orcid")
-            .map(metadataValue -> metadataValue.getValue());
+            .map(MetadataValue::getValue);
+    }
+
+    public Optional<String> getFGS() {
+        return getMetadataValue(item, "person.identifier.fgs")
+            .map(MetadataValue::getValue);
+    }
+
+    public Optional<String> getEmail() {
+        return getMetadataValue(item, "person.email.official")
+            .map(MetadataValue::getValue);
+    }
+
+    public Optional<String> getInstitution() {
+        return getMetadataValue(item, "person.affiliation.institution")
+            .map(MetadataValue::getValue);
     }
 
     private MetadataValue getDspaceObjectOwnerMetadata(Item item) {

--- a/dspace-api/src/main/java/org/dspace/profile/ResearcherProfileServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/profile/ResearcherProfileServiceImpl.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import jakarta.annotation.PostConstruct;
 import org.apache.commons.collections4.CollectionUtils;
@@ -58,6 +59,7 @@ import org.dspace.orcid.service.OrcidSynchronizationService;
 import org.dspace.profile.service.AfterResearcherProfileCreationAction;
 import org.dspace.profile.service.ResearcherProfileService;
 import org.dspace.services.ConfigurationService;
+import org.dspace.uclouvain.core.model.publication.Publication;
 import org.dspace.util.UUIDUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -439,6 +441,20 @@ public class ResearcherProfileServiceImpl implements ResearcherProfileService {
         } catch (SearchServiceException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public Map<String, String> getAuthorsIdentifiers(ResearcherProfile profile) {
+        // Create a map of profile identifiers.
+        return Stream.of(
+                Map.entry(Publication.AUTHOR_EMAIL_FIELD, profile.getEmail()),
+                Map.entry(Publication.AUTHOR_ORCID_FIELD, profile.getOrcid()),
+                Map.entry(Publication.AUTHOR_FGS_FIELD, profile.getFGS())
+            )
+            .filter(entry -> entry.getValue().isPresent())
+            .collect(Collectors.toMap(
+                entry -> entry.getKey(),
+                entry -> entry.getValue().get()
+            ));
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/profile/service/ResearcherProfileService.java
+++ b/dspace-api/src/main/java/org/dspace/profile/service/ResearcherProfileService.java
@@ -127,4 +127,12 @@ public interface ResearcherProfileService {
     String getProfileType();
 
     boolean isAuthorOf(Context context, EPerson ePerson, Item item);
+
+    /**
+     * Retrieve a map of identifiers for the given profile.
+     * The key of the map is the metadata field string and the value is the value of the identifier.
+     * @param profile The profile to generate a map for.
+     * @return A map containing the identifiers of the given profile.
+     */
+    public Map<String, String> getAuthorsIdentifiers(ResearcherProfile profile);
 }

--- a/dspace-api/src/main/java/org/dspace/uclouvain/consumer/ProfileLinkConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/consumer/ProfileLinkConsumer.java
@@ -1,0 +1,142 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.consumer;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.ItemService;
+import org.dspace.content.service.MetadataValueService;
+import org.dspace.core.Context;
+import org.dspace.event.Consumer;
+import org.dspace.event.Event;
+import org.dspace.profile.ResearcherProfile;
+import org.dspace.profile.service.ResearcherProfileService;
+import org.dspace.uclouvain.core.model.publication.Publication;
+import org.dspace.uclouvain.factories.UCLouvainServiceFactory;
+import org.dspace.uclouvain.services.PublicationService;
+import org.dspace.utils.DSpace;
+
+/**
+ * When a profile is created/modified, in some cases we could have publications that mention this author
+ * but have no authority link.
+ * The main goal of this consumer is to link those 'unlinked' authors to the profile.
+ * 
+ * @author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+public class ProfileLinkConsumer implements Consumer {
+
+    private Logger logger = LogManager.getLogger(ProfileLinkConsumer.class);
+
+    private ItemService itemService;
+    private MetadataValueService metadataValueService;
+    private PublicationService publicationService;
+    private ResearcherProfileService researcherProfileService;
+
+    private Set<UUID> profilesToProcess = new HashSet<>();
+
+    @Override
+    public void initialize() throws Exception {
+        ContentServiceFactory contentServiceFactory = ContentServiceFactory.getInstance();
+        itemService = contentServiceFactory.getItemService();
+        metadataValueService = contentServiceFactory.getMetadataValueService();
+        publicationService = UCLouvainServiceFactory.getInstance().getPublicationService();
+        researcherProfileService = new DSpace().getSingletonService(ResearcherProfileService.class);
+    }
+
+    @Override
+    public void consume(Context context, Event event) throws Exception {
+        Item item = (Item) event.getSubject(context);
+        if (ResearcherProfile.ENTITY_TYPE.equals(itemService.getEntityType(item))) {
+            profilesToProcess.add(item.getID());
+        }
+    }
+
+    @Override
+    public void end(Context context) throws Exception {
+        if (profilesToProcess.isEmpty()) {
+            return;
+        }
+
+        for (UUID profileUUID : profilesToProcess) {
+            logger.debug("In consumer for profile with uuid " + profileUUID);
+            Item profileItem = itemService.find(context, profileUUID);
+            ResearcherProfile profile = new ResearcherProfile(profileItem, false);
+            Map<String, String> authorsIdentifier = researcherProfileService.getAuthorsIdentifiers(profile);
+            logger.debug("Profile authors identifiers: " + authorsIdentifier);
+            if (authorsIdentifier.isEmpty()) {
+                continue;
+            }
+
+            // Once we have the full identifiers map, check for matching publications.
+            List<Pair<DSpaceObject, Integer>> matchingPublicationsPlaces = metadataValueService
+                    .findByFieldAndValue(context, authorsIdentifier, false);
+            Set<Item> itemsToUpdate = new HashSet<>();
+
+            for (Pair<DSpaceObject, Integer> publicationPlace : matchingPublicationsPlaces) {
+                DSpaceObject dso = publicationPlace.getLeft();
+                int place = publicationPlace.getRight();
+                // We only manage items
+                if (!(dso instanceof Item item)) {
+                    continue;
+                }
+                try {
+                    if (!Objects.equals(itemService.getEntityType(item), Publication.ENTITY_TYPE)) {
+                        continue;
+                    }
+                    logger.debug("Found publication to update!! " + item.getID()
+                            + " with title " + item.getName());
+                    logger.debug("Update needed at place " + place);
+                    // Once we have the publication and the place,
+                    // we need to update the metadata values of the corresponding author.
+                    Publication publication = new Publication(item);
+                    String previousRole = publication.getAuthor(place).getRole();
+                    // Set values of the author for the found place.
+                    publicationService.setAuthor(
+                            context,
+                            publication,
+                            profile.getName().orElse(null),
+                            profile.getEmail().orElse(null),
+                            profile.getOrcid().orElse(null),
+                            profile.getFGS().orElse(null),
+                            profile.getInstitution().orElse(null),
+                            // Use previously set role.
+                            previousRole,
+                            profileUUID.toString(),
+                            place);
+                    itemsToUpdate.add(item);
+                } catch (Exception e) {
+                    logger.warn(
+                        "Could not link author profile %s to publication %s".formatted(profileUUID, item.getID()),
+                        e
+                    );
+                }
+            }
+            for (Item itemToUpdate : itemsToUpdate) {
+                // Do external update of item since an item can be updated multiple times in the previous process.
+                itemService.update(context, itemToUpdate);
+            }
+        }
+        profilesToProcess.clear();
+    }
+
+    @Override
+    public void finish(Context context) throws Exception {
+    }
+
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/core/model/exceptions/PublicationSetAuthorException.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/core/model/exceptions/PublicationSetAuthorException.java
@@ -1,0 +1,25 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.core.model.exceptions;
+
+import org.dspace.content.Item;
+import org.dspace.uclouvain.core.model.publication.PublicationAuthor;
+
+public class PublicationSetAuthorException extends Exception {
+    private final Item item;
+    private final PublicationAuthor author;
+
+    public PublicationSetAuthorException(Item item, PublicationAuthor author) {
+        this.item = item;
+        this.author = author;
+    }
+
+    public String getMessage() {
+        return "Could not add author %s to publication with id %s".formatted(author.getName(), item.getID());
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/core/model/publication/Publication.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/core/model/publication/Publication.java
@@ -31,10 +31,14 @@ public class Publication extends ItemModel {
             configService.getProperty(FIELD_PREFIX + "publication.authorName.field", "dc.contributor.author");
     public static final String AUTHOR_EMAIL_FIELD =
             configService.getProperty(FIELD_PREFIX + "publication.authorEmail.field", "authors.email");
+    public static final String AUTHOR_ORCID_FIELD =
+            configService.getProperty(FIELD_PREFIX + "publication.authorOrcid.field", "authors.identifier.orcid");
     public static final String AUTHOR_INSTITUTION_FIELD =
             configService.getProperty(FIELD_PREFIX + "publication.authorInstitution.field", "authors.institution.code");
     public static final String AUTHOR_ROLE_FIELD =
             configService.getProperty(FIELD_PREFIX + "publication.authorRole.field", "authors.role");
+    public static final String AUTHOR_FGS_FIELD =
+            configService.getProperty(FIELD_PREFIX + "publication.authorFgs.field", "authors.identifier.fgs");
 
     // CONSTRUCTOR =====================================================================================================
     public Publication(Item item) throws InvalidModelEntityTypeException {
@@ -60,6 +64,7 @@ public class Publication extends ItemModel {
                 .setEmail(itemService.getMetadata(item, AUTHOR_EMAIL_FIELD, mv.getPlace()))
                 .setInstitution(itemService.getMetadata(item, AUTHOR_INSTITUTION_FIELD, mv.getPlace()))
                 .setRole(itemService.getMetadata(item, AUTHOR_ROLE_FIELD, mv.getPlace()))
+                .setPlace(mv.getPlace())
             )
             .toList();
     }
@@ -75,5 +80,18 @@ public class Publication extends ItemModel {
             .stream()
             .filter(author -> roles.contains(author.getRole()))
             .toList();
+    }
+
+    /**
+     * Find an author based on its place in the authors of the publication.
+     * 
+     * @param place The place of the author to find.
+     * @return The author of the publication at the given place.
+     */
+    public PublicationAuthor getAuthor(int place) {
+        return getAuthors().stream()
+            .filter(author -> Objects.equals(author.getPlace(), place))
+            .findFirst()
+            .orElse(null);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/uclouvain/core/model/publication/PublicationAuthor.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/core/model/publication/PublicationAuthor.java
@@ -47,6 +47,7 @@ public class PublicationAuthor {
     private String email;
     private String institution;
     private String role;
+    private int place;
     private Map<String, String> identifiers = new HashMap<>();
     private Item researcherProfileAuthority;
 
@@ -94,6 +95,13 @@ public class PublicationAuthor {
     }
     public PublicationAuthor setRole(String role) {
         this.role = role;
+        return this;
+    }
+    public int getPlace() {
+        return place;
+    }
+    public PublicationAuthor setPlace(int place) {
+        this.place = place;
         return this;
     }
 

--- a/dspace-api/src/main/java/org/dspace/uclouvain/factories/UCLouvainServiceFactory.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/factories/UCLouvainServiceFactory.java
@@ -17,6 +17,7 @@ import org.dspace.uclouvain.profileIngester.services.IDMPersonValidityService;
 import org.dspace.uclouvain.services.DirectLinkService;
 import org.dspace.uclouvain.services.JournalService;
 import org.dspace.uclouvain.services.OrgUnitService;
+import org.dspace.uclouvain.services.PublicationService;
 import org.dspace.uclouvain.services.UCLouvainAffiliationEntityRestService;
 import org.dspace.uclouvain.services.UCLouvainEntityService;
 import org.dspace.uclouvain.services.UCLouvainFWBValidationService;
@@ -42,6 +43,7 @@ public abstract  class UCLouvainServiceFactory {
     public abstract UCLouvainCitationsService getCitationsService();
     public abstract JournalService getJournalService();
     public abstract OrgUnitService getOrgUnitService();
+    public abstract PublicationService getPublicationService();
     public abstract IDMPersonValidityService getIDMPersonValidityService();
 
     public static UCLouvainServiceFactory getInstance() {

--- a/dspace-api/src/main/java/org/dspace/uclouvain/factories/UCLouvainServiceFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/factories/UCLouvainServiceFactoryImpl.java
@@ -16,6 +16,7 @@ import org.dspace.uclouvain.profileIngester.services.IDMPersonValidityService;
 import org.dspace.uclouvain.services.DirectLinkService;
 import org.dspace.uclouvain.services.JournalService;
 import org.dspace.uclouvain.services.OrgUnitService;
+import org.dspace.uclouvain.services.PublicationService;
 import org.dspace.uclouvain.services.UCLouvainAffiliationEntityRestService;
 import org.dspace.uclouvain.services.UCLouvainEntityService;
 import org.dspace.uclouvain.services.UCLouvainFWBValidationService;
@@ -53,6 +54,8 @@ public class UCLouvainServiceFactoryImpl extends UCLouvainServiceFactory {
     private JournalService journalService;
     @Autowired
     private OrgUnitService orgUnitService;
+    @Autowired
+    private PublicationService publicationService;
     @Autowired
     private IDMPersonValidityService idmPersonValidityService;
 
@@ -102,6 +105,10 @@ public class UCLouvainServiceFactoryImpl extends UCLouvainServiceFactory {
     @Override
     public OrgUnitService getOrgUnitService() {
         return orgUnitService;
+    }
+    @Override
+    public PublicationService getPublicationService() {
+        return publicationService;
     }
     @Override
     public IDMPersonValidityService getIDMPersonValidityService() {

--- a/dspace-api/src/main/java/org/dspace/uclouvain/services/PublicationService.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/services/PublicationService.java
@@ -1,0 +1,46 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.services;
+
+import org.dspace.core.Context;
+import org.dspace.uclouvain.core.model.exceptions.PublicationSetAuthorException;
+import org.dspace.uclouvain.core.model.publication.Publication;
+import org.dspace.uclouvain.core.model.publication.PublicationAuthor;
+
+public interface PublicationService {
+    /**
+     * Add a new author to a publication (item) metadata at a specific place.
+     * 
+     * @param context     The current DSpace context.
+     * @param name        The name of the author.
+     * @param email       The email of the author.
+     * @param orcid       The ORCID of the author.
+     * @param fgs         The fgs identifier of the author.
+     * @param institution The institution of the author.
+     * @param role        The role of the author in the publication.
+     * @param authority   The UUID of the profile item.
+     * @param place       The place pf the author in the author list.
+     * @return A PublicationAuthor object containing all the informations.
+     * @throws PublicationSetAuthorException
+     */
+    public PublicationAuthor setAuthor(Context context, Publication publication, String name, String email,
+            String orcid, String fgs, String institution, String role, String authority, Integer place)
+            throws PublicationSetAuthorException;
+
+    /**
+     * Set author information in the publication (item) metadata.
+     * 
+     * @param context     The current DSpace context.
+     * @param publication The publication to set an author for.
+     * @param author      The author to persist.
+     * @throws PublicationSetAuthorException if any error occurres while persisting
+     *                                       information in publication.
+     */
+    public void setAuthor(Context context, Publication publication, PublicationAuthor author)
+            throws PublicationSetAuthorException;
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/services/impl/PublicationServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/services/impl/PublicationServiceImpl.java
@@ -1,0 +1,87 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.services.impl;
+
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+import static org.dspace.content.authority.Choices.CF_ACCEPTED;
+import static org.dspace.content.authority.Choices.CF_UNSET;
+
+import java.util.UUID;
+
+import org.dspace.content.Item;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Context;
+import org.dspace.uclouvain.core.model.exceptions.PublicationSetAuthorException;
+import org.dspace.uclouvain.core.model.publication.Publication;
+import org.dspace.uclouvain.core.model.publication.PublicationAuthor;
+import org.dspace.uclouvain.services.PublicationService;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class PublicationServiceImpl implements PublicationService {
+
+    @Autowired
+    ItemService itemService;
+
+    public PublicationAuthor setAuthor(Context context, Publication publication,
+            String name, String email, String orcid, String fgs,
+            String institution, String role, String authority, Integer place)
+            throws PublicationSetAuthorException {
+        PublicationAuthor author = new PublicationAuthor()
+                .setName(name)
+                .setEmail(email)
+                .setOrcidID(orcid)
+                .setRole(role)
+                .setInstitution(institution)
+                .setAuthority(UUID.fromString(authority))
+                .setPlace(place);
+        this.setAuthor(context, publication, author);
+        return author;
+    }
+
+    public void setAuthor(Context context, Publication publication, PublicationAuthor author)
+            throws PublicationSetAuthorException {
+        Item item = publication.getItem();
+        try {
+            String authority = (author.getAuthority() != null) ? author.getAuthority().getID().toString() : null;
+            int confidence = isNotEmpty(authority) ? CF_ACCEPTED : CF_UNSET;
+            int place = author.getPlace();
+
+            // Name, email, fgs and role are mandatory so no need to check for existing value.
+            itemService.setMetadataInPlace(
+                    context, item, Publication.AUTHOR_NAME_FIELD, null, author.getName(), authority,
+                    place,
+                    confidence);
+            itemService.setMetadataInPlace(
+                    context, item, Publication.AUTHOR_EMAIL_FIELD, null, author.getEmail(),
+                    authority, place,
+                    confidence);
+            itemService.setMetadataInPlace(
+                    context, item, Publication.AUTHOR_FGS_FIELD, null, author.getFgs(), authority,
+                    place, confidence);
+            itemService.setMetadataInPlace(
+                    context, item, Publication.AUTHOR_ROLE_FIELD, null, author.getRole(), null,
+                    place, CF_UNSET);
+
+            if (author.getOrcidID() != null) {
+                itemService.setMetadataInPlace(
+                        context, item, Publication.AUTHOR_ORCID_FIELD, null,
+                        author.getOrcidID(), authority, place,
+                        confidence);
+            }
+            if (author.getInstitution() != null) {
+                itemService.setMetadataInPlace(
+                        context, item, Publication.AUTHOR_INSTITUTION_FIELD, null,
+                        author.getInstitution(), null, place,
+                        confidence);
+            }
+        } catch (Exception e) {
+            throw new PublicationSetAuthorException(item, author);
+        }
+    }
+
+}

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -823,8 +823,8 @@ event.dispatcher.RelatedItemEnhancerUpdatePoller.class = org.dspace.event.BasicD
 # Add rdf here, if you are using dspace-rdf to export your repository content as RDF.
 # Add iiif here, if you are using dspace-iiif.
 # Add orcidqueue here, if the integration with ORCID is configured and wish to enable the synchronization queue functionality
-event.dispatcher.default.consumers = versioning, discovery, eperson, dedup, crisconsumer, orcidqueue, audit, qaeventsdelete, referenceresolver, orcidwebhook, itemenhancer, customurl, iiif, reciprocal, filetypemetadataenhancer, authoritylink, ldnmessage,  licensegenerator, accesstype, authoritymetadataenhancer, formfieldcleaner, fillervalueremover, dissertationyearextract, journaldefaultdeletepolicy
-event.dispatcher.RelatedItemEnhancerUpdatePoller.consumers = versioning, discovery, eperson, dedup, crisconsumer, orcidqueue, audit, qaeventsdelete, referenceresolver, orcidwebhook, itemenhancer, customurl, iiif, reciprocal, filetypemetadataenhancer, authoritylink, ldnmessage, journaldefaultdeletepolicy
+event.dispatcher.default.consumers = versioning, discovery, eperson, dedup, crisconsumer, orcidqueue, audit, qaeventsdelete, referenceresolver, orcidwebhook, itemenhancer, customurl, iiif, reciprocal, filetypemetadataenhancer, authoritylink, ldnmessage,  licensegenerator, accesstype, authoritymetadataenhancer, formfieldcleaner, fillervalueremover, dissertationyearextract, journaldefaultdeletepolicy, profilelink
+event.dispatcher.RelatedItemEnhancerUpdatePoller.consumers = versioning, discovery, eperson, dedup, crisconsumer, orcidqueue, audit, qaeventsdelete, referenceresolver, orcidwebhook, itemenhancer, customurl, iiif, reciprocal, filetypemetadataenhancer, authoritylink, ldnmessage, journaldefaultdeletepolicy, profilelink
 
 # enable the item enhancer poller
 related-item-enhancer-poller.enabled = true

--- a/dspace/config/modules/uclouvain.cfg
+++ b/dspace/config/modules/uclouvain.cfg
@@ -90,6 +90,9 @@ event.consumer.journaldefaultdeletepolicy.filters = Item+Install
 # The group that will be authorized to delete a Journal.
 event.consumer.journaldefaultdeletepolicy.group = Journal manager
 
+event.consumer.profilelink.class = org.dspace.uclouvain.consumer.ProfileLinkConsumer
+event.consumer.profilelink.filters = Item+Install|Modify|Modify_Metadata
+
 #------------------------------------------------------------------#
 #------------- Community/Collection configuration -----------------#
 #------------------------------------------------------------------#

--- a/dspace/config/spring/uclouvain/uclouvain-services.xml
+++ b/dspace/config/spring/uclouvain/uclouvain-services.xml
@@ -48,6 +48,7 @@
     <bean id="uclouvainCitationsService" class="org.dspace.uclouvain.citations.UCLouvainCitationsServiceImpl"/>
     <bean id="journalService" class="org.dspace.uclouvain.services.impl.JournalServiceImpl" />
     <bean id="orgUnitService" class="org.dspace.uclouvain.services.impl.OrgUnitServiceImpl" />
+    <bean id="publicationService" class="org.dspace.uclouvain.services.impl.PublicationServiceImpl" />
     <bean id="uclouvainProfileService" class="org.dspace.uclouvain.services.UCLouvainProfileServiceImpl"/>
     <bean id="idmPersonValidityService" class="org.dspace.uclouvain.profileIngester.services.IDMPersonValidityServiceImpl"/>
 


### PR DESCRIPTION
# Descrption

When a profile is created/updated, we search for all authors that could be linked using the identifiers of the person (email, fgs and orcid). If authors are found, we override their data to be up to date with the profile and we link them using authority.

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module