### PR TITLE
[ADD] feat(item-validator): Validate items before creation/update.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -106,6 +106,8 @@ import org.dspace.qaevent.dao.QAEventsDAO;
 import org.dspace.services.ConfigurationService;
 import org.dspace.uclouvain.content.service.CommentService;
 import org.dspace.uclouvain.itemEnhancer.UCLouvainItemEnhancerService;
+import org.dspace.uclouvain.itemValidators.ItemValidator;
+import org.dspace.uclouvain.itemValidators.factories.ItemValidatorFactory;
 import org.dspace.versioning.Version;
 import org.dspace.versioning.VersionHistory;
 import org.dspace.versioning.service.VersionHistoryService;
@@ -221,6 +223,9 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
 
     @Autowired(required = true)
     private UCLouvainItemEnhancerService uclouvainItemEnhancerService;
+
+    @Autowired(required = true)
+    private ItemValidatorFactory itemValidatorFactory;
 
     @Autowired
     private CommentService commentService;
@@ -836,6 +841,12 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
 
         log.info(LogHelper.getHeader(context, "update_item", "item_id="
             + item.getID()));
+
+        // Get a validator and validate the current item.
+        ItemValidator validator = itemValidatorFactory.getValidator(item);
+        if (validator != null) {
+            validator.validate(context, item);
+        }
 
         super.update(context, item);
 

