### PR TITLE
[ADD] feat(arxiv-integration): Custom arXiv import provider.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/uclouvain/core/model/publication/Publication.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/core/model/publication/Publication.java
@@ -162,6 +162,8 @@ public class Publication extends ItemModel implements FWBValidation {
     public static final String DEFENSE_DATE_FIELD =
         getField("dissertationDefenseDate", "dissertation.defenseDate");
 
+    public static final String DOI_IDENTIFIER_FIELD =
+        getField("doiIdentifier", "dc.identifier.doi");
     public static final String IDENTIFIER_ISBN_FIELD =
         getField("identifierISBN", "dc.identifier.isbn");
 

--- a/dspace-api/src/main/java/org/dspace/uclouvain/external/importer/xml/UCLouvainXMLImportSourceService.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/external/importer/xml/UCLouvainXMLImportSourceService.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 import org.dspace.content.dto.MetadataValueDTO;
 import org.dspace.uclouvain.external.importer.UCLouvainImportSourceServiceImpl;
 import org.jdom2.Element;
+import org.jdom2.Namespace;
 import org.jdom2.filter.Filters;
 import org.jdom2.xpath.XPathExpression;
 import org.jdom2.xpath.XPathFactory;
@@ -58,6 +59,18 @@ public abstract class UCLouvainXMLImportSourceService extends UCLouvainImportSou
      * @return An new XpathExpression object.
      */
     protected XPathExpression<Element> buildXpath(String path) {
-        return XPathFactory.instance().compile(path, Filters.element());
+        return XPathFactory.instance().compile(path, Filters.element(), null, getNamespaces());
+    }
+
+    protected XPathExpression<Element> buildXpath(String path, List<Namespace> namespaces) {
+        return XPathFactory.instance().compile(path, Filters.element(), null, namespaces);
+    }
+
+    /**
+     * Get available namespace for a specific XML source.
+     * @return A list of all needed namespace for a specific XML source.
+     */
+    protected List<Namespace> getNamespaces() {
+        return List.of();
     }
 }

