### PR TITLE
[ADD] feat(serial-year-consumer): Copy date issued year into serial year.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/event/Event.java
+++ b/dspace-api/src/main/java/org/dspace/event/Event.java
@@ -15,6 +15,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.logging.log4j.Logger;
@@ -543,6 +544,21 @@ public class Event implements Serializable {
      */
     public String getDetail() {
         return detail;
+    }
+
+    /**
+     * Retrieve metadata from details of event as a list.
+     * Use separator to change format of metadata field.
+     * 
+     * @param separator The separator used for rendering metadata field string.
+     * @return A list of metadata field string contained in the details.
+     */
+    public List<String> getDetailsMetadata(String separator) {
+        return detail == null
+            ? List.of()
+            : Stream.of(detail.split(", "))
+                .map(metadata -> metadata.replaceAll("_", separator))
+                .toList();
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/uclouvain/consumer/DefaultSerialYearConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/consumer/DefaultSerialYearConsumer.java
@@ -1,0 +1,105 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.consumer;
+
+import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.content.Item;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Context;
+import org.dspace.event.Consumer;
+import org.dspace.event.Event;
+import org.dspace.uclouvain.core.model.MetadataField;
+import org.dspace.uclouvain.core.model.publication.ArticlePublication;
+import org.dspace.uclouvain.core.model.publication.Publication;
+import org.dspace.uclouvain.core.model.publication.PublicationFactory;
+import org.dspace.uclouvain.core.model.publication.SpeechPublication;
+
+/**
+ * When a publication date issued is provided, pre-fill the serial issued year if no value is present.
+ * 
+ * @author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+public class DefaultSerialYearConsumer implements Consumer {
+
+    private ItemService itemService;
+    private MetadataField journalIssuedField;
+    private Set<Publication> publicationsToProcess = new HashSet<>();
+
+    private static final Logger logger = LogManager.getLogger(DefaultSerialYearConsumer.class);
+
+    public void initialize() {
+        itemService = ContentServiceFactory.getInstance().getItemService();
+        journalIssuedField = new MetadataField(Publication.JOURNAL_DATE_ISSUED_FIELD);
+    }
+
+    @Override
+    public void consume(Context context, Event event) throws Exception {
+        Item item = (Item) event.getSubject(context);
+        if (item == null || !isEventValid(context, event)) {
+            return;
+        }
+        Publication publication = PublicationFactory.build(item);
+        if (publication instanceof ArticlePublication ||
+                (publication instanceof SpeechPublication speech && speech.publishedInSerial())) {
+            publicationsToProcess.add(publication);
+        }
+    }
+
+    @Override
+    public void end(Context context) {
+        if (publicationsToProcess.isEmpty()) {
+            return;
+        }
+        for (Publication publication : publicationsToProcess) {
+            Item item = publication.getItem();
+            if (item == null) {
+                continue;
+            }
+            // Prevent updating an already existing value.
+            if (itemService.getMetadata(item, Publication.JOURNAL_DATE_ISSUED_FIELD) != null) {
+                continue;
+            }
+            int issuedYear = publication.getIssuedYear();
+            if (issuedYear == -1) { // if no issued year, exit.
+                continue;
+            }
+            context.turnOffAuthorisationSystem();
+            try {
+                itemService.setMetadataSingleValue(
+                    context,
+                    item,
+                    journalIssuedField,
+                    null,
+                    String.valueOf(issuedYear)
+                );
+                itemService.update(context, item);
+            } catch (Exception e) {
+                logger.warn("Could not update modified publication :: {}", item.getID().toString(), e);
+            }
+            context.restoreAuthSystemState();
+        }
+        publicationsToProcess.clear();
+    }
+
+    @Override
+    public void finish(Context context) {
+        // Nothing to do here.
+    }
+
+    private boolean isEventValid(Context context, Event event) throws SQLException {
+        return event.getDetailsMetadata(".")
+                .stream()
+                .anyMatch(Publication.DATE_ISSUED_FIELD::equals);
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/consumer/DissertationExtractYearConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/consumer/DissertationExtractYearConsumer.java
@@ -7,7 +7,6 @@
  */
 package org.dspace.uclouvain.consumer;
 
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
@@ -34,14 +33,12 @@ public class DissertationExtractYearConsumer implements Consumer {
 
     private Set<UUID> idsToProcess = new HashSet<>();
     private ItemService itemService;
-    private MetadataField defenseDateField;
     private MetadataField dateIssuedField;
     private Logger logger;
 
     @Override
     public void initialize() throws Exception {
         itemService = ContentServiceFactory.getInstance().getItemService();
-        defenseDateField = new MetadataField(Publication.DEFENSE_DATE_FIELD);
         dateIssuedField = new MetadataField(Publication.DATE_ISSUED_FIELD);
         logger = LogManager.getLogger(DissertationExtractYearConsumer.class);
     }
@@ -49,14 +46,14 @@ public class DissertationExtractYearConsumer implements Consumer {
     @Override
     public void consume(Context context, Event event) throws Exception {
         // If event.detail is null, we cannot know which metadata was affected so we add the item to the list anyway.
-        if (event.getDetail() == null || areDetailValid(event.getDetail())) {
+        if (areDetailsValid(event)) {
             idsToProcess.add(event.getSubjectID());
         }
     }
 
-    private boolean areDetailValid(String details) {
-        return Arrays.stream(details.split(", "))
-            .anyMatch(detail -> detail.equals(defenseDateField.getFullString("_")));
+    private boolean areDetailsValid(Event event) {
+        return event.getDetail() == null && event.getDetailsMetadata(".").stream()
+            .anyMatch(detail -> detail.equals(Publication.DEFENSE_DATE_FIELD));
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/uclouvain/core/model/publication/SpeechPublication.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/core/model/publication/SpeechPublication.java
@@ -61,8 +61,16 @@ public class SpeechPublication extends Publication {
             || itemService.hasMetadata(item, HOST_DOCUMENT_TITLE_FIELD);
     }
 
+    public boolean publishedInSerial() {
+        return Objects.equals(getFirstMetadataValue(SPEECH_STATUS_FIELD), STATUS_PUBLISHED_SERIAL);
+    }
+
+    public boolean publishedInBook() {
+        return Objects.equals(getFirstMetadataValue(SPEECH_STATUS_FIELD), STATUS_PUBLISHED_BOOK);
+    }
+
     public boolean isAbstract() {
-        return Objects.equals(getFirstMetadataValue(Publication.CONFERENCE_IS_ABSTRACT_FIELD), "true");
+        return Objects.equals(getFirstMetadataValue(CONFERENCE_IS_ABSTRACT_FIELD), "true");
     }
 
     // FWB METHODS IMPLEMENTATION ======================================================================================

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -823,8 +823,8 @@ event.dispatcher.RelatedItemEnhancerUpdatePoller.class = org.dspace.event.BasicD
 # Add rdf here, if you are using dspace-rdf to export your repository content as RDF.
 # Add iiif here, if you are using dspace-iiif.
 # Add orcidqueue here, if the integration with ORCID is configured and wish to enable the synchronization queue functionality
-event.dispatcher.default.consumers = versioning, discovery, eperson, dedup, crisconsumer, orcidqueue, audit, qaeventsdelete, referenceresolver, orcidwebhook, itemenhancer, customurl, iiif, reciprocal, filetypemetadataenhancer, authoritylink, ldnmessage,  licensegenerator, accesstype, authoritymetadataenhancer, formfieldcleaner, fillervalueremover, dissertationyearextract, journaldefaultdeletepolicy, profilelink, enrichmetadata, defaultauthorrole
-event.dispatcher.RelatedItemEnhancerUpdatePoller.consumers = versioning, discovery, eperson, dedup, crisconsumer, orcidqueue, audit, qaeventsdelete, referenceresolver, orcidwebhook, itemenhancer, customurl, iiif, reciprocal, filetypemetadataenhancer, authoritylink, ldnmessage, journaldefaultdeletepolicy, profilelink, enrichmetadata, defaultauthorrole
+event.dispatcher.default.consumers = versioning, discovery, eperson, dedup, crisconsumer, orcidqueue, audit, qaeventsdelete, referenceresolver, orcidwebhook, itemenhancer, customurl, iiif, reciprocal, filetypemetadataenhancer, authoritylink, ldnmessage,  licensegenerator, accesstype, authoritymetadataenhancer, formfieldcleaner, fillervalueremover, dissertationyearextract, journaldefaultdeletepolicy, profilelink, enrichmetadata, defaultauthorrole, defaultserialissued
+event.dispatcher.RelatedItemEnhancerUpdatePoller.consumers = versioning, discovery, eperson, dedup, crisconsumer, orcidqueue, audit, qaeventsdelete, referenceresolver, orcidwebhook, itemenhancer, customurl, iiif, reciprocal, filetypemetadataenhancer, authoritylink, ldnmessage, journaldefaultdeletepolicy, profilelink, enrichmetadata, defaultauthorrole, defaultserialissued
 
 # enable the item enhancer poller
 related-item-enhancer-poller.enabled = true

--- a/dspace/config/modules/uclouvain.cfg
+++ b/dspace/config/modules/uclouvain.cfg
@@ -146,6 +146,9 @@ event.consumer.enrichmetadata.filters = Item+Create
 event.consumer.defaultauthorrole.class = org.dspace.uclouvain.consumer.DefaultAuthorRoleConsumer
 event.consumer.defaultauthorrole.filters = Item+All
 
+event.consumer.defaultserialissued.class = org.dspace.uclouvain.consumer.DefaultSerialYearConsumer
+event.consumer.defaultserialissued.filters = Item+Install|Modify|Modify_Metadata
+
 #------------------------------------------------------------------#
 #------------- Community/Collection configuration -----------------#
 #------------------------------------------------------------------#


### PR DESCRIPTION
## Description

When a user adds a serial year in the form, the value is copied in the serial year field.
This only apply if the serial year field has no value.

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module