### PR TITLE
[UPD] feat(profile-affiliation): Find matching affiliation based on shibboleth header.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/ShibAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/ShibAuthentication.java
@@ -808,6 +808,7 @@ public class ShibAuthentication implements AuthenticationMethod {
         String lnameHeader = configurationService.getProperty("authentication-shibboleth.lastname-header");
         String fgsHeader = configurationService.getProperty("authentication-shibboleth.fgs-header");
         String idmIdHeader = configurationService.getProperty("authentication-shibboleth.idm-id-header");
+        String ouHeader = configurationService.getProperty("authentication-shibboleth.ou-header");
 
         String netid = findSingleAttribute(request, netidHeader);
         String email = findSingleAttribute(request, emailHeader);
@@ -815,6 +816,7 @@ public class ShibAuthentication implements AuthenticationMethod {
         String lname = findSingleAttribute(request, lnameHeader);
         String fgs = findSingleAttribute(request, fgsHeader);
         List<String> idmIds = findMultipleAttributes(request, idmIdHeader);
+        List<String> affiliations = findMultipleAttributes(request, ouHeader);
 
         // Truncate values of parameters that are too big.
         if (fname != null && fname.length() > NAME_MAX_SIZE) {
@@ -865,9 +867,28 @@ public class ShibAuthentication implements AuthenticationMethod {
                         context, eperson, "eperson", "idm", "id", null, idmId.toString()
                     );
                 } catch (SQLException e) {
-                    log.warn("Could not set idm id of person: " + idmId);
+                    log.warn("Could not set idm id of person %s : '%s'".formatted(netid, idmId));
                 }
             });
+        }
+
+        // Update affiliations values.
+        List<MetadataValue> existingAffiliations =
+            ePersonService.getMetadata(eperson, "eperson", "affiliation", null, null);
+        if (!existingAffiliations.isEmpty()) {
+            ePersonService.removeMetadataValues(context, eperson, existingAffiliations);
+        }
+
+        if (affiliations != null && !affiliations.isEmpty()) {
+            for (String affiliation : affiliations) {
+                try {
+                    ePersonService.addMetadata(
+                        context, eperson, "eperson", "affiliation", null, null, affiliation
+                    );
+                } catch (SQLException e) {
+                    log.warn("Could not set affiliation of person %s : '%s'".formatted(netid, affiliation));
+                }
+            }
         }
 
         if (log.isDebugEnabled()) {

--- a/dspace-api/src/main/java/org/dspace/uclouvain/services/OrgUnitService.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/services/OrgUnitService.java
@@ -8,6 +8,7 @@
 package org.dspace.uclouvain.services;
 
 import java.sql.SQLException;
+import java.util.List;
 
 import org.dspace.core.Context;
 import org.dspace.uclouvain.core.model.OrgUnit;
@@ -32,4 +33,24 @@ public interface OrgUnitService {
         String entityAcronym,
         String entityName
     ) throws SQLException;
+
+    /**
+     * Find matching OrgUnits for a given list of affiliation names.
+     * Each affiliations has to be splitted into levels based on the '/' element.
+     * We only work with level 3 and 2 so affiliations of only 1 level are ignored.
+     * Ex. of accepted affiliation: ['LS/SGSI/SISG', 'SSS/FASB'].
+     * Ex. of ignored affiliation: ['StLuc', 'SSH'].
+     * @param context The current Dspace context.
+     * @param affiliations A list of affiliations to search on.
+     * @return A list of OrgUnit representing the matching affiliations for the given list.
+     * Can return null if no matching affiliation are found.
+     */
+    List<OrgUnit> findByName(Context context, List<String> affiliations);
+
+    /**
+     * Find first matching OrgUnit from a list of affiliations.
+     * @param context The current DSpace context.
+     * @param affiliations The list of affiliations to find matching orgUnit of.
+     */
+    OrgUnit findFirstByName(Context context, List<String> affiliations);
 }

--- a/dspace-api/src/main/java/org/dspace/uclouvain/services/UCLouvainProfileServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/services/UCLouvainProfileServiceImpl.java
@@ -7,6 +7,8 @@
  */
 package org.dspace.uclouvain.services;
 
+import static org.dspace.content.authority.Choices.CF_ACCEPTED;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -17,6 +19,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.dspace.content.Collection;
 import org.dspace.content.Item;
+import org.dspace.content.MetadataValue;
 import org.dspace.content.WorkspaceItem;
 import org.dspace.content.service.CollectionService;
 import org.dspace.content.service.InstallItemService;
@@ -32,6 +35,7 @@ import org.dspace.discovery.indexobject.IndexableWorkflowItem;
 import org.dspace.discovery.indexobject.IndexableWorkspaceItem;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.service.EPersonService;