--- a/dspace-api/src/main/java/org/dspace/profile/ResearcherProfile.java
+++ b/dspace-api/src/main/java/org/dspace/profile/ResearcherProfile.java
@@ -33,6 +33,15 @@ public class ResearcherProfile {
 
     public static final String ENTITY_TYPE = "Person";
 
+    public static final String EMAIL_FIELD = "person.email";
+    public static final String OFFICIAL_EMAIL_FIELD = "person.email.official";
+    public static final String NAME_FIELD = "dc.title";
+    public static final String OFFICIAL_NAME_FIELD = "crisrp.name";
+    public static final String FGS_FIELD = "person.identifier.fgs";
+    public static final String ORCID_FIELD = "person.identifier.orcid";
+    public static final String INSTITUTION_FIELD = "person.affiliation.institution";
+    public static final String DEPARTMENT_FIELD = "person.affiliation.department";
+
     /**
      * Create a new ResearcherProfile object from the given item.
      *
@@ -78,27 +87,32 @@ public class ResearcherProfile {
     }
 
     public Optional<String> getName() {
-        return getMetadataValue(item, "dc.title")
+        return getMetadataValue(item, NAME_FIELD)
             .map(MetadataValue::getValue);
     }
 
     public Optional<String> getOrcid() {
-        return getMetadataValue(item, "person.identifier.orcid")
+        return getMetadataValue(item, ORCID_FIELD)
             .map(MetadataValue::getValue);
     }
 
     public Optional<String> getFGS() {
-        return getMetadataValue(item, "person.identifier.fgs")
+        return getMetadataValue(item, FGS_FIELD)
             .map(MetadataValue::getValue);
     }
 
     public Optional<String> getEmail() {
-        return getMetadataValue(item, "person.email.official")
+        return getMetadataValue(item, OFFICIAL_EMAIL_FIELD)
+            .map(MetadataValue::getValue);
+    }
+
+    public Optional<String> getPrivateEmail() {
+        return getMetadataValue(item, EMAIL_FIELD)
             .map(MetadataValue::getValue);
     }
 
     public Optional<String> getInstitution() {
-        return getMetadataValue(item, "person.affiliation.institution")
+        return getMetadataValue(item, INSTITUTION_FIELD)
             .map(MetadataValue::getValue);
     }
 

--- a/dspace-api/src/main/java/org/dspace/profile/ResearcherProfileServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/profile/ResearcherProfileServiceImpl.java
@@ -131,8 +131,12 @@ public class ResearcherProfileServiceImpl implements ResearcherProfileService {
     }
 
     @Override
-    public Item findByIdentifier(Context context, Map<String, String> identifiers)
+    public ResearcherProfile findFirstByIdentifiers(Context context, Map<String, String> identifiers)
             throws AuthorizeException, SQLException {
+        return this.findByIdentifiers(context, identifiers).stream().findFirst().orElse(null);
+    }
+
+    public List<ResearcherProfile> findByIdentifiers(Context context, Map<String, String> identifiers) {
         DiscoverQuery discoverQuery = new DiscoverQuery();
         discoverQuery.setDSpaceObjectFilter(IndexableItem.TYPE);
         discoverQuery.addFilterQueries("dspace.entity.type:" + getProfileType());
@@ -143,13 +147,11 @@ public class ResearcherProfileServiceImpl implements ResearcherProfileService {
                 .collect(Collectors.joining(" OR ")
             )
         );
-
         DiscoverResult discoverResult = search(context, discoverQuery);
         List<IndexableObject> indexableObjects = discoverResult.getIndexableObjects();
-        if (CollectionUtils.isEmpty(indexableObjects)) {
-            return null;
-        }
-        return (Item) indexableObjects.get(0).getIndexedObject();
+        return indexableObjects.stream()
+            .map(object -> new ResearcherProfile((Item) object.getIndexedObject(), false))
+            .toList();
     }
 
     @Override
@@ -445,16 +447,29 @@ public class ResearcherProfileServiceImpl implements ResearcherProfileService {
 
     public Map<String, String> getAuthorsIdentifiers(ResearcherProfile profile) {
         // Create a map of profile identifiers.
-        return Stream.of(
+        return createIdentifiersMap(
                 Map.entry(Publication.AUTHOR_EMAIL_FIELD, profile.getEmail()),
                 Map.entry(Publication.AUTHOR_ORCID_FIELD, profile.getOrcid()),
                 Map.entry(Publication.AUTHOR_FGS_FIELD, profile.getFGS())
-            )
+            );
+    }
+
+    public Map<String, String> getProfileIdentifiers(ResearcherProfile profile) {
+        return createIdentifiersMap(
+                Map.entry(ResearcherProfile.EMAIL_FIELD, profile.getPrivateEmail()),
+                Map.entry(ResearcherProfile.OFFICIAL_EMAIL_FIELD, profile.getEmail()),
+                Map.entry(ResearcherProfile.FGS_FIELD, profile.getFGS()),
+                Map.entry(ResearcherProfile.ORCID_FIELD, profile.getOrcid())
+            );
+    }
+
+    @SafeVarargs
+    private static Map<String, String> createIdentifiersMap(Map.Entry<String, Optional<String>>... entries) {
+        return Stream.of(entries)
             .filter(entry -> entry.getValue().isPresent())
             .collect(Collectors.toMap(
                 entry -> entry.getKey(),
                 entry -> entry.getValue().get()
             ));
     }
-
 }

--- a/dspace-api/src/main/java/org/dspace/profile/service/ResearcherProfileService.java
+++ b/dspace-api/src/main/java/org/dspace/profile/service/ResearcherProfileService.java
@@ -9,6 +9,7 @@ package org.dspace.profile.service;
 
 import java.net.URI;
 import java.sql.SQLException;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -42,9 +43,6 @@ public interface ResearcherProfileService {
 
     /**
      * Find a unique `ResearcherProfile` using search criteria.
-     * DEV_NOTE:
-     *   We returned an `Item` (instead of `ResearcherProfile`) because a `ResearcherProfile` must have an owner to
-     *   be valid, but for batch ingested profile, the owner could not be set.
      *
      * @param context the relevant DSpace Context.
      * @param identifiers the list of identifier to search for. Each entry must be a combination of Solr key and value
@@ -52,8 +50,16 @@ public interface ResearcherProfileService {
      * @throws SQLException if any database occurred
      * @throws AuthorizeException if any authorization occurred
      */
-    public Item findByIdentifier(Context context, Map<String, String> identifiers)
+    public ResearcherProfile findFirstByIdentifiers(Context context, Map<String, String> identifiers)
         throws SQLException, AuthorizeException;
+
+    /**
+     * Find all matching ResearcherProfile using the provided identifiers.
+     * @param context The current DSpace context.
+     * @param identifiers The identifiers to search on (fgs, email...).
+     * @return A list of matching researcher profiles.
+     */
+    public List<ResearcherProfile> findByIdentifiers(Context context, Map<String, String> identifiers);
 
     /**
      * Create a new researcher profile for the given ePerson.
@@ -131,8 +137,17 @@ public interface ResearcherProfileService {
     /**
      * Retrieve a map of identifiers for the given profile.
      * The key of the map is the metadata field string and the value is the value of the identifier.
+     * This can be used to find authors using referencing this profile.
      * @param profile The profile to generate a map for.
      * @return A map containing the identifiers of the given profile.
      */
     public Map<String, String> getAuthorsIdentifiers(ResearcherProfile profile);
+
+    /**
+     * Retrieve a map of identifiers for the given profile.
+     * The key of the map is the metadata field string and the value is the value of the identifier.
+     * @param profile The profile to generate a map for.
+     * @return A map containing the identifiers of the given profile.
+     */
+    public Map<String, String> getProfileIdentifiers(ResearcherProfile profile);
 }

