### PR TITLE
[UPD] feat(emails): Private and official author email + manager in cc.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/profile/ResearcherProfile.java
+++ b/dspace-api/src/main/java/org/dspace/profile/ResearcherProfile.java
@@ -71,6 +71,10 @@ public class ResearcherProfile {
         return UUIDUtils.fromString(dspaceObjectOwner.getAuthority());
     }
 
+    public UUID getItemId() {
+        return item.getID();
+    }
+
     /**
      * A profile is considered visible if accessible by anonymous users. This method
      * returns true if the given item has a READ policy related to ANONYMOUS group,

--- a/dspace-api/src/main/java/org/dspace/uclouvain/core/mails/AbstractNotifyEmail.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/core/mails/AbstractNotifyEmail.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.dspace.access.status.DefaultAccessStatusHelper;
 import org.dspace.access.status.factory.AccessStatusServiceFactory;
@@ -24,9 +25,9 @@ import org.dspace.authorize.ResourcePolicy;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
 import org.dspace.content.Item;
-import org.dspace.content.MetadataValue;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
+import org.dspace.core.CrisConstants;
 import org.dspace.handle.factory.HandleServiceFactory;
 import org.dspace.handle.service.HandleService;
 import org.dspace.uclouvain.exceptions.EmailFailedInitException;
@@ -64,10 +65,15 @@ public abstract class AbstractNotifyEmail extends GenericPublicationEmail {
 
     @Override
     protected List<String> getRecipientAddresses() {
-        List<String> recipients = itemService.getMetadataByMetadataString(item, authorEmailField)
-                .stream()
-                .map(MetadataValue::getValue)
-                .collect(Collectors.toList());
+        // Send email on both private and official adresses.
+        List<String> recipients = publication.getAuthors().stream()
+            .flatMap(author -> Stream.of(
+                author.getEmail(),
+                author.getPrivateEmail()
+            ))
+            .filter(this::isValidValue)
+            .distinct()
+            .collect(Collectors.toList());
         String submitterEmail = item.getSubmitter().getEmail();
         if (!recipients.contains(submitterEmail)) {
             recipients.add(submitterEmail);
@@ -76,6 +82,10 @@ public abstract class AbstractNotifyEmail extends GenericPublicationEmail {
             log.debug("Initial TO recipient addresses for notify email are :: " + String.join(", ", recipients));
         }
         return recipients;
+    }
+
+    private boolean isValidValue(String value) {
+        return value != null && !value.equals(CrisConstants.PLACEHOLDER_PARENT_METADATA_VALUE);
     }
 
     protected String getHandle(Context context, Item item) throws SQLException {

--- a/dspace-api/src/main/java/org/dspace/uclouvain/core/mails/DissertationNotifyEmail.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/core/mails/DissertationNotifyEmail.java
@@ -7,12 +7,14 @@
  */
 package org.dspace.uclouvain.core.mails;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.dspace.content.Item;
 import org.dspace.content.MetadataValue;
 import org.dspace.core.Context;