--- a/dspace-api/src/main/java/org/dspace/uclouvain/external/importer/xml/arXiv/UCLouvainArXivImportSourceService.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/external/importer/xml/arXiv/UCLouvainArXivImportSourceService.java
@@ -1,0 +1,175 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.external.importer.xml.arXiv;
+
+import static org.dspace.content.authority.Choices.CF_UNSET;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.net.URISyntaxException;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.content.dto.MetadataValueDTO;
+import org.dspace.core.Context;
+import org.dspace.importer.external.liveimportclient.service.LiveImportClient;
+import org.dspace.uclouvain.core.model.publication.Publication;
+import org.dspace.uclouvain.external.importer.xml.UCLouvainXMLImportSourceService;
+import org.dspace.web.ContextUtil;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.JDOMException;
+import org.jdom2.Namespace;
+import org.jdom2.input.SAXBuilder;
+import org.jdom2.xpath.XPathExpression;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Service to extract a list of MetadataValueDTO from Pubmed for a given ArXiv identifier.
+ * 
+ * @author Michaël Pourbaix (michael.pourbaix@uclouvain.be)
+ */
+public class UCLouvainArXivImportSourceService extends UCLouvainXMLImportSourceService {
+    private static final Logger logger = LogManager.getLogger(UCLouvainArXivImportSourceService.class);
+    private static final String ARXIV_URL_PREFIX = "http://arxiv.org/abs/";
+    private static final String ARXIV_PREFIX = "arxiv:";
+
+    @Autowired
+    private LiveImportClient liveImportClient;
+
+    private String url;
+
+    @Override
+    protected List<Namespace> getNamespaces() {
+        return Arrays.asList(
+            Namespace.getNamespace("ns", "http://www.w3.org/2005/Atom"),
+            Namespace.getNamespace("arxiv", "http://arxiv.org/schemas/atom")
+        );
+    }
+
+    @Override
+    public List<MetadataValueDTO> getMetadataList(String query) {
+        try {
+            Context context = ContextUtil.obtainCurrentRequestContext();
+            String rawResponse = fetchData(extractID(query));
+            Element parsedXml = parseXmlResponse(rawResponse);
+            return generateMetadataList(context, parsedXml);
+        } catch (URISyntaxException e) {
+            logger.error("Could not build ArXiv request URL.", e);
+            return List.of();
+        }
+    };
+
+    private String extractID(String query) {
+        if (StringUtils.isNotBlank(query)) {
+            query = query.trim();
+            if (query.startsWith(ARXIV_URL_PREFIX)) {
+                query = query.substring(ARXIV_URL_PREFIX.length());
+            } else if (query.toLowerCase().startsWith(ARXIV_PREFIX)) {
+                query = query.substring(ARXIV_PREFIX.length());
+            }
+        }
+        return query;
+    }
+
+    private String fetchData(String query) throws URISyntaxException {
+        URIBuilder uriBuilder = new URIBuilder(url);
+        uriBuilder.addParameter("id_list", query);
+        Map<String, Map<String, String>> params = new HashMap<>();
+        return liveImportClient.executeHttpGetRequest(2000, uriBuilder.toString(), params);
+    }
+
+    private Element parseXmlResponse(String xmlResponse) {
+        try {
+            SAXBuilder saxBuilder = new SAXBuilder();
+            Document document = saxBuilder.build(new StringReader(xmlResponse));
+            Element root = document.getRootElement();
+
+            XPathExpression<Element> xpath = buildXpath("ns:entry", getNamespaces());
+
+            List<Element> recordsList = xpath.evaluate(root);
+            return recordsList != null ? recordsList.get(0) : null;
+        } catch (JDOMException | IOException e) {
+            return null;
+        }
+    }
+
+    // METADATA EXTRACTION =============================================================================================
+
+    /**
+     * Generate a list of all metadata values extracted from the external source.
+     * 
+     * @param context The current Dspace application context.
+     * @param rootXml The root document to extract data from.
+     * @return A list of all extracted MetadataValueDTO.
+     */
+    private List<MetadataValueDTO> generateMetadataList(Context context, Element rootXml) {
+        List<MetadataValueDTO> metadataList = new ArrayList<>();
+        if (rootXml == null) {
+            return metadataList;
+        }
+        // Author names
+        addAllMetadata(metadataList, Publication.AUTHOR_NAME_FIELD,
+            getAllText(rootXml, "ns:author/ns:name"), null, CF_UNSET, false);
+        // Title
+        addMetadata(metadataList, Publication.TITLE_FIELD,
+            getFirstText(rootXml, "ns:title"), null, CF_UNSET, false);
+        // Abstract (summary)
+        addMetadata(metadataList, Publication.ABSTRACT_FIELD,
+            getFirstText(rootXml, "ns:summary"), null, CF_UNSET, false);
+        // DOI
+        addMetadata(metadataList, Publication.DOI_IDENTIFIER_FIELD,
+            getFirstText(rootXml, "arxiv:doi"), null, CF_UNSET, false);
+        // Date issued (published)
+        addMetadata(metadataList, Publication.DATE_ISSUED_FIELD,
+            convertToDSpaceDate(getFirstText(rootXml, "ns:published")), null, CF_UNSET, false);
+        // Journal info (title)
+        addMetadata(metadataList, Publication.JOURNAL_TITLE_FIELD,
+            getFirstText(rootXml, "arxiv:journal_ref"), null, CF_UNSET, false);
+        // Keyword (term)
+        addMetadata(metadataList, Publication.KEYWORD_FIELD,
+            getFirstText(rootXml, "ns:category/@term"), null, CF_UNSET, false);
+
+        return metadataList;
+    }
+
+    /**
+     * Convert a date from arXiv (ISO 8601) to a valid dspace date.
+     * @param date The date string to convert.
+     * @return A DSpace valid date string composed of 'year-month-day'.
+     */
+    private String convertToDSpaceDate(String date) {
+        if (StringUtils.isEmpty(date)) {
+            return null;
+        }
+        String finalDate = Instant.parse(date)
+            .atZone(ZoneOffset.UTC)
+            .toLocalDate()
+            .toString();
+        return finalDate;
+    }
+
+    // GETTERS AND SETTERS =============================================================================================
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+}