--- a/dspace-api/src/main/java/org/dspace/uclouvain/itemValidators/ItemValidator.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/itemValidators/ItemValidator.java
@@ -1,0 +1,22 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.itemValidators;
+
+import org.dspace.content.Item;
+import org.dspace.core.Context;
+import org.dspace.uclouvain.itemValidators.exceptions.ItemValidationException;
+
+/**
+ * An item validator is a class that can be used to process some validation on an item before creating/updating it.
+ * This can be especially useful when checking for duplicates for example.
+ * 
+ * @author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+public interface ItemValidator {
+    public void validate(Context context, Item item) throws ItemValidationException;
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/itemValidators/exceptions/ItemValidationException.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/itemValidators/exceptions/ItemValidationException.java
@@ -1,0 +1,30 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.itemValidators.exceptions;
+
+/**
+ * RuntimeException to throw when an item was considered not valid and so cannot be created/updated.
+ * 
+ * DEV_NOTE: We use a RuntimeException so that we are not forced to handle it in the calling classes.
+ * 
+ * @author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+public class ItemValidationException extends RuntimeException {
+    // Store a string to use in the frontend for translation purposes.
+    protected String translatableMessage;
+
+    public ItemValidationException(String message, String translatableMessage) {
+        super(message);
+        this.translatableMessage = translatableMessage;
+    }
+
+    // GETTERS && SETTERS
+    public String getTranslatableMessage() {
+        return translatableMessage;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/itemValidators/factories/ItemValidatorFactory.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/itemValidators/factories/ItemValidatorFactory.java
@@ -1,0 +1,31 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.itemValidators.factories;
+
+import org.dspace.content.Item;
+import org.dspace.uclouvain.itemValidators.ItemValidator;
+
+/**
+ * Factory to retrieve a {@link ItemValidator} for a given item or entityType.
+ * 
+ * @author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+public interface ItemValidatorFactory {
+    /**
+     * Retrieve an {@link ItemValidator} for a given item.
+     * @param item The item to get a validator for.
+     * @return The validator for the given item. Null if none existing for the provided item entity-type.
+     */
+    public ItemValidator getValidator(Item item);
+    /**
+     * Retrieve an {@link ItemValidator} for a given entity-type.
+     * @param entityType The entity-type to get a validator for.
+     * @return The validator for the given item. Null if none existing for the provided item entity-type.
+     */
+    public ItemValidator getValidator(String entityType);
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/itemValidators/factories/ItemValidatorFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/itemValidators/factories/ItemValidatorFactoryImpl.java
@@ -1,0 +1,52 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.itemValidators.factories;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.dspace.content.Item;
+import org.dspace.content.service.ItemService;
+import org.dspace.uclouvain.itemValidators.ItemValidator;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Factory to retrieve a specific ItemValidator for a given item.
+ */
+public class ItemValidatorFactoryImpl implements ItemValidatorFactory {
+
+    private Map<String, ItemValidator> validatorsMap = new HashMap<>();
+
+    @Autowired
+    protected ItemService itemService;
+
+    // PUBLIC METHODS
+
+    @Override
+    public ItemValidator getValidator(Item item) {
+        return getValidator(itemService.getEntityType(item));
+    }
+
+    @Override
+    public ItemValidator getValidator(String entityType) {
+        return StringUtils.isNotBlank(entityType)
+            ? validatorsMap.get(entityType)
+            : null;
+    }
+
+    // SETTERS AND GETTERS
+
+    public Map<String, ItemValidator> getValidatorsMap() {
+        return validatorsMap;
+    }
+
+    public void setValidatorsMap(Map<String, ItemValidator> validatorsMap) {
+        this.validatorsMap = validatorsMap;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/itemValidators/validators/ItemProfileValidator.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/itemValidators/validators/ItemProfileValidator.java
@@ -1,0 +1,50 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.itemValidators.validators;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.dspace.content.Item;
+import org.dspace.core.Context;
+import org.dspace.profile.ResearcherProfile;
+import org.dspace.profile.service.ResearcherProfileService;
+import org.dspace.uclouvain.itemValidators.ItemValidator;
+import org.dspace.uclouvain.itemValidators.exceptions.ItemValidationException;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Validate a Profile Item.
+ * Check if the identifiers of the item are already existing in another profile item.
+ * Email, fgs and ORCID have to be unique and cannot be present in two different profiles.
+ * 
+ * @author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+public class ItemProfileValidator implements ItemValidator {
+
+    @Autowired
+    ResearcherProfileService researcherProfileService;
+
+    public void validate(Context context, Item item) throws ItemValidationException {
+        ResearcherProfile profile = new ResearcherProfile(item, false);
+        Map<String, String> identifiers = researcherProfileService.getProfileIdentifiers(profile);
+        if (identifiers.isEmpty()) {
+            return;
+        }
+        boolean hasOtherProfile = researcherProfileService.findByIdentifiers(context, identifiers)
+            .stream()
+            .anyMatch(matchingProfile -> !Objects.equals(matchingProfile.getItem().getID(), item.getID()));
+        if (hasOtherProfile) {
+            // Found an already existing profile with the same identifiers.
+            throw new ItemValidationException(
+                "Found an already existing profile with the same identifiers.",
+                "item.validator.person.not-unique.message"
+            );
+        }
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/packager/DSpaceUCLouvainMETSIngester.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/packager/DSpaceUCLouvainMETSIngester.java
@@ -50,6 +50,7 @@ import org.dspace.content.service.DSpaceObjectService;
 import org.dspace.content.service.MetadataFieldService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
+import org.dspace.profile.ResearcherProfile;
 import org.dspace.profile.service.ResearcherProfileService;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
@@ -548,11 +549,12 @@ public class DSpaceUCLouvainMETSIngester extends DSpaceMETSIngester {
                     .map(entry -> entry.getKey() + ":" + entry.getValue())
                     .collect(Collectors.joining(", ", "[", "]"));
                 log.debug("  * Identifiers are " + pretty);
-                Item profile = researcherProfileService.findByIdentifier(context, identifiers);
+                ResearcherProfile profile = researcherProfileService.findFirstByIdentifiers(context, identifiers);
                 if (profile != null) {
-                    log.debug("  * Matching authority found: " + profile.getID());
-                    updateAuthorElementValues(authorElement, profile);
-                    authorElement.setAttribute("authority", profile.getID().toString());
+                    Item profileItem = profile.getItem();
+                    log.debug("  * Matching authority found: " + profileItem.getID());
+                    updateAuthorElementValues(authorElement, profileItem);
+                    authorElement.setAttribute("authority", profileItem.getID().toString());
                 } else {
                     log.debug("  * No matching authority for this author");
                 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
@@ -33,6 +33,7 @@ import org.dspace.core.Context;
 import org.dspace.eperson.InvalidReCaptchaException;
 import org.dspace.orcid.exception.OrcidValidationException;
 import org.dspace.services.ConfigurationService;
+import org.dspace.uclouvain.itemValidators.exceptions.ItemValidationException;
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
@@ -268,6 +269,19 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
         // something. We can't do anything. To avoid excessive stack traces
         // in log, just print a simple message
         log.warn("ClientAbortException");
+    }
+
+    /**
+     * Custom exception handler for ItemValidationException that returns the translatable message in the HTTP response.
+     * @param request The incoming request object.
+     * @param response The response object to send back to the client.
+     * @param ex The Exception to handle.
+     * @throws IOException
+     */
+    @ExceptionHandler(ItemValidationException.class)
+    protected void handleItemValidationException(
+        HttpServletRequest request, HttpServletResponse response, ItemValidationException ex) throws IOException {
+        sendErrorResponse(request, response, ex, ex.getTranslatableMessage(), HttpStatus.CONFLICT.value());
     }
 
     @ExceptionHandler(Exception.class)

--- a/dspace/config/spring/uclouvain/uclouvain-services.xml
+++ b/dspace/config/spring/uclouvain/uclouvain-services.xml
@@ -35,6 +35,16 @@
 
     <bean id="profileActionFactory" class="org.dspace.uclouvain.profileIngester.actions.factory.ProfileActionFactoryImpl"/>
 
+    <bean id="itemValidatorFactory" class="org.dspace.uclouvain.itemValidators.factories.ItemValidatorFactoryImpl">
+        <property name="validatorsMap">
+            <util:map>
+                <entry key="Person" value-ref="itemProfileValidator"/>
+            </util:map>
+        </property>
+    </bean>
+    <!-- VALIDATORS -->
+    <bean id="itemProfileValidator" class="org.dspace.uclouvain.itemValidators.validators.ItemProfileValidator"/>
+
     <!-- SERVICES ========================================================= -->
     <bean id="uclouvainDirectLinkService" class="org.dspace.uclouvain.services.DirectLinkServiceImpl"/>
     <bean id="publicationAuthorAuthority" class="org.dspace.uclouvain.authority.PublicationAuthorAuthority"/>


### PR DESCRIPTION
## Description

Added a new system to define a validator for each item entity-type. When an item is created or updated, the validator is executed an can cancel the update if some requirements are not met. For profiles, a new validator has been added to prevent duplicate identifiers (on email, fgs and ORCID).
Also added a new 'ExceptionHandler' to DSpace that allows to send a specfic translatable string to the frontend when an error is fired in a validator.

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module