### PR TITLE
[UPD] feat(external-provider): Improved language mapping for external source import.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/importer/external/pubmed/metadatamapping/contributor/PubmedLanguageMetadatumContributor.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/pubmed/metadatamapping/contributor/PubmedLanguageMetadatumContributor.java
@@ -85,7 +85,8 @@ public class PubmedLanguageMetadatumContributor<T> implements MetadataContributo
 
             for (MetadatumDTO metadatum : languageList) {
                 // Add the iso2 language code corresponding to the retrieved iso3 code to the metadata
-                values.add(metadataFieldMapping.toDCValue(field, iso3toIso2.get(metadatum.getValue().toLowerCase())));
+                // CHANGES : Do not return the converted value, use it as it is since pubmed returns iso3 format.
+                values.add(metadataFieldMapping.toDCValue(field, metadatum.getValue().toLowerCase()));
             }
         } catch (Exception e) {
             log.error("Error", e);

--- a/dspace/config/init-sample.xml
+++ b/dspace/config/init-sample.xml
@@ -29,6 +29,11 @@
             <name>Publication</name>
             <entity-type>Publication</entity-type>
             <submission-type>publication</submission-type>
+            <templateItem>
+                <metadata schema="dc" element="language" qualifier="iso">
+                    <value>eng</value>
+                </metadata>
+            </templateItem>
         </collection>
         <collection identifier="2078.5/Dissertation">
             <name>Dissertation</name>

--- a/dspace/config/spring/api/pubmed-integration.xml
+++ b/dspace/config/spring/api/pubmed-integration.xml
@@ -24,8 +24,10 @@
         <entry key-ref="dc.date.issued" value-ref="dateContrib"/>
         <entry key-ref="dc.language.iso" value-ref="pubmedLanguageContrib"/>
         <entry key-ref="dc.subject" value-ref="keywordContrib"/>
+        <entry key-ref="dc.subject.mesh" value-ref="meshKeywordContrib"/>
         <entry key-ref="dcJournalTitle" value-ref="journalContrib"/>
         <entry key-ref="publication.serial.issn" value-ref="journalIssnContrib"/>
+        <entry key-ref="publication.serial.eissn" value-ref="journalEissnContrib"/>
         <entry key-ref="publication.serial.volume" value-ref="volumeContrib"/>
         <entry key-ref="publication.serial.issue" value-ref="issueContrib"/>
         <entry key-ref="publication.serial.pages" value-ref="paginationContrib"/>
@@ -100,6 +102,13 @@
         <property name="query" value="descendant::Keyword"/>
         <property name="prefixToNamespaceMapping" ref="prefixToNamespaceMapping"/>
     </bean>
+
+    <bean id="meshKeywordContrib" class="org.dspace.importer.external.metadatamapping.contributor.SimpleXpathMetadatumContributor">
+        <property name="field" ref="dc.subject.mesh"/>
+        <property name="query" value="descendant::MeshHeading/DescriptorName"/>
+        <property name="prefixToNamespaceMapping" ref="prefixToNamespaceMapping"/>
+    </bean>
+
     <bean id="yearContrib" class="org.dspace.importer.external.metadatamapping.contributor.SimpleXpathMetadatumContributor">
         <property name="field" ref="dc.date.issued"/>
         <property name="query" value="descendant::PubDate/Year"/>
@@ -124,18 +133,23 @@
         <property name="prefixToNamespaceMapping" ref="prefixToNamespaceMapping"/>
     </bean>
 
-
     <bean id="journalContrib" class="org.dspace.importer.external.metadatamapping.contributor.SimpleXpathMetadatumContributor">
         <property name="field" ref="dcJournalTitle"/>
         <property name="query" value="descendant::Journal/Title"/>
         <property name="prefixToNamespaceMapping" ref="prefixToNamespaceMapping"/>
     </bean>
 
-    <bean id="journalIssnContrib" class="org.dspace.importer.external.metadatamapping.contributor.SimpleXpathMetadatumContributor">
-        <property name="field" ref="publication.serial.issn"/>
-        <property name="query" value="descendant::Journal/ISSN"/>
+    <bean id="journalEissnContrib" class="org.dspace.importer.external.metadatamapping.contributor.SimpleXpathMetadatumContributor">
+        <property name="field" ref="publication.serial.eissn"/>
+        <property name="query" value="descendant::Journal/ISSN[@IssnType='Electronic']"/>
         <property name="prefixToNamespaceMapping" ref="prefixToNamespaceMapping"/>
     </bean>
+
+    <bean id="journalIssnContrib" class="org.dspace.importer.external.metadatamapping.contributor.SimpleXpathMetadatumContributor">
+        <property name="field" ref="publication.serial.issn"/>
+        <property name="query" value="descendant::MedlineJournalInfo/ISSNLinking"/>
+        <property name="prefixToNamespaceMapping" ref="prefixToNamespaceMapping"/>
+    </bean>  
 
     <bean id="volumeContrib" class="org.dspace.importer.external.metadatamapping.contributor.SimpleXpathMetadatumContributor">
         <property name="field" ref="publication.serial.volume"/>
@@ -237,6 +251,10 @@
 
     <bean id="dc.subject" class="org.dspace.importer.external.metadatamapping.MetadataFieldConfig">
         <constructor-arg value="dc.subject"/>
+    </bean>
+
+    <bean id="dc.subject.mesh" class="org.dspace.importer.external.metadatamapping.MetadataFieldConfig">
+        <constructor-arg value="dc.subject.mesh"/>
     </bean>
 
     <bean id="dc.identifier.pmid" class="org.dspace.importer.external.metadatamapping.MetadataFieldConfig">


### PR DESCRIPTION
## Description

- Added a default value for 'dc.language.iso' of 'eng'.
- Updated the language mapping class for Pubmed import to not convert iso3 to iso2.
- Improved mapping of issn and e-issn for pubmed import.

Authored-by: Michaël Pourbaix <michael.pourbaix@uclouvain.be>

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module