### PR TITLE
[ADD] feat(solr-search): API endpoint to query Solr for publications search.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/uclouvain/search/model/SolrSearchResponse.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/search/model/SolrSearchResponse.java
@@ -1,0 +1,62 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.search.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Object to send as an API response for a search result.
+ * 
+ * @author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+public class SolrSearchResponse {
+    private long total;
+    private int page;
+    private int size;
+    private List<Map<String, Object>> results = new ArrayList<>();
+
+    // GETTERS && SETTERS
+
+    public long getTotal() {
+        return total;
+    }
+
+    public SolrSearchResponse setTotal(long total) {
+        this.total = total;
+        return this;
+    }
+
+    public int getPage() {
+        return page;
+    }
+
+    public SolrSearchResponse setPage(int page) {
+        this.page = page;
+        return this;
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+    public SolrSearchResponse setSize(int size) {
+        this.size = size;
+        return this;
+    }
+
+    public List<Map<String, Object>> getResults() {
+        return results;
+    }
+
+    public SolrSearchResponse setResults(List<Map<String, Object>> results) {
+        this.results = results;
+        return this;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/search/services/UCLouvainSearchService.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/search/services/UCLouvainSearchService.java
@@ -1,0 +1,30 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.search.services;
+
+import java.util.List;
+
+import org.dspace.core.Context;
+import org.dspace.discovery.SearchServiceException;
+import org.dspace.uclouvain.search.model.SolrSearchResponse;
+
+public interface UCLouvainSearchService {
+    /**
+     * Perform a SOLR search on all available publications.
+     * @param context The current DSpace application context.
+     * @param query The query to execute.
+     * @param filterQueries The filters queries.
+     * @param page The page number of the result.
+     * @param size The size of each page.
+     * @return A SolrSearchResponse object containing the search result and the search parameters.
+     * @throws SearchServiceException if any exception occurres while querying Solr.
+     */
+    public SolrSearchResponse searchPublications(
+        Context context, String query, List<String> filterQueries, int page, int size
+    ) throws SearchServiceException;
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/search/services/UCLouvainSearchServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/search/services/UCLouvainSearchServiceImpl.java
@@ -1,0 +1,140 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.search.services;
+
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.common.SolrDocument;
+import org.apache.solr.common.SolrDocumentList;
+import org.dspace.core.Context;
+import org.dspace.discovery.SearchServiceException;
+import org.dspace.discovery.SolrSearchCore;
+import org.dspace.uclouvain.core.model.publication.Publication;
+import org.dspace.uclouvain.search.model.SolrSearchResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Service to directly query SOLR without going through DSpace layer.
+ * 
+ * @author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+public class UCLouvainSearchServiceImpl implements UCLouvainSearchService {
+
+    @Autowired
+    protected SolrSearchCore solrSearchCore;
+
+    private List<String> fieldValidationRegexps = new ArrayList<>();
+
+    private static final Pattern SOLR_ERROR_PATTERN =
+        Pattern.compile("org\\.apache\\.solr\\.search\\.(.+?)(?:\\r?\\n|$)");
+    private static final String DEFAULT_SOLR_ERROR_MESSAGE = "Search exception occurred";
+
+    public SolrSearchResponse searchPublications(
+        Context context, String query, List<String> filterQueries, int page, int size
+    ) throws SearchServiceException {
+        SolrQuery solrQuery = new SolrQuery(query);
+        // Default filters: Keep only Publication items which are archived, discoverable and not withdrawn.
+        String[] defaultFilters = {
+            "search.resourcetype:Item",
+            "dspace.entity.type:" + Publication.ENTITY_TYPE,
+            "archived:true",
+            "discoverable:true",
+            "withdrawn:false"
+        };
+        solrQuery.addFilterQuery(defaultFilters);
+        // Add user's filters.
+        Optional.ofNullable(filterQueries).ifPresent(filters -> filters.forEach(solrQuery::addFilterQuery));
+        solrQuery.setStart(page * size);
+        solrQuery.setRows(size);
+
+        // Query SOLR using created SolrQuery
+        try {
+            QueryResponse response = solrSearchCore.getSolr().query(solrQuery, solrSearchCore.REQUEST_METHOD);
+            SolrDocumentList results = response.getResults();
+
+            SolrSearchResponse searchResponse = new SolrSearchResponse()
+                .setPage(page)
+                .setSize(size)
+                .setTotal(results.getNumFound())
+                .setResults(parseDocs(results));
+
+            return searchResponse;
+        } catch (Exception e) {
+            throw new SearchServiceException(parseSolrMessage(e.getMessage()));
+        }
+    }
+
+    /**
+     * Parse a SolrDocumentList into a usable List of Map.
+     * Each document (=publication) is converted into a Map of String/object (field/value).
+     * @param docs The SolrDocumentList object.
+     * @return A List of Map<String, Object> representing the field/values pair of each publication.
+     */
+    private List<Map<String, Object>> parseDocs(SolrDocumentList docs) {
+        return docs.stream().map(this::parseDoc).toList();
+    }
+
+    /**
+     * Convert a SolrDocument into a Map of String Object.
+     * EAch key of the map is a solr field and each value is the value for that field.
+     * @param doc the SolrDocument object to convert.
+     * @return A Map containing all the SolrDocument's fields and their corresponding values.
+     */
+    private Map<String, Object> parseDoc(SolrDocument doc) {
+        Map<String, Object> cleaned = new HashMap<>();
+        doc.getFieldNames().forEach(field -> {
+            if (isValid(field)) {
+                cleaned.put(field, doc.getFieldValue(field));
+            }
+        });
+        return cleaned;
+    }
+
+    /**
+     * A field is valid if at least one of the configured regexp matches.
+     * @param field The field to check validity of
+     */
+    private boolean isValid(String field) {
+        return fieldValidationRegexps.stream().anyMatch(regex -> field.matches(regex));
+    }
+
+    /**
+     * Parse a Solr error to keep only the interesting part of the message (and not leak any sensitive data).
+     * @param message The error message.
+     * @return A cleaned version of the error message.
+     */
+    private String parseSolrMessage(String message) {
+        if (isEmpty(message)) {
+            return DEFAULT_SOLR_ERROR_MESSAGE;
+        }
+        // Keep only the part of the error message matching this regex.
+        Matcher matcher = SOLR_ERROR_PATTERN.matcher(message);
+        // Default error message if pattern does not match.
+        return matcher.find() ? matcher.group(1).trim() : DEFAULT_SOLR_ERROR_MESSAGE;
+    }
+
+    // GETTER && SETTERS
+
+    public void setFieldValidationRegexps(List<String> fieldValidationRegexps) {
+        this.fieldValidationRegexps = fieldValidationRegexps;
+    }
+
+    public List<String> getFieldValidationRegexps() {
+        return fieldValidationRegexps;
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/SearchRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/SearchRestController.java
@@ -1,0 +1,61 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest;
+
+import java.util.List;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.dspace.app.rest.exception.InvalidSearchRequestException;
+import org.dspace.app.rest.utils.ContextUtil;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.core.Context;
+import org.dspace.discovery.SearchServiceException;
+import org.dspace.eperson.service.GroupService;
+import org.dspace.uclouvain.search.model.SolrSearchResponse;
+import org.dspace.uclouvain.search.services.UCLouvainSearchService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/uclouvain/search")
+public class SearchRestController {
+    @Autowired
+    UCLouvainSearchService uclouvainSearchService;
+    @Autowired
+    GroupService groupService;
+    @Autowired
+    AuthorizeService authorizeService;
+
+    // MAIN ENDPOINTS --------------------------------------------------------------------------------------------------
+
+    @GetMapping
+    // Allow user to access to the search endpoint if he is a member of the configured group.
+    @PreAuthorize("@groupSecurity.isMemberOf('Publication API Search')")
+    public ResponseEntity<?> search(
+        HttpServletResponse response, HttpServletRequest request,
+        @RequestParam(value = "q", defaultValue = "*:*") String query,
+        @RequestParam(value = "fq", required = false) List<String> filterQueries,
+        @RequestParam(value = "page", defaultValue = "0") int page,
+        @RequestParam(value = "size", defaultValue = "10") int size
+    ) {
+        Context context = ContextUtil.obtainContext(request);
+        try {
+            SolrSearchResponse res = uclouvainSearchService
+                .searchPublications(context, query, filterQueries, page, size);
+            return ResponseEntity.ok(res);
+        } catch (SearchServiceException e) {
+            throw new InvalidSearchRequestException(e.getMessage(), e);
+        }
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DspaceNotFoundException.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DspaceNotFoundException.java
@@ -1,0 +1,27 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * When a request is send to an existing endpoint but we don't want the user to know that the endpoint exists.
+ *
+ * @author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+@ResponseStatus(value = HttpStatus.NOT_FOUND, reason = "Not Found")
+public class DspaceNotFoundException extends RuntimeException {
+    public DspaceNotFoundException(String message) {
+        super(message);
+    }
+
+    public DspaceNotFoundException(String message, Exception e) {
+        super(message, e);
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/GroupSecurityEvaluator.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/GroupSecurityEvaluator.java
@@ -1,0 +1,69 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.security;
+
+import java.sql.SQLException;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.dspace.app.rest.utils.ContextUtil;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.core.Context;
+import org.dspace.eperson.Group;
+import org.dspace.eperson.service.GroupService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Group security component to check for group membership.
+ * 
+ * @author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+@Component(value = "groupSecurity")
+public class GroupSecurityEvaluator {
+    @Autowired
+    private GroupService groupService;
+    @Autowired
+    private HttpServletRequest request;
+    @Autowired
+    private AuthorizeService authorizeService;
+
+    /**
+     * Check whether the current DSpace user is a member of at least one
+     * of the given groups.
+     * 
+     * An admin user is considered a member of any group.
+     *
+     * Intended for use in Spring Security SpEL expressions.
+     *
+     * @param groupNames one or more group names
+     * @return true if the current user belongs to any of the groups,
+     *         false otherwise or in case of error
+     */
+    public boolean isMemberOf(String... groupNames) {
+        Context context = ContextUtil.obtainContext(request);
+
+        if (context == null || context.getCurrentUser() == null) {
+            return false;
+        }
+
+        try {
+            if (authorizeService.isAdmin(context)) {
+                return true;
+            }
+            for (String groupName : groupNames) {
+                Group group = groupService.findByName(context, groupName);
+                if (group != null && groupService.isMember(context, context.getCurrentUser(), group)) {
+                    return true;
+                }
+            }
+        } catch (SQLException e) {
+            return false;
+        }
+        return false;
+    }
+}

--- a/dspace/config/spring/uclouvain/uclouvain-services.xml
+++ b/dspace/config/spring/uclouvain/uclouvain-services.xml
@@ -63,6 +63,18 @@
     <bean id="uclouvainProfileService" class="org.dspace.uclouvain.services.UCLouvainProfileServiceImpl"/>
     <bean id="idmPersonValidityService" class="org.dspace.uclouvain.profileIngester.services.IDMPersonValidityServiceImpl"/>
     <bean id="uclouvainExportService" class="org.dspace.uclouvain.export.services.UCLouvainExportServiceImpl"/>
+    <bean id="uclouvainSearchService" class="org.dspace.uclouvain.search.services.UCLouvainSearchServiceImpl">
+        <property name="fieldValidationRegexps">
+            <!-- One of the following has to match in order to keep the field in the search result: -->
+            <util:list>
+                <!-- Keep all metadata fields of form "<schema>.<element>(.qualifier)" that are not containing the word "email" -->
+                <!-- This does not include fields containing an underscore like "dc.title_dt" for example -->
+                <value>^(?!.*email)[a-z][a-zA-Z]*\.[a-z][a-zA-Z]*(\.[a-z][a-zA-Z]*)?$</value>
+                <!-- Keep "handle" field -->
+                <value>^handle$</value>
+            </util:list>
+        </property>
+    </bean>
 
     <!-- UTILS ============================================================ -->
     <bean id="itemUtils" class="org.dspace.uclouvain.core.utils.ItemUtils" />

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -162,6 +162,8 @@ while IFS= read -r group; do
   create_group "${group}"
 done < <(jq -r '.users[].groups[]' ${USERS_CONFIG_PATH} | sort -u)
 create_group "UCLouvain network"
+# Group for Search API access
+create_group "Publication API Search"
 
 echo -e "👤 Creating admin user..."
 users_number=$(jq '.admins | length' "${USERS_CONFIG_PATH}")


### PR DESCRIPTION
## Description

Added a new endpoint to query SOLR in order to find publications. The endpoint only returns publication items that are archived, discoverable and not withdrawn. The client can specify a query, some filter queries, a page and a size.

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module