### PR TITLE
[ADD] feat(pubmed-import): Custom crossref import provider.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/uclouvain/core/model/publication/Publication.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/core/model/publication/Publication.java
@@ -75,8 +75,16 @@ public class Publication extends ItemModel implements FWBValidation {
 
     public static final String TITLE_FIELD =
         getField("title", "dc.title");
+    public static final String ABSTRACT_FIELD =
+        getField("abstract", "dc.description.abstract");
     public static final String DATE_ISSUED_FIELD =
         getField("dateIssued", "dc.date.issued");
+    public static final String LANGUAGE_FIELD =
+        getField("language", "dc.language.iso");
+    public static final String KEYWORD_FIELD =
+        getField("keyword", "dc.subject");
+    public static final String MESH_KEYWORD_FIELD =
+        getField("meshKeyword", "dc.subject.mesh");
     public static final String PUBLICATION_STATUS_FIELD =
         getField("publication-status", "publication.publicationStatus");
 
@@ -99,6 +107,14 @@ public class Publication extends ItemModel implements FWBValidation {
         getField("journalEissn", "publication.serial.eissn");
     public static final String JOURNAL_PEER_REVIEWED_FIELD =
         getField("journalPeerReviewed", "publication.serial.peerReviewed");
+    public static final String JOURNAL_VOLUME_FIELD =
+        getField("journalVolume", "publication.serial.volume");
+    public static final String JOURNAL_ISSUE_FIELD =
+        getField("journalIssue", "publication.serial.issue");
+    public static final String JOURNAL_PAGES_FIELD =
+        getField("journalPages", "publication.serial.pages");
+    public static final String JOURNAL_DATE_ISSUED_FIELD =
+        getField("journalDateIssued", "publication.serial.dateIssued");
 
     public static final String EDITOR_NAME_FIELD =
         getField("editorName", "publication.editor.name");

--- a/dspace-api/src/main/java/org/dspace/uclouvain/external/importer/UCLouvainImportSourceService.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/external/importer/UCLouvainImportSourceService.java
@@ -1,0 +1,30 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.external.importer;
+
+import java.util.List;
+
+import org.dspace.content.dto.MetadataValueDTO;
+
+public interface UCLouvainImportSourceService {
+    public List<MetadataValueDTO> getMetadataList(String query);
+
+    /**
+     * Retrieve the total result count for a given query.
+     * This should be implemented if pagination is needed.
+     * 
+     * @param query The query used to find records.
+     * @return The number of records matching the given query.
+     */
+    public default int getResultCount(String query) {
+        // ! See what to do here since we dont want to create a specific count method in importService...
+        // Used by the ExternalSourceRestRepository when importing items from external source in the frontend.
+        // TODO: Return results count.
+        return 0;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/external/importer/UCLouvainImportSourceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/external/importer/UCLouvainImportSourceServiceImpl.java
@@ -1,0 +1,74 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.external.importer;
+
+import static org.dspace.content.authority.Choices.CF_UNSET;
+
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.dspace.content.dto.MetadataValueDTO;
+import org.dspace.core.CrisConstants;
+import org.dspace.uclouvain.core.model.MetadataField;
+
+public abstract class UCLouvainImportSourceServiceImpl implements UCLouvainImportSourceService {
+    public abstract List<MetadataValueDTO> getMetadataList(String query);
+
+    /**
+     * Adds a metadata to the given metadata list.
+     * If the placeholder flag is set to true and the value is empty, add a metadata placeholder.
+     * If the placeholder flag is set to false and the value is empty, don't add any metadata.
+     * 
+     * @param list The complete metadata list to amend the metadata to.
+     * @param field The metadata field of the metadata to create.
+     * @param value The value of the metadata to create.
+     * @param authority The authority of the metadata to create.
+     * @param confidence The confidence of the metadata to create.
+     * @param placeholder Whether to use a placeholder for the value of the metadata if given value is empty.
+     */
+    protected void addMetadata(
+        List<MetadataValueDTO> list, String field, String value, String authority, int confidence, boolean placeholder
+    ) {
+        boolean isBlank = StringUtils.isEmpty(value);
+        if (isBlank && !placeholder) {
+            return;
+        }
+
+        value = isBlank ? CrisConstants.PLACEHOLDER_PARENT_METADATA_VALUE : value;
+        authority = isBlank ? null : authority;
+        confidence = isBlank ? CF_UNSET : confidence;
+
+        MetadataField md = new MetadataField(field);
+        MetadataValueDTO dto = new MetadataValueDTO();
+
+        dto.setSchema(md.getSchema());
+        dto.setElement(md.getElement());
+        dto.setQualifier(md.getQualifier());
+        dto.setValue(value);
+        dto.setAuthority(authority);
+        dto.setConfidence(confidence);
+
+        list.add(dto);
+    }
+
+    /**
+     * Same as 'addMetadata' but for a list of values.
+     * @param list The complete metadata list to amend the metadata to.
+     * @param field The metadata field of the metadata to create.
+     * @param values The values of the metadata to create.
+     * @param authority The authority of the metadata to create.
+     * @param confidence The confidence of the metadata to create.
+     * @param placeholder Whether to use a placeholder for the value of the metadata if given value is empty.
+     */
+    protected void addAllMetadata(
+        List<MetadataValueDTO> list, String field, List<String> values,
+        String authority, int confidence, boolean placeholder
+    ) {
+        values.forEach(val -> addMetadata(list, field, val, authority, confidence, placeholder));
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/external/importer/xml/UCLouvainXMLImportSourceService.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/external/importer/xml/UCLouvainXMLImportSourceService.java
@@ -1,0 +1,63 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.external.importer.xml;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.dspace.content.dto.MetadataValueDTO;
+import org.dspace.uclouvain.external.importer.UCLouvainImportSourceServiceImpl;
+import org.jdom2.Element;
+import org.jdom2.filter.Filters;
+import org.jdom2.xpath.XPathExpression;
+import org.jdom2.xpath.XPathFactory;
+
+/**
+ * External import service specialized for XML sources.
+ */
+public abstract class UCLouvainXMLImportSourceService extends UCLouvainImportSourceServiceImpl {
+    public abstract List<MetadataValueDTO> getMetadataList(String query);
+
+    /**
+     * Get the value of the first matching element of a given XML tree.
+     * 
+     * @param root  The XML element tree to extract the value from.
+     * @param xpath The path to the element to extract the value of.
+     * @return The value of the first found element. Can return null if no element is found.
+     */
+    protected String getFirstText(Element root, String xpath) {
+        return Optional
+            .ofNullable(buildXpath(xpath).evaluateFirst(root))
+            .map(Element::getTextTrim)
+            .orElse(null);
+    }
+
+    /**
+     * Get all the value of every element matching a given xpath for a given XML tree.
+     * 
+     * @param root  The XML element tree to extract the value from.
+     * @param xpath The path to the elements to extract the value of.
+     * @return The values of the all found elements. Can return an empty list if no elements are found.
+     */
+    protected List<String> getAllText(Element root, String xpath) {
+        return buildXpath(xpath).evaluate(root)
+            .stream()
+            .map(Element::getTextTrim)
+            .toList();
+    }
+
+    /**
+     * Little helper to build an XPath expression.
+     * 
+     * @param path The xpath expression.
+     * @return An new XpathExpression object.
+     */
+    protected XPathExpression<Element> buildXpath(String path) {
+        return XPathFactory.instance().compile(path, Filters.element());
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/external/importer/xml/pubmed/UCLouvainPubmedImportSourceService.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/external/importer/xml/pubmed/UCLouvainPubmedImportSourceService.java
@@ -1,0 +1,363 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.external.importer.xml.pubmed;
+
+import static org.dspace.content.authority.Choices.CF_ACCEPTED;
+import static org.dspace.content.authority.Choices.CF_UNSET;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.net.URISyntaxException;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.content.Item;
+import org.dspace.content.dto.MetadataValueDTO;
+import org.dspace.core.Context;
+import org.dspace.importer.external.liveimportclient.service.LiveImportClient;
+import org.dspace.profile.ResearcherProfile;
+import org.dspace.uclouvain.core.model.Journal;
+import org.dspace.uclouvain.core.model.publication.Publication;
+import org.dspace.uclouvain.external.importer.xml.UCLouvainXMLImportSourceService;
+import org.dspace.uclouvain.services.JournalService;
+import org.dspace.uclouvain.services.UCLouvainProfileService;
+import org.dspace.web.ContextUtil;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.JDOMException;
+import org.jdom2.input.SAXBuilder;
+import org.jdom2.xpath.XPathExpression;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.xml.sax.InputSource;
+
+/**
+ * Service to extract a list of MetadataValueDTO from Pubmed for a given
+ * PubmedId.
+ * 
+ * @author Michaël Pourbaix (michael.pourbaix@uclouvain.be)
+ */
+public class UCLouvainPubmedImportSourceService extends UCLouvainXMLImportSourceService {
+
+    private final Logger logger = LogManager.getLogger(UCLouvainPubmedImportSourceService.class);
+    private static final String ORCID_IDENTIFIER = "ORCID";
+    private static final DateTimeFormatter MONTH_FORMATTER = DateTimeFormatter.ofPattern("MMM", Locale.ENGLISH);
+
+    @Autowired
+    private LiveImportClient liveImportClient;
+    @Autowired
+    private UCLouvainProfileService uclouvainProfileService;
+    @Autowired
+    private JournalService journalService;
+
+    private String urlFetch;
+    private String urlSearch;
+
+    public List<MetadataValueDTO> getMetadataList(String query) {
+        try {
+            Context context = ContextUtil.obtainCurrentRequestContext();
+            String rawResponse = fetchData(query);
+            Element parsedXml = parseXmlResponse(rawResponse);
+            return generateMetadataList(context, parsedXml);
+        } catch (URISyntaxException e) {
+            logger.error("Could not build Pubmed request URL.", e);
+            return List.of();
+        }
+    };
+
+    private String fetchData(String query) throws URISyntaxException {
+        URIBuilder uriBuilder = new URIBuilder(urlFetch);
+        uriBuilder.addParameter(query, query);
+        uriBuilder.addParameter("db", "pubmed");
+        uriBuilder.addParameter("retmode", "xml");
+        uriBuilder.addParameter("id", query);
+        Map<String, Map<String, String>> params = new HashMap<>();
+        return liveImportClient.executeHttpGetRequest(2000, uriBuilder.toString(), params);
+    }
+
+    private Element parseXmlResponse(String xmlResponse) {
+        try {
+            SAXBuilder saxBuilder = new SAXBuilder();
+            // Disallow external entities & entity expansion to protect against XXE attacks
+            // (NOTE: We receive errors if we disable all DTDs for PubMed, so this is the best we can do)
+            saxBuilder.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            saxBuilder.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            saxBuilder.setExpandEntities(false);
+            saxBuilder.setEntityResolver((publicId, systemId) -> new InputSource(new StringReader("")));
+
+            Document document = saxBuilder.build(new StringReader(xmlResponse));
+            Element root = document.getRootElement();
+
+            XPathExpression<Element> xpath = buildXpath("//PubmedArticle");
+
+            List<Element> recordsList = xpath.evaluate(root);
+            return recordsList != null ? recordsList.get(0) : null;
+        } catch (JDOMException | IOException e) {
+            return null;
+        }
+    }
+
+    // METADATA EXTRACTION
+    // =============================================================================================
+
+    /**
+     * Generate a list of all metadata values extracted from the external source.
+     * 
+     * @param context The current Dspace application context.
+     * @param rootXml The root document to extract data from.
+     * @return A list of all extracted MetadataValueDTO.
+     */
+    private List<MetadataValueDTO> generateMetadataList(Context context, Element rootXml) {
+        List<MetadataValueDTO> metadataList = new ArrayList<>();
+        if (rootXml == null) {
+            return metadataList;
+        }
+        metadataList.addAll(extractAuthors(context, rootXml));
+        metadataList.addAll(extractBasicInfo(context, rootXml));
+        metadataList.addAll(extractJournalInfo(context, rootXml));
+        return metadataList;
+    }
+
+    /**
+     * Import all possible authors from the source.
+     * If an OrcidID is present for an author, try to find a matching person profile in DSpace and use it as authority.
+     * 
+     * @param context The current DSpace context.
+     * @param root    The root XML object coming from the source.
+     * @return A list of extracted MetadataValueDTO.
+     */
+    private List<MetadataValueDTO> extractAuthors(Context context, Element root) {
+        List<MetadataValueDTO> mdValues = new ArrayList<>();
+        List<Element> authors = buildXpath("//AuthorList/Author").evaluate(root);
+        for (Element author : authors) {
+
+            Element identifier = author.getChild("Identifier");
+            String orcid = (identifier != null && ORCID_IDENTIFIER.equals(identifier.getAttributeValue("Source")))
+                ? identifier.getTextTrim()
+                : null;
+
+            // Try to enrich metadata values by finding a matching profile.
+            Item profileItem = (orcid != null) ? uclouvainProfileService.findByOrcid(context, orcid) : null;
+            if (profileItem != null) {
+                String authority = profileItem.getID().toString();
+                ResearcherProfile profile = new ResearcherProfile(profileItem, false);
+                String fullName = profile.getName().orElse(null);
+                String officialEmail = profile.getEmail().orElse(null);
+                String institution = profile.getInstitution().orElse(null);
+                String fgs = profile.getFGS().orElse(null);
+                addMetadata(mdValues, Publication.AUTHOR_NAME_FIELD, fullName, authority, CF_ACCEPTED, true);
+                addMetadata(mdValues, Publication.AUTHOR_EMAIL_FIELD, officialEmail, authority, CF_ACCEPTED, true);
+                addMetadata(mdValues, Publication.AUTHOR_ORCID_FIELD, orcid, authority, CF_ACCEPTED, true);
+                addMetadata(mdValues, Publication.AUTHOR_INSTITUTION_FIELD, institution, authority, CF_ACCEPTED, true);
+                addMetadata(mdValues, Publication.AUTHOR_FGS_FIELD, fgs, authority, CF_ACCEPTED, true);
+            } else {
+                // We don't find any matching profile. Just create author name, orcid and affiliation metadata based
+                // on source input (email & fgs are not relevant in this case)
+                // TODO : Try to extract institution from affiliation ???
+                String authorName = "%s, %s".formatted(
+                    author.getChildTextTrim("LastName"),
+                    author.getChildTextTrim("ForeName")
+                );
+                addMetadata(mdValues, Publication.AUTHOR_NAME_FIELD, authorName, null, CF_UNSET, true);
+                addMetadata(mdValues, Publication.AUTHOR_ORCID_FIELD, orcid, null, CF_UNSET, true);
+                addMetadata(mdValues, Publication.AUTHOR_INSTITUTION_FIELD, null, null, CF_UNSET, true);
+                addMetadata(mdValues, Publication.AUTHOR_FGS_FIELD, null, null, CF_UNSET, true);
+                addMetadata(mdValues, Publication.AUTHOR_EMAIL_FIELD, null, null, CF_UNSET, true);
+            }
+        }
+        return mdValues;
+    }
+
+    /**
+     * Import all possible basic information from the source.
+     * 
+     * @param context The current DSpace context.
+     * @param root    The root XML object coming from the source.
+     * @return A list of extracted MetadataValueDTO.
+     */
+    private List<MetadataValueDTO> extractBasicInfo(Context context, Element root) {
+        List<MetadataValueDTO> mdValues = new ArrayList<>();
+        addMetadata(mdValues, Publication.TITLE_FIELD, getFirstText(root, "//ArticleTitle"), null, CF_UNSET, false);
+        // TODO: Multiple abstract can exist see how to extract them.
+        addAllMetadata(mdValues, Publication.ABSTRACT_FIELD, getAllText(root, "//AbstractText"), null, CF_UNSET, false);
+        addMetadata(mdValues, Publication.DATE_ISSUED_FIELD,
+            parsePubmedDate(buildXpath("//PubDate").evaluateFirst(root)), null, CF_UNSET, false);
+        addMetadata(mdValues, Publication.LANGUAGE_FIELD, getFirstText(root, "//Language"), null, CF_UNSET, false);
+        addAllMetadata(mdValues, Publication.KEYWORD_FIELD, getAllText(root, "//Keyword"), null, CF_UNSET, false);
+        addAllMetadata(mdValues, Publication.MESH_KEYWORD_FIELD,
+            getAllText(root, "//MeshHeading/DescriptorName"),null, CF_UNSET, false);
+        return mdValues;
+    }
+
+    /**
+     * Import all possible journal information from the source.
+     * If an issn or e-issn is present, try to find a matching journal in DSpace and
+     * use it as authority.
+     * 
+     * @param context The current DSpace context.
+     * @param root    The root XML object coming from the source.
+     * @return A list of extracted MetadataValueDTO.
+     */
+    private List<MetadataValueDTO> extractJournalInfo(Context context, Element root) {
+        List<MetadataValueDTO> mdValues = new ArrayList<>();
+
+        // Handle publication status
+        String publicationStatus = mapPublicationStatus(getFirstText(root, "//PubmedData/PublicationStatus"));
+        addMetadata(mdValues, Publication.PUBLICATION_STATUS_FIELD, publicationStatus, null, CF_UNSET, false);
+        // Extract volume, issue and pagination (+year?).
+        addMetadata(mdValues, Publication.JOURNAL_VOLUME_FIELD,
+            getFirstText(root, "//Journal/JournalIssue/Volume"), null, CF_UNSET, false);
+        addMetadata(mdValues, Publication.JOURNAL_ISSUE_FIELD,
+            getFirstText(root, "//Journal/JournalIssue/Issue"), null, CF_UNSET, false);
+        String journalPages = extractJournalPages(buildXpath("//Article/Pagination").evaluateFirst(root));
+        addMetadata(mdValues, Publication.JOURNAL_PAGES_FIELD, journalPages, null, CF_UNSET, false);
+        addMetadata(mdValues, Publication.JOURNAL_DATE_ISSUED_FIELD,
+            getFirstText(root, "//Journal/JournalIssue/PubDate/Year"), null, CF_UNSET, false);
+
+        String issn = getFirstText(root, "//MedlineJournalInfo/ISSNLinking");
+        String eissn = getFirstText(root, "//Journal/ISSN[@IssnType='Electronic']");
+        Journal journal = (issn != null || eissn != null)
+            ? journalService.findByIdentifiers(context, issn, eissn)
+            : null;
+        if (journal != null) {
+            String authority = journal.getID().toString();
+            int confidence = CF_ACCEPTED;
+            addMetadata(
+                mdValues, Publication.JOURNAL_ISSN_FIELD, journal.getIdentifier(Journal.ISSN_IDENTIFIER),
+                authority, confidence, false);
+            addMetadata(
+                mdValues, Publication.JOURNAL_EISSN_FIELD, journal.getIdentifier(Journal.EISSN_IDENTIFIER),
+                authority, confidence, false);
+            addMetadata(mdValues, Publication.JOURNAL_TITLE_FIELD, journal.getTitle(), authority, confidence, false);
+            addMetadata(mdValues, Publication.EDITOR_NAME_FIELD, journal.getPublisher(), authority, confidence, false);
+            addMetadata(
+                mdValues, Publication.EDITOR_LOCATION_FIELD, journal.getPublisherLocation(),
+                authority, confidence, false);
+            addMetadata(
+                mdValues, Publication.JOURNAL_PEER_REVIEWED_FIELD, journal.isPeerReviewedString(),
+                authority, confidence, false);
+        } else {
+            addMetadata(mdValues, Publication.JOURNAL_ISSN_FIELD, issn, null, CF_UNSET, false);
+            addMetadata(mdValues, Publication.JOURNAL_EISSN_FIELD, eissn, null, CF_UNSET, false);
+            addMetadata(mdValues, Publication.JOURNAL_TITLE_FIELD,
+                getFirstText(root, "//Title"), null, CF_UNSET, false);
+        }
+        return mdValues;
+    }
+
+    // Private methods specific to Pubmed import.
+
+    /**
+     * Parse a date found in Pubmed XML to a common DSpace date.
+     * 
+     * @param pubDateElem The XML element containing the date information.
+     * @return A DSpace formatted date string.
+     */
+    private String parsePubmedDate(Element pubDateElem) {
+        if (pubDateElem == null) {
+            return null;
+        }
+        // At least the year is required, so if none: exit.
+        String year = pubDateElem.getChildTextTrim("Year");
+        if (StringUtils.isBlank(year)) {
+            return null;
+        }
+        // If no month is found, just return the year.
+        String month = pubDateElem.getChildTextTrim("Month");
+        if (StringUtils.isBlank(month)) {
+            return year;
+        }
+        String isoMonth = tryParseMonth(month);
+        if (isoMonth == null) {
+            return year;
+        }
+        String iso = "%s-%s".formatted(year, isoMonth);
+        // Try to add a day if possible
+        String day = pubDateElem.getChildTextTrim("Day");
+        if (StringUtils.isNumeric(day)) {
+            return "%s-%02d".formatted(iso, Integer.parseInt(day));
+        }
+        return iso;
+    }
+
+    private String tryParseMonth(String monthName) {
+        try {
+            int monthVal = MONTH_FORMATTER.parse(monthName).get(ChronoField.MONTH_OF_YEAR);
+            return "%02d".formatted(monthVal);
+        } catch (DateTimeParseException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Map any pubmed 'publication status' to our own vocabulary.
+     * 
+     * @param publicationStatus The publication status string.
+     * @return The mapped publication string, if no mapping found, return null.
+     */
+    private String mapPublicationStatus(String publicationStatus) {
+        if (StringUtils.isNotEmpty(publicationStatus)) {
+            return switch (publicationStatus) {
+                case "ppublish", "received", "epublish" -> Publication.STATUS_PUBLISHED;
+                case "aheadofprint" -> Publication.STATUS_INPRESS;
+                default -> null;
+            };
+        }
+        return null;
+    }
+
+    /**
+     * Extract journal pages information from a given 'Pagination' XML element.
+     * 
+     * @param pagination The pagination XML element to extract information from.
+     * @return Return a pagination range.
+     */
+    private String extractJournalPages(Element pagination) {
+        if (pagination == null) {
+            return null;
+        }
+        String start = pagination.getChildTextTrim("StartPage");
+        String end = pagination.getChildTextTrim("EndPage");
+        // we found both data & it's not the same value
+        if (StringUtils.isNotEmpty(start) && StringUtils.isNotEmpty(end) && !end.equals(start)) {
+            return "%s-%s".formatted(start, end);
+        }
+        // we only found the start
+        if (StringUtils.isNotEmpty(start)) {
+            return start;
+        }
+        // fallback
+        return pagination.getChildTextTrim("MedlinePgn");
+    }
+
+    // GETTERS AND SETTERS
+    public String getUrlFetch() {
+        return urlFetch;
+    }
+
+    public void setUrlFetch(String urlFetch) {
+        this.urlFetch = urlFetch;
+    }
+
+    public String getUrlSearch() {
+        return urlSearch;
+    }
+
+    public void setUrlSearch(String urlSearch) {
+        this.urlSearch = urlSearch;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/external/provider/UCLouvainDataProvider.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/external/provider/UCLouvainDataProvider.java
@@ -1,0 +1,68 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.external.provider;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.dspace.content.dto.MetadataValueDTO;
+import org.dspace.external.model.ExternalDataObject;
+import org.dspace.external.provider.AbstractExternalDataProvider;
+import org.dspace.uclouvain.external.importer.UCLouvainImportSourceService;
+
+public class UCLouvainDataProvider extends AbstractExternalDataProvider {
+
+    private UCLouvainImportSourceService metadataSource;
+    private String sourceIdentifier;
+
+    @Override
+    public Optional<ExternalDataObject> getExternalDataObject(String id) {
+        return Optional.of(getExternalDataObject(metadataSource.getMetadataList(id), id));
+    }
+
+    @Override
+    public List<ExternalDataObject> searchExternalDataObjects(String query, int start, int limit) {
+        return null;
+    }
+
+    @Override
+    public boolean supports(String source) {
+        return Objects.equals(source, sourceIdentifier);
+    }
+
+    @Override
+    public int getNumberOfResults(String query) {
+        return metadataSource.getResultCount(query);
+    }
+
+    private ExternalDataObject getExternalDataObject(List<MetadataValueDTO> metadataList, String id) {
+        ExternalDataObject externalDataObject = new ExternalDataObject(sourceIdentifier);
+        externalDataObject.setMetadata(metadataList);
+        return externalDataObject;
+    }
+
+    // GETTERS AND SETTERS =============================================================================================
+
+    public UCLouvainImportSourceService getMetadataSource() {
+        return metadataSource;
+    }
+
+    public void setMetadataSource(UCLouvainImportSourceService metadataSource) {
+        this.metadataSource = metadataSource;
+    }
+
+    @Override
+    public String getSourceIdentifier() {
+        return sourceIdentifier;
+    }
+
+    public void setSourceIdentifier(String sourceIdentifier) {
+        this.sourceIdentifier = sourceIdentifier;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/services/UCLouvainProfileService.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/services/UCLouvainProfileService.java
@@ -32,6 +32,14 @@ public interface UCLouvainProfileService {
     Item findByEmail(Context context, String email);
 
     /**
+     * Find a profile item using an orcid.
+     * @param context The DSpace application context.
+     * @param orcid   The orcid to use to find the profile.
+     * @return Returns the profile that has the given orcid, null otherwise.
+     */
+    Item findByOrcid(Context context, String orcid);
+
+    /**
      * Find a profile corresponding to the given identifier.
      * @param context The current DSpace application context.
      * @param uuid uuid of the profile item.

--- a/dspace-api/src/main/java/org/dspace/uclouvain/services/UCLouvainProfileServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/services/UCLouvainProfileServiceImpl.java
@@ -79,11 +79,15 @@ public class UCLouvainProfileServiceImpl implements UCLouvainProfileService {
 
     // IMPLEMENTED FUNCTIONS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     public Item findById(Context context, String fgs) {
-        return findOneByAttribute(context, "person.identifier.fgs:" + fgs);
+        return findOneByAttribute(context, ResearcherProfile.FGS_FIELD + ":" + fgs);
     }
 
     public Item findByEmail(Context context, String email) {
-        return findOneByAttribute(context, "person.email:" + email);
+        return findOneByAttribute(context, ResearcherProfile.OFFICIAL_EMAIL_FIELD + ":" + email);
+    }
+
+    public Item findByOrcid(Context context, String orcid) {
+        return findOneByAttribute(context, ResearcherProfile.ORCID_FIELD + ":" + orcid);
     }
 
     public Item findByIdentifiers(Context context, String uuid, String fgs, String email) {

--- a/dspace-api/src/main/resources/spring/spring-dspace-addon-import-services.xml
+++ b/dspace-api/src/main/resources/spring/spring-dspace-addon-import-services.xml
@@ -73,6 +73,11 @@
           class="org.dspace.importer.external.arxiv.metadatamapping.ArXivFieldMapping">
     </bean>
 
+    <bean id="customPubmedImportService" class="org.dspace.uclouvain.external.importer.xml.pubmed.UCLouvainPubmedImportSourceService">
+        <property name="urlFetch" value="${pubmed.url.fetch}"/>
+        <property name="urlSearch" value="${pubmed.url.search}"/>
+    </bean>
+
     <bean id="pubmedImportService"
           class="org.dspace.importer.external.pubmed.service.PubmedImportMetadataSourceServiceImpl">
         <property name="metadataFieldMapping" ref="pubmedMetadataFieldMapping"/>

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/ExtractMetadataStep.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/ExtractMetadataStep.java
@@ -113,7 +113,7 @@ public class ExtractMetadataStep implements ListenerProcessingStep, UploadableSt
                         if (!alreadyFilledMetadata.contains(joiner.toString())) {
                             itemService.addMetadata(context, wsi.getItem(), metadataValue.getSchema(),
                                 metadataValue.getElement(), metadataValue.getQualifier(), null,
-                                metadataValue.getValue());
+                                metadataValue.getValue(), metadataValue.getAuthority(), metadataValue.getConfidence());
                         }
                     }
                 }

--- a/dspace/config/modules/uclouvain.cfg
+++ b/dspace/config/modules/uclouvain.cfg
@@ -40,6 +40,7 @@ uclouvain.global.metadata.publication.authorInstitution.field = authors.institut
 uclouvain.global.metadata.publication.authorRole.field = authors.role
 uclouvain.global.metadata.publication.authorFgs.field = authors.identifier.fgs
 uclouvain.global.metadata.publication.advisorEmail.field = advisors.email
+uclouvain.global.metadata.publication.abstract.field = dc.description.abstract
 uclouvain.global.metadata.publication.conferenceEndDate.field = publication.conference.endDat
 uclouvain.global.metadata.publication.conferenceIsAbstract.field = publication.isAbstract
 uclouvain.global.metadata.publication.conferenceLocation.field = publication.conference.location
@@ -52,14 +53,22 @@ uclouvain.global.metadata.publication.editorLocation.field = publication.editor.
 uclouvain.global.metadata.publication.hostIsbn.field = publication.host.isbn
 uclouvain.global.metadata.publication.hostTitle.field = publication.host.title
 uclouvain.global.metadata.publication.hostType.field = publication.host.type
+uclouvain.global.metadata.publication.journalDateIssued.field = publication.serial.dateIssued
 uclouvain.global.metadata.publication.journalEissn.field = publication.serial.eissn
 uclouvain.global.metadata.publication.journalIssn.field = publication.serial.issn
-uclouvain.global.metadata.publication.journalPeer-reviewed.field = publication.serial.peerReviewed
+uclouvain.global.metadata.publication.journalIssue.field = publication.serial.issue
+uclouvain.global.metadata.publication.journalPages.field = publication.serial.pages
+uclouvain.global.metadata.publication.journalPeerReviewed.field = publication.serial.peerReviewed
 uclouvain.global.metadata.publication.journalTitle.field = dc.relation.journal
+uclouvain.global.metadata.publication.journalVolume.field = publication.serial.volume
+uclouvain.global.metadata.publication.keyword.field = dc.subject
+uclouvain.global.metadata.publication.language.field = dc.language.iso
 uclouvain.global.metadata.publication.mainType.field = dc.type.maintype
+uclouvain.global.metadata.publication.meshKeyword.field = dc.subject.mesh
 uclouvain.global.metadata.publication.publicationStatus.field = publication.publicationStatus
 uclouvain.global.metadata.publication.subType.field = dc.type.subtype
 uclouvain.global.metadata.publication.title.field = dc.title
+
 
 # Default institution for new profiles.
 uclouvain.profile.default-institution.acronym = UCLouvain

--- a/dspace/config/spring/api/external-services.xml
+++ b/dspace/config/spring/api/external-services.xml
@@ -98,6 +98,16 @@
         </property>
     </bean>
 
+    <bean id="customPubmedDataProvider" class="org.dspace.uclouvain.external.provider.UCLouvainDataProvider">
+        <property name="metadataSource" ref="customPubmedImportService"/>
+        <property name="sourceIdentifier" value="pubmed"/>
+        <property name="supportedEntityTypes">
+            <list>
+                <value>Publication</value>
+            </list>
+        </property>
+    </bean>
+
     <bean id="pubmedLiveImportDataProvider" class="org.dspace.external.provider.impl.LiveImportDataProvider">
         <property name="metadataSource" ref="pubmedImportService"/>
         <property name="sourceIdentifier" value="pubmed"/>
@@ -274,4 +284,3 @@
     </bean>
 
 </beans>
-

--- a/dspace/config/spring/api/step-processing-listener.xml
+++ b/dspace/config/spring/api/step-processing-listener.xml
@@ -9,7 +9,8 @@
 	        <map>
                 <entry key="dc.identifier.pmid">
                     <list>
-                        <ref bean="pubmedLiveImportDataProvider"/>
+                        <!-- <ref bean="pubmedLiveImportDataProvider"/> -->
+                        <ref bean="customPubmedDataProvider"/>
                     </list>
                 </entry>
                 <entry key="dc.identifier.scopus">


### PR DESCRIPTION
## Description

Added a new custom import provider that uses a given pubmed id to retrieve information from pubmed and auto-complete form. This provider can potentially search into DSpace to find matching author or journal to enrich the metadata of the publication.

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module