### PR TITLE
[UPD] feat(indexing) Authors of a publication can now see it in their dashboard.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -2475,6 +2475,7 @@ prevent the generation of resource policy entry values with null dspace_object a
             existing.setAuthority(authority);
             existing.setLanguage(lang);
             existing.setConfidence((confidence != null) ? confidence : CF_UNSET);
+            item.setMetadataModified();
         } else {
             String[] metadataField = getMDValueByField(mdString);
             addMetadata(

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceWorkspaceWorkflowRestrictionPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceWorkspaceWorkflowRestrictionPlugin.java
@@ -9,6 +9,7 @@ package org.dspace.discovery;
 
 import java.sql.SQLException;
 import java.util.Set;
+import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.solr.client.solrj.SolrQuery;
@@ -73,13 +74,19 @@ public class SolrServiceWorkspaceWorkflowRestrictionPlugin implements SolrServic
 
         // extra security check to avoid the possibility that an anonymous user
         // get access to workspace or workflow
-        if (currentUser == null && (isWorkflow || isWorkspace || isSupervision)) {
-            throw new IllegalStateException(
-                    "An anonymous user cannot perform a workspace or workflow search");
+        if (currentUser == null) {
+            if (isWorkflow || isWorkspace || isSupervision) {
+                throw new IllegalStateException(
+                        "An anonymous user cannot perform a workspace or workflow search");
+            }
+            return;
         }
+        UUID userID = currentUser.getID();
         if (isWorkspace) {
-            // insert filter by submitter
-            solrQuery.addFilterQuery("submitter_authority:(" + currentUser.getID() + ")");
+            // insert filter by submitter or read right.
+            // This allows to see a publication where the user is mentioned as a contributor.
+            solrQuery.addFilterQuery("submitter_authority:(%s) OR read: (e%s)"
+                .formatted(userID, userID));
         } else if ((isWorkflow && !isWorkflowAdmin) || (isSupervision && !isAdmin(context))) {
             // Retrieve all the groups the current user is a member of !
             Set<Group> groups;
@@ -96,6 +103,8 @@ public class SolrServiceWorkspaceWorkflowRestrictionPlugin implements SolrServic
                 controllerQuery.append(" OR g").append(group.getID());
             }
             controllerQuery.append(")");
+            // This allows to see a publication where the user is mentioned as a contributor.
+            controllerQuery.append(" OR read:(e%s)".formatted(userID));
             solrQuery.addFilterQuery(controllerQuery.toString());
         }
     }

--- a/dspace-api/src/main/java/org/dspace/uclouvain/consumer/FormFieldCleanerConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/consumer/FormFieldCleanerConsumer.java
@@ -131,9 +131,16 @@ public class FormFieldCleanerConsumer implements Consumer {
 
                 // Delete all metadata that should not be present
                 if (metadataToRemove.size() != 0) {
-                    this.logger.debug("Found metadata to remove because type-bind was not valid: " + metadataToRemove);
-                    itemService.removeMetadataValues(context, item, metadataToRemove);
-                    itemService.update(context, item);
+                    context.turnOffAuthorisationSystem();
+                    try {
+                        this.logger.debug(
+                            "Found metadata to remove because type-bind was not valid: " + metadataToRemove
+                        );
+                        itemService.removeMetadataValues(context, item, metadataToRemove);
+                        itemService.update(context, item);
+                    } finally {
+                        context.restoreAuthSystemState();
+                    }
                 }
             } catch (Exception e) {
                 logger.error(

--- a/dspace-api/src/main/java/org/dspace/uclouvain/consumer/ProfileLinkConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/consumer/ProfileLinkConsumer.java
@@ -42,14 +42,14 @@ import org.dspace.utils.DSpace;
  */
 public class ProfileLinkConsumer implements Consumer {
 
-    private Logger logger = LogManager.getLogger(ProfileLinkConsumer.class);
-
     private ItemService itemService;
     private MetadataValueService metadataValueService;
     private PublicationService publicationService;
     private ResearcherProfileService researcherProfileService;
 
-    private Set<UUID> profilesToProcess = new HashSet<>();
+    private static final Logger logger = LogManager.getLogger(ProfileLinkConsumer.class);
+
+    private Set<Item> itemsToUpdate = new HashSet<>();
 
     @Override
     public void initialize() throws Exception {
@@ -62,78 +62,87 @@ public class ProfileLinkConsumer implements Consumer {
 
     @Override
     public void consume(Context context, Event event) throws Exception {
-        Item item = (Item) event.getSubject(context);
-        if (item != null && ResearcherProfile.ENTITY_TYPE.equals(itemService.getEntityType(item))) {
-            profilesToProcess.add(item.getID());
-        }
-    }
-
-    @Override
-    public void end(Context context) throws Exception {
-        if (profilesToProcess.isEmpty()) {
-            return;
-        }
-
-        for (UUID profileUUID : profilesToProcess) {
-            logger.debug("In consumer for profile with uuid " + profileUUID);
-            Item profileItem = itemService.find(context, profileUUID);
+        Item profileItem = (Item) event.getSubject(context);
+        if (profileItem != null && ResearcherProfile.ENTITY_TYPE.equals(itemService.getEntityType(profileItem))) {
+            logger.debug("In consumer for profile with uuid " + profileItem.getID());
+            UUID profileUUID = profileItem.getID();
             ResearcherProfile profile = new ResearcherProfile(profileItem, false);
             Map<String, String> authorsIdentifier = researcherProfileService.getAuthorsIdentifiers(profile);
             logger.debug("Profile authors identifiers: " + authorsIdentifier);
             if (authorsIdentifier.isEmpty()) {
-                continue;
+                return;
             }
 
             // Once we have the full identifiers map, check for matching publications.
             List<Pair<DSpaceObject, Integer>> matchingPublicationsPlaces = metadataValueService
                     .findByFieldAndValue(context, authorsIdentifier, false);
-            Set<Item> itemsToUpdate = new HashSet<>();
-
-            for (Pair<DSpaceObject, Integer> publicationPlace : matchingPublicationsPlaces) {
-                DSpaceObject dso = publicationPlace.getLeft();
-                int place = publicationPlace.getRight();
-                // We only manage items
-                if (!(dso instanceof Item item)) {
-                    continue;
-                }
-                try {
-                    if (!Objects.equals(itemService.getEntityType(item), Publication.ENTITY_TYPE)) {
+            context.turnOffAuthorisationSystem();
+            try {
+                for (Pair<DSpaceObject, Integer> publicationPlace : matchingPublicationsPlaces) {
+                    DSpaceObject dso = publicationPlace.getLeft();
+                    int place = publicationPlace.getRight();
+                    // We only manage items
+                    if (!(dso instanceof Item item)) {
                         continue;
                     }
-                    logger.debug("Found publication to update!! " + item.getID()
-                            + " with title " + item.getName());
-                    logger.debug("Update needed at place " + place);
-                    // Once we have the publication and the place,
-                    // we need to update the metadata values of the corresponding author.
-                    Publication publication = PublicationFactory.build(item);
-                    String previousRole = publication.getAuthor(place).getRole();
-                    // Set values of the author for the found place.
-                    publicationService.setAuthor(
-                            context,
-                            publication,
-                            profile.getName().orElse(null),
-                            profile.getEmail().orElse(null),
-                            profile.getOrcid().orElse(null),
-                            profile.getFGS().orElse(null),
-                            profile.getInstitution().orElse(null),
-                            // Use previously set role.
-                            previousRole,
-                            profileUUID,
-                            place);
-                    itemsToUpdate.add(item);
-                } catch (Exception e) {
-                    logger.warn(
-                        "Could not link author profile %s to publication %s".formatted(profileUUID, item.getID()),
-                        e
-                    );
+                    try {
+                        if (!Objects.equals(itemService.getEntityType(item), Publication.ENTITY_TYPE)) {
+                            continue;
+                        }
+                        logger.debug("Found publication to update!! " + item.getID()
+                                + " with title " + item.getName());
+                        logger.debug("Update needed at place " + place);
+                        // Once we have the publication and the place,
+                        // we need to update the metadata values of the corresponding author.
+                        Publication publication = PublicationFactory.build(item);
+                        String previousRole = publication.getAuthor(place).getRole();
+                        // Set values of the author for the found place.
+                        publicationService.setAuthor(
+                                context,
+                                publication,
+                                profile.getName().orElse(null),
+                                profile.getEmail().orElse(null),
+                                profile.getOrcid().orElse(null),
+                                profile.getFGS().orElse(null),
+                                profile.getInstitution().orElse(null),
+                                // Use previously set role.
+                                previousRole,
+                                profileUUID,
+                                place);
+                        itemsToUpdate.add(item);
+                        // We need to fire an event here to trigger the indexing consumer and update the Solr index.
+                        context.addEvent(new Event(
+                            Event.MODIFY_METADATA,
+                            item.getType(),
+                            item.getID(),
+                            null,
+                            itemService.getIdentifiers(context, item)
+                        ));
+                    } catch (Exception e) {
+                        logger.warn(
+                            "Could not link author profile %s to publication %s".formatted(profileUUID, item.getID()),
+                            e
+                        );
+                    }
                 }
+            } finally {
+                context.restoreAuthSystemState();
             }
+        }
+    }
+
+    @Override
+    public void end(Context context) throws Exception {
+        context.turnOffAuthorisationSystem();
+        try {
             for (Item itemToUpdate : itemsToUpdate) {
                 // Do external update of item since an item can be updated multiple times in the previous process.
                 itemService.update(context, itemToUpdate);
             }
+            itemsToUpdate.clear();
+        } finally {
+            context.restoreAuthSystemState();
         }
-        profilesToProcess.clear();
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/uclouvain/discovery/indexing/SolrServicePublicationIndexingPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/discovery/indexing/SolrServicePublicationIndexingPlugin.java
@@ -7,24 +7,32 @@
  */
 package org.dspace.uclouvain.discovery.indexing;
 
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.solr.common.SolrInputDocument;
 import org.dspace.content.Item;
+import org.dspace.content.MetadataValue;
+import org.dspace.content.service.ItemService;
 import org.dspace.core.Context;
 import org.dspace.discovery.IndexableObject;
 import org.dspace.discovery.SolrServiceIndexPlugin;
+import org.dspace.eperson.EPerson;
+import org.dspace.eperson.service.EPersonService;
 import org.dspace.uclouvain.core.model.exceptions.InvalidModelEntityTypeException;
 import org.dspace.uclouvain.core.model.publication.Publication;
 import org.dspace.uclouvain.core.model.publication.PublicationAuthor;
 import org.dspace.uclouvain.core.model.publication.PublicationFactory;
 import org.dspace.uclouvain.services.UCLouvainFWBValidationService;
 import org.dspace.uclouvain.validation.fnrs.FNRSValidator;
+import org.dspace.util.UUIDUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -43,7 +51,10 @@ public class SolrServicePublicationIndexingPlugin
     private UCLouvainFWBValidationService uclouvainFWBValidationService;
     @Autowired
     private FNRSValidator fnrsValidator;
-
+    @Autowired
+    private ItemService itemService;
+    @Autowired
+    private EPersonService ePersonService;
 
     @Override
     @SuppressWarnings("rawtypes")
@@ -52,7 +63,8 @@ public class SolrServicePublicationIndexingPlugin
             Publication publication = PublicationFactory.build(getItem(dso));
             addFWBValidationKeys(context, publication.getItem(), document);
             addFNRSValidationKeys(publication.getItem(), document);
-            addAuthorsIndexingKeys(publication, document);
+            authorFgsIndexing(publication, document);
+            readPermissionsIndexing(context, publication, document);
         } catch (InvalidModelEntityTypeException e) {
             log.debug(e.getMessage());
         }
@@ -98,7 +110,7 @@ public class SolrServicePublicationIndexingPlugin
      * @param publication The {@class Publication} item to analyze
      * @param document The Solr document to add the keys to.
      */
-    private void addAuthorsIndexingKeys(Publication publication, SolrInputDocument document) {
+    private void authorFgsIndexing(Publication publication, SolrInputDocument document) {
         List<String> authorsFgsIdentifier = publication.getAuthors().stream()
             .map(PublicationAuthor::getFgs)
             .filter(Objects::nonNull)
@@ -106,6 +118,59 @@ public class SolrServicePublicationIndexingPlugin
         if (!authorsFgsIdentifier.isEmpty()) {
             document.addField("authors.identifier.fgs", authorsFgsIdentifier);
         }
+    }
 
+    /**
+     * Index read permissions for the publication in the solr document.
+     * This adds a read permission for the submitter of the publication and for all authors of the publication.
+     * @param context The current DSpace application context.
+     * @param publication The publication to add read permission to.
+     * @param document The solr document to add the read permissions to.
+     */
+    private void readPermissionsIndexing(Context context, Publication publication, SolrInputDocument document) {
+        // Add read permission for submitter
+        addRead(document, Optional.ofNullable(publication.getItem().getSubmitter()));
+        // Add read permission for any author
+        publication.getAuthors().stream()
+            .map(PublicationAuthor::getAuthority)
+            .filter(Objects::nonNull)
+            .forEach((author) -> {
+                addRead(document, findOwner(context, author));
+            });
+    }
+
+    /**
+     * Add a read permission to the document for the given person.
+     * @param document The solr Document.
+     * @param person The person to add a read permission for.
+     */
+    private void addRead(SolrInputDocument document, Optional<EPerson> person) {
+        person.ifPresent(personObj -> document.addField("read", "e" + personObj.getID().toString()));
+    }
+
+    /**
+     * Find the owner of a given item and return it as a EPerson.
+     * @param context The current DSpace application context.
+     * @param profile The profile item to find the owner of.
+     * @return An Optional containing the EPerson owner of the item, or an empty Optional if
+     * no owner is found or if an error occurs.
+     */
+    private Optional<EPerson> findOwner(Context context, Item profile) {
+        return itemService.getMetadata(profile, "dspace", "object", "owner", Item.ANY)
+            .stream()
+            .findFirst()
+            .map(MetadataValue::getAuthority)
+            .filter(StringUtils::isNotEmpty)
+            // Check uuid conversion since uuid is a string and could be other things than an actual uuid.
+            .map(UUIDUtils::fromString)
+            .filter(Objects::nonNull)
+            .map(uuid -> {
+                try {
+                    return Optional.ofNullable(ePersonService.find(context, uuid));
+                } catch (SQLException e) {
+                    throw new RuntimeException(e);
+                }
+            })
+            .orElse(Optional.empty());
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/login/impl/ResearcherProfileAutomaticClaim.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/login/impl/ResearcherProfileAutomaticClaim.java
@@ -119,8 +119,11 @@ public class ResearcherProfileAutomaticClaim implements PostLoggedInAction {
             }
         }
         if (item != null) {
+            context.turnOffAuthorisationSystem();
             itemService.addMetadata(context, item, "dspace", "object", "owner",
                 null, fullName, id.toString(), CF_ACCEPTED);
+            itemService.update(context, item);
+            context.restoreAuthSystemState();
         }
 
     }


### PR DESCRIPTION
## Description

Indexed 'read' property now contains also the ids of the author profiles. This works for archived items and workspace items but not for workflow; further analyzing needed. 

Also fixed some consumers not working properly due to authorization problems.

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module