+import org.dspace.uclouvain.core.model.OrgUnit;
 import org.dspace.uclouvain.profileIngester.services.IDMPersonValidityService;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -58,6 +62,8 @@ public class UCLouvainProfileServiceImpl implements UCLouvainProfileService {
     private EPersonService ePersonService;
     @Autowired
     private IDMPersonValidityService idmService;
+    @Autowired
+    private OrgUnitService orgUnitService;
 
     private static final String PROFILE_ENTITY_TYPE = "Person";
 
@@ -131,6 +137,28 @@ public class UCLouvainProfileServiceImpl implements UCLouvainProfileService {
         if (StringUtils.isNotBlank(fullName)) {
             itemService.addSecuredMetadata(context, profile, "crisrp", "name", null, null, fullName, null, 0, 1);
             itemService.addSecuredMetadata(context, profile, "dc", "title", null, null, fullName, null, 0, 0);
+        }
+
+        List<String> affiliations = ePersonService.getMetadata(person, "eperson", "affiliation", null, null)
+            .stream()
+            .map(MetadataValue::getValue)
+            .collect(Collectors.toList());
+        if (affiliations != null) {
+            // Try to find a matching affiliation item for the affiliations stored in the person.
+            OrgUnit mainAffiliation = orgUnitService.findFirstByName(context, affiliations);
+            if (mainAffiliation != null) {
+                itemService.addMetadata(
+                    context, profile,
+                    "person", "affiliation", "department",
+                    null, mainAffiliation.getTitle(), mainAffiliation.getID().toString(), CF_ACCEPTED
+                );
+                OrgUnit institution = mainAffiliation.getParentUniversity();
+                itemService.addMetadata(
+                    context, profile,
+                    "person", "affiliation", "institution",
+                    null, institution.getAcronym(), institution.getID().toString(), CF_ACCEPTED
+                );
+            }
         }
         return profile;
     }

--- a/dspace-api/src/main/java/org/dspace/uclouvain/services/impl/OrgUnitServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/services/impl/OrgUnitServiceImpl.java
@@ -8,8 +8,10 @@
 package org.dspace.uclouvain.services.impl;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
 import org.dspace.content.Item;
@@ -91,5 +93,35 @@ public class OrgUnitServiceImpl implements OrgUnitService {
         } catch (Exception ignored) {
             return null;
         }
+    }
+
+    public List<OrgUnit> findByName(Context context, List<String> affiliations) {
+        // We have a list of strings that represent affiliations:
+        // - ex: ["SSS/SIONS", "SSS/IONS/CEMO", "SSS/MEDE", "StLuc"]
+        // We want to split each string based on the '/' character, so we will have a list of arrays.
+        // Then get the largest list (beginning with size 3) and see if we can find a matching OrgUnit acronym.
+        return affiliations.stream()
+            .map(aff -> List.of(aff.split("/")))
+            .flatMap(parts -> Stream.of(3, 2)
+                .filter(i -> parts.size() >= i)
+                .map(i -> String.join("/", parts.subList(0, i))))
+            .sorted(Comparator.comparingInt(this::getAffiliationLevel).reversed())
+            .map(name -> findByName(context, null, null, name, null))
+            .filter(Objects::nonNull)
+            .toList();
+    }
+
+    public OrgUnit findFirstByName(Context context, List<String> affiliations) {
+        return findByName(context, affiliations).stream().findFirst().orElse(null);
+    }
+
+    /**
+     * Get the level of a specific affiliation, based on the number of '/' in the string.
+     * @param affiliation The affiliation to process the level of.
+     * @return The level of the affiliation.
+     */
+    private int getAffiliationLevel(String affiliation) {
+        // Subtract the length of the string to the length of the string without slashes.
+        return affiliation.length() - affiliation.replace("/", "").length();
     }
 }

--- a/dspace/config/modules/authentication-shibboleth.cfg
+++ b/dspace/config/modules/authentication-shibboleth.cfg
@@ -195,3 +195,4 @@ authentication-shibboleth.role.student = Authenticated users
 # Header to extract fgs from.
 authentication-shibboleth.fgs-header = employeeNumber
 authentication-shibboleth.idm-id-header = uclstatusid
+authentication-shibboleth.ou-header = ou

--- a/dspace/config/registries/uclouvain-additions-types.xml
+++ b/dspace/config/registries/uclouvain-additions-types.xml
@@ -608,6 +608,10 @@
         <element>idm</element>
         <qualifier>id</qualifier>
     </dc-type>
+    <dc-type>
+        <schema>eperson</schema>
+        <element>affiliation</element>
+    </dc-type>
     <!-- JOURNAL SCHEMA -->
     <dc-schema>
         <name>journal</name>


### PR DESCRIPTION
## Description

We can now find a matching affiliation when logging through shibboleth and add it to the corresponding profile.

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module