+import org.dspace.uclouvain.core.utils.ItemUtils;
 import org.dspace.uclouvain.exceptions.EmailFailedInitException;
 
 public abstract class DissertationNotifyEmail extends AbstractNotifyEmail {
@@ -23,9 +25,18 @@ public abstract class DissertationNotifyEmail extends AbstractNotifyEmail {
 
     @Override
     protected List<String> getCCAddresses() {
-        return getAdvisorEmails(context, item);
+        List<String> ccAddresses = new ArrayList<>();
+        ccAddresses.addAll(getAdvisorEmails(context, item));
+        ccAddresses.addAll(getManagerEmails(context, item));
+        return ccAddresses.stream().distinct().toList();
     }
 
+    /**
+     * Get all advisors emails from the item metadata and return them as a list of strings.
+     * @param context The current DSpace application context.
+     * @param item The item to get the advisor emails from.
+     * @return A list of strings containing all the advisor emails found in the item metadata.
+     */
     protected List<String> getAdvisorEmails(Context context, Item item) {
         List<String> advisorMails = itemService.getMetadataByMetadataString(item, advisorEmailField)
                 .stream()
@@ -35,5 +46,24 @@ public abstract class DissertationNotifyEmail extends AbstractNotifyEmail {
             log.debug("Initial CC recipient addresses for notify email are :: " + String.join(", ", advisorMails));
         }
         return advisorMails;
+    }
+
+    /**
+     * Try to get all managers of the item and return their email addresses.
+     * @param context The current DSpace application context.
+     * @param item The item to get managers of.
+     * @return All the email addresses of the managers of the item.
+     * If any exception occurs during the retrieval of the managers or their emails, an empty list is returned.
+     */
+    protected List<String> getManagerEmails(Context context, Item item) {
+        try {
+            return ItemUtils.getManagersOfItem(context, item).stream()
+                .map(manager -> manager.getEmail())
+                .filter(email -> email != null && !email.isEmpty())
+                .collect(Collectors.toList());
+        } catch (Exception e) {
+            log.warn("Could not retrieve manager emails for item with id " + item.getID(), e);
+            return List.of();
+        }
     }
 }

--- a/dspace-api/src/main/java/org/dspace/uclouvain/core/mails/GenericPublicationEmail.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/core/mails/GenericPublicationEmail.java
@@ -12,6 +12,9 @@ import java.util.List;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
 import org.dspace.core.Email;
+import org.dspace.uclouvain.core.model.exceptions.InvalidModelEntityTypeException;
+import org.dspace.uclouvain.core.model.publication.Publication;
+import org.dspace.uclouvain.core.model.publication.PublicationFactory;
 import org.dspace.uclouvain.exceptions.EmailFailedInitException;
 import org.dspace.uclouvain.exceptions.EmailGenerationException;
 
@@ -29,6 +32,8 @@ public abstract class GenericPublicationEmail extends AbstractUCLouvainEmail {
     protected String advisorEmailField = configService.getProperty(
         "uclouvain.global.metadata.advisoremail.field", "advisors.email");
 
+    protected Publication publication;
+
     // ABSTRACT METHODS ================================================================================================
     protected abstract String getTemplatePath();
     protected abstract String buildMailSubject();
@@ -39,6 +44,11 @@ public abstract class GenericPublicationEmail extends AbstractUCLouvainEmail {
     // METHODS =========================================================================================================
     public GenericPublicationEmail(Context context, Item item) throws EmailFailedInitException {
         super(context, item);
+        try {
+            this.publication = PublicationFactory.build(item);
+        } catch (InvalidModelEntityTypeException e) {
+            throw new EmailFailedInitException("Could not build publication from item: " + item.getID(), e);
+        }
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/uclouvain/core/model/publication/PublicationAuthor.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/core/model/publication/PublicationAuthor.java
@@ -15,10 +15,10 @@ import java.util.UUID;
 
 import org.apache.commons.lang.StringUtils;
 import org.dspace.content.Item;
-import org.dspace.content.MetadataFieldName;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Context;
+import org.dspace.profile.ResearcherProfile;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.web.ContextUtil;
@@ -49,7 +49,7 @@ public class PublicationAuthor {
     private String role;
     private int place;
     private Map<String, String> identifiers = new HashMap<>();
-    private Item researcherProfileAuthority;
+    private ResearcherProfile researcherProfileAuthority;
 
     private final ConfigurationService configService = DSpaceServicesFactory.getInstance().getConfigurationService();
     private final ItemService itemService = ContentServiceFactory.getInstance().getItemService();
@@ -82,6 +82,12 @@ public class PublicationAuthor {
         return this;
     }
 
+    public String getPrivateEmail() {
+        return researcherProfileAuthority != null
+            ? researcherProfileAuthority.getPrivateEmail().orElse(null)
+            : null;
+    }
+
     public String getInstitution() {
         return institution;
     }
@@ -108,13 +114,7 @@ public class PublicationAuthor {
     public String getOrcidID() {
         String orcidID = identifiers.getOrDefault("orcid", null);
         if (StringUtils.isBlank(orcidID) && researcherProfileAuthority != null) {
-            orcidID = itemService.getMetadataFirstValue(
-                researcherProfileAuthority,
-                new MetadataFieldName(
-                    configService.getProperty("uclouvain.global.metadata.person.orcidID.field", "dc.identifier.orcid")
-                ),
-                null
-            );
+            orcidID = researcherProfileAuthority.getOrcid().orElse(null);
             identifiers.put("orcid", orcidID);
         }
         return orcidID;
@@ -127,20 +127,13 @@ public class PublicationAuthor {
     public String getFgs() {
         String fgs = identifiers.getOrDefault("fgs", null);
         if (StringUtils.isBlank(fgs) && researcherProfileAuthority != null) {
-            fgs = itemService.getMetadataFirstValue(
-                researcherProfileAuthority,
-                new MetadataFieldName(configService.getProperty(
-                    "uclouvain.global.metadata.person.institutionalID.field",
-                    "person.identifier.fgs")
-                ),
-                null
-            );
+            fgs = researcherProfileAuthority.getFGS().orElse(null);
             identifiers.put("fgs", fgs);
         }
         return fgs;
     }
 
-    public Item getAuthority() {
+    public ResearcherProfile getAuthority() {
         return researcherProfileAuthority;
     }
     public PublicationAuthor setAuthority(UUID authorityID) {
@@ -157,7 +150,7 @@ public class PublicationAuthor {
             if (entityType != null && !entityType.equals(researchProfileEntityType)) {
                 throw new IllegalArgumentException("Item[" + authorityID + "] isn't a valid researcher profile");
             }
-            this.researcherProfileAuthority = authorityItem;
+            this.researcherProfileAuthority = new ResearcherProfile(authorityItem, false);
             return this;
         } catch (SQLException e) {
             throw new RuntimeException();

--- a/dspace-api/src/main/java/org/dspace/uclouvain/core/utils/AuthorizationUtils.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/core/utils/AuthorizationUtils.java
@@ -12,7 +12,6 @@ import java.sql.SQLException;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
-import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Utility class for authorization checks.
@@ -20,9 +19,6 @@ import org.springframework.beans.factory.annotation.Autowired;
  * @author Michaël Pourbaix (michael.pourbaix@uclouvain.be)
  */
 public class AuthorizationUtils {
-
-    @Autowired
-    private ItemUtils itemUtils;
 
     /**
      * Checks if the current user is a manager of the item's collection.
@@ -35,6 +31,6 @@ public class AuthorizationUtils {
      * @throws SQLException for any database exception.
      */
     public boolean isManagerOfItem(Context context, Item item, EPerson currentUser) throws SQLException {
-        return this.itemUtils.getManagersOfItem(context, item).contains(currentUser);
+        return ItemUtils.getManagersOfItem(context, item).contains(currentUser);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/uclouvain/core/utils/ItemUtils.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/core/utils/ItemUtils.java
@@ -28,7 +28,6 @@ import org.dspace.xmlworkflow.factory.XmlWorkflowServiceFactory;
 import org.dspace.xmlworkflow.storedcomponents.CollectionRole;
 import org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem;
 import org.dspace.xmlworkflow.storedcomponents.service.CollectionRoleService;
-import org.dspace.xmlworkflow.storedcomponents.service.XmlWorkflowItemService;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /** 
@@ -40,10 +39,6 @@ public class ItemUtils {
 
     @Autowired
     private BitstreamService bitstreamService;
-    @Autowired
-    private XmlWorkflowItemService xmlWorkflowItemService;
-    @Autowired
-    private CollectionRoleService collectionRoleService;
 
     /** 
     * This method is used to extract all bitstreams from an item.
@@ -75,21 +70,24 @@ public class ItemUtils {
      * @return The list of all valid managers for the given item.
      * @throws SQLException for any database exception
      */
-    public List<EPerson> getManagersOfItem(Context context, Item item) throws SQLException {
+    public static List<EPerson> getManagersOfItem(Context context, Item item) throws SQLException {
         List<EPerson> managers = new ArrayList<>();
         Collection collection = item.getOwningCollection();
 
         if (collection == null) {
             // Check if the item is in the workflow; if yes, we need to use the XmlWorkflowItem to retrieve the
             // owning collection.
-            XmlWorkflowItem xmlWorkflowItem = this.xmlWorkflowItemService.findByItem(context, item);
+            XmlWorkflowItem xmlWorkflowItem = XmlWorkflowServiceFactory.getInstance().getXmlWorkflowItemService()
+                .findByItem(context, item);
             if (xmlWorkflowItem != null) {
                 collection = xmlWorkflowItem.getCollection();
             }
         }
 
         // Retrieve all the roles created for the item's collection.
-        for (CollectionRole role : this.collectionRoleService.findByCollection(context, collection)) {
+        List<CollectionRole> roles = XmlWorkflowServiceFactory.getInstance().getCollectionRoleService()
+            .findByCollection(context, collection);
+        for (CollectionRole role : roles) {
             if (role.getRoleId().equals(CollectionRoleService.LEGACY_WORKFLOW_STEP1_NAME)) {
                 for (Group group: role.getGroup().getMemberGroups()) {
                     managers.addAll(group.getMembers());

--- a/dspace-api/src/main/java/org/dspace/uclouvain/discovery/indexing/SolrServicePublicationIndexingPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/discovery/indexing/SolrServicePublicationIndexingPlugin.java
@@ -135,7 +135,7 @@ public class SolrServicePublicationIndexingPlugin
             .map(PublicationAuthor::getAuthority)
             .filter(Objects::nonNull)
             .forEach((author) -> {
-                addRead(document, findOwner(context, author));
+                addRead(document, findOwner(context, author.getItem()));
             });
     }
 

--- a/dspace-api/src/main/java/org/dspace/uclouvain/export/utils/FNRSExportUtils.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/export/utils/FNRSExportUtils.java
@@ -99,7 +99,7 @@ public class FNRSExportUtils {
         return publication.getAuthors().stream()
             .filter(author -> author.getAuthority() != null)
             .anyMatch((PublicationAuthor author) -> {
-                return Objects.equals(author.getAuthority().getID().toString(), authorId)
+                return Objects.equals(author.getAuthority().getItemId().toString(), authorId)
                     && Objects.equals(author.getRole(), role);
             });
     }

--- a/dspace-api/src/main/java/org/dspace/uclouvain/services/impl/PublicationServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/services/impl/PublicationServiceImpl.java
@@ -65,7 +65,7 @@ public class PublicationServiceImpl implements PublicationService {
             throws PublicationSetAuthorException {
         Item item = publication.getItem();
         try {
-            String authority = (author.getAuthority() != null) ? author.getAuthority().getID().toString() : null;
+            String authority = (author.getAuthority() != null) ? author.getAuthority().getItemId().toString() : null;
             int confidence = isNotEmpty(authority) ? CF_ACCEPTED : CF_UNSET;
             int place = author.getPlace();
 


### PR DESCRIPTION
## Description

- For all mails: receipient is now the author official email and private email.
- For dissertation: added managers in CC of the mail (doctoral thesis manager).
- Misc: Refactor a bit of code to use 'ResearchProfile' class instead of Item.

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module