### PR TITLE
[ADD] feat(crossref): External data import at item creation.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/uclouvain/consumer/EnrichMetadataConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/consumer/EnrichMetadataConsumer.java
@@ -1,0 +1,100 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.consumer;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.dspace.content.Item;
+import org.dspace.content.dto.MetadataValueDTO;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.dspace.event.Consumer;
+import org.dspace.event.Event;
+import org.dspace.external.model.ExternalDataObject;
+import org.dspace.submit.listener.MetadataListener;
+import org.dspace.utils.DSpace;
+
+/**
+ * The main goal of this consumer is to add additional metadata to a freshly created Item which
+ * would already have some metadata.
+ * The intent is to enrich the metadata of the object with some external source (Crossref for example).
+ * 
+ * @author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+public class EnrichMetadataConsumer implements Consumer {
+
+    private MetadataListener listener;
+    private ItemService itemService;
+
+    private Set<UUID> itemsToEnrich = new HashSet<>();
+
+    @Override
+    public void initialize() throws Exception {
+        listener = new DSpace().getSingletonService(MetadataListener.class);
+        itemService = ContentServiceFactory.getInstance().getItemService();
+    }
+
+    @Override
+    public void consume(Context context, Event event) throws Exception {
+        if (event.getSubjectType() != Constants.ITEM) {
+            return;
+        }
+        Item item = (Item) event.getSubject(context);
+        if (item != null) {
+            itemsToEnrich.add(item.getID());
+        }
+    }
+
+    @Override
+    public void end(Context context) throws Exception {
+        for (UUID uuid: itemsToEnrich) {
+            Item item = itemService.find(context, uuid);
+
+            Set<String> existingFields = item.getMetadata()
+                .stream()
+                .map(metadata -> metadata.getMetadataField().toString('.'))
+                .distinct()
+                .collect(Collectors.toSet());
+            if (existingFields.isEmpty()) {
+                // If no fields are present in the item, we can just exit here.
+                continue;
+            }
+
+            Set<String> externalMetadata = listener.getMetadataToListen()
+                .stream()
+                .filter(listenerMetadata -> existingFields.contains(listenerMetadata))
+                .collect(Collectors.toSet());
+            if (externalMetadata.isEmpty()) {
+                continue;
+            }
+
+            ExternalDataObject externalObject = listener.getExternalDataObject(context, item, externalMetadata);
+            if (externalObject != null) {
+                for (MetadataValueDTO metadata : externalObject.getMetadata()) {
+                    if (!existingFields.contains(metadata.getMetadataField())) {
+                        itemService.addMetadata(
+                            context, item,
+                            metadata.getSchema(), metadata.getElement(), metadata.getQualifier(),
+                            null, metadata.getValue()
+                        );
+                    }
+                }
+            }
+        }
+        itemsToEnrich.clear();
+    }
+
+    @Override
+    public void finish(Context context) throws Exception {
+    }
+}

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -823,8 +823,8 @@ event.dispatcher.RelatedItemEnhancerUpdatePoller.class = org.dspace.event.BasicD
 # Add rdf here, if you are using dspace-rdf to export your repository content as RDF.
 # Add iiif here, if you are using dspace-iiif.
 # Add orcidqueue here, if the integration with ORCID is configured and wish to enable the synchronization queue functionality
-event.dispatcher.default.consumers = versioning, discovery, eperson, dedup, crisconsumer, orcidqueue, audit, qaeventsdelete, referenceresolver, orcidwebhook, itemenhancer, customurl, iiif, reciprocal, filetypemetadataenhancer, authoritylink, ldnmessage,  licensegenerator, accesstype, authoritymetadataenhancer, formfieldcleaner, fillervalueremover, dissertationyearextract, journaldefaultdeletepolicy, profilelink
-event.dispatcher.RelatedItemEnhancerUpdatePoller.consumers = versioning, discovery, eperson, dedup, crisconsumer, orcidqueue, audit, qaeventsdelete, referenceresolver, orcidwebhook, itemenhancer, customurl, iiif, reciprocal, filetypemetadataenhancer, authoritylink, ldnmessage, journaldefaultdeletepolicy, profilelink
+event.dispatcher.default.consumers = versioning, discovery, eperson, dedup, crisconsumer, orcidqueue, audit, qaeventsdelete, referenceresolver, orcidwebhook, itemenhancer, customurl, iiif, reciprocal, filetypemetadataenhancer, authoritylink, ldnmessage,  licensegenerator, accesstype, authoritymetadataenhancer, formfieldcleaner, fillervalueremover, dissertationyearextract, journaldefaultdeletepolicy, profilelink, enrichmetadata
+event.dispatcher.RelatedItemEnhancerUpdatePoller.consumers = versioning, discovery, eperson, dedup, crisconsumer, orcidqueue, audit, qaeventsdelete, referenceresolver, orcidwebhook, itemenhancer, customurl, iiif, reciprocal, filetypemetadataenhancer, authoritylink, ldnmessage, journaldefaultdeletepolicy, profilelink, enrichmetadata
 
 # enable the item enhancer poller
 related-item-enhancer-poller.enabled = true

--- a/dspace/config/modules/uclouvain.cfg
+++ b/dspace/config/modules/uclouvain.cfg
@@ -99,6 +99,9 @@ event.consumer.journaldefaultdeletepolicy.group = Journal manager
 event.consumer.profilelink.class = org.dspace.uclouvain.consumer.ProfileLinkConsumer
 event.consumer.profilelink.filters = Item+Install|Modify|Modify_Metadata
 
+event.consumer.enrichmetadata.class = org.dspace.uclouvain.consumer.EnrichMetadataConsumer
+event.consumer.enrichmetadata.filters = Item+Create
+
 #------------------------------------------------------------------#
 #------------- Community/Collection configuration -----------------#
 #------------------------------------------------------------------#

--- a/dspace/config/spring/api/crossref-integration.xml
+++ b/dspace/config/spring/api/crossref-integration.xml
@@ -178,7 +178,7 @@
         <property name="query" value="/publisher"/>
     </bean>
     <bean id="crossref.publisher" class="org.dspace.importer.external.metadatamapping.MetadataFieldConfig">
-        <constructor-arg value="dc.publisher"/>
+        <constructor-arg value="publication.editor.name"/>
     </bean>
 
     <bean class="java.lang.Integer" id="maxRetry">


### PR DESCRIPTION
## Description

Added a consumer to enrich the metadata of a created item using external source. This allows, for example, to complete the metadata of an object imported from ORCID.

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module