--- a/dspace-api/src/main/resources/spring/spring-dspace-addon-import-services.xml
+++ b/dspace-api/src/main/resources/spring/spring-dspace-addon-import-services.xml
@@ -64,6 +64,10 @@
           class="org.dspace.importer.external.datacite.DataCiteFieldMapping">
     </bean>
 
+    <bean id="customArXivImportService" class="org.dspace.uclouvain.external.importer.xml.arXiv.UCLouvainArXivImportSourceService">
+        <property name="url" value="http://export.arxiv.org/api/query"/>
+    </bean>
+
     <bean id="ArXivImportService"
           class="org.dspace.importer.external.arxiv.service.ArXivImportMetadataSourceServiceImpl" scope="singleton">
         <property name="metadataFieldMapping" ref="ArXivMetadataFieldMapping"/>

--- a/dspace/config/modules/uclouvain.cfg
+++ b/dspace/config/modules/uclouvain.cfg
@@ -51,6 +51,7 @@ uclouvain.global.metadata.publication.conferenceName.field = publication.confere
 uclouvain.global.metadata.publication.conferenceStartDate.field = publication.conference.startDate
 uclouvain.global.metadata.publication.dateIssued.field = dc.date.issued
 uclouvain.global.metadata.publication.dissertationDefenseDate.field = dissertation.defenseDate
+uclouvain.global.metadata.publication.doiIdentifier.field = dc.identifier.doi
 uclouvain.global.metadata.publication.editorName.field = publication.editor.name
 uclouvain.global.metadata.publication.editorLocation.field = publication.editor.location
 uclouvain.global.metadata.publication.entityDepartmentName.field = oairecerif.affiliation.orgunitDepartment

--- a/dspace/config/spring/api/external-services.xml
+++ b/dspace/config/spring/api/external-services.xml
@@ -119,6 +119,16 @@
         </property>
     </bean>
 
+    <bean id="customArXivImportDataProvider" class="org.dspace.uclouvain.external.provider.UCLouvainDataProvider">
+        <property name="metadataSource" ref="customArXivImportService"/>
+        <property name="sourceIdentifier" value="arxiv"/>
+        <property name="supportedEntityTypes">
+            <list>
+                <value>Publication</value>
+            </list>
+        </property>
+    </bean>
+
     <bean id="arxivLiveImportDataProvider" class="org.dspace.external.provider.impl.LiveImportDataProvider">
         <property name="metadataSource" ref="ArXivImportService"/>
         <property name="sourceIdentifier" value="arxiv"/>

--- a/dspace/config/spring/api/step-processing-listener.xml
+++ b/dspace/config/spring/api/step-processing-listener.xml
@@ -20,7 +20,8 @@
                 </entry>
                 <entry key="dc.identifier.arxiv">
                     <list>
-                        <ref bean="arxivLiveImportDataProvider"/>
+                        <!-- <ref bean="arxivLiveImportDataProvider"/> -->
+                         <ref bean="customArXivImportDataProvider"/>
                     </list>
                 </entry>
                 <entry key="dc.identifier.doi">


### PR DESCRIPTION
## Description

New custom import provider that uses a given arxiv identifier to retreieve additional information from arXiv registry and auto-complete the form. ArXiv does not provide many information, only:
- Title and abstract
- Authors names
- Issue date
- DOI
- Keywords
- Journal title

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module