### PR TITLE
[UPD] feat(submission): Improve GROBID extractor plugin

### DIFF
--- a/dspace-api/src/main/java/org/dspace/importer/external/metadatamapping/contributor/SimpleAdditionMetadataContributor.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/metadatamapping/contributor/SimpleAdditionMetadataContributor.java
@@ -1,0 +1,74 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.importer.external.metadatamapping.contributor;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.drew.lang.annotations.NotNull;
+import org.dspace.content.MetadataFieldName;
+import org.dspace.importer.external.metadatamapping.MetadatumDTO;
+import org.dspace.importer.external.service.components.dto.PlainMetadataSourceDto;
+
+/**
+ * Metadata contributor that add as many as specific metadatum as super class creates.
+ * It is useful to add linked metadata to a real-extracted metadata
+ *
+ * @author Renaud Michotte (renaud.michotte@uclouvain.be)
+ */
+public class SimpleAdditionMetadataContributor extends SimpleMetadataContributor {
+
+    protected Map<MetadataFieldName, String> additionalMetadata = new HashMap<>();
+
+    @Override
+    public Collection<MetadatumDTO> contributeMetadata(PlainMetadataSourceDto t) {
+        Collection<MetadatumDTO> baseMetadata = super.contributeMetadata(t);
+        // Ensure we work on a modifiable list to avoid UnsupportedOperationException
+        List<MetadatumDTO> result = new ArrayList<>(baseMetadata);
+        int baseCount = baseMetadata.size();
+        if (baseCount == 0 || additionalMetadata.isEmpty()) {
+            return result;
+        }
+        // For each entry in additionalMetadata, create N copies (N = baseCount)
+        List<MetadatumDTO> additions = additionalMetadata.entrySet().stream()
+            .flatMap(entry -> Stream
+                .generate(() -> createAdditionField(entry.getKey(), entry.getValue()))
+                .limit(baseCount))
+            .toList();
+
+        result.addAll(additions);
+        return result;
+    }
+
+    private MetadatumDTO createAdditionField(MetadataFieldName mdField, String mdValues) {
+        MetadatumDTO md = new MetadatumDTO();
+        md.setSchema(mdField.schema);
+        md.setElement(mdField.element);
+        md.setQualifier(mdField.qualifier);
+        md.setValue(mdValues);
+        return md;
+    }
+
+    // SETTER ==========================================================================================================
+    public void setAdditionalMetadata(@NotNull Map<String, String> inputMetadata) {
+        this.additionalMetadata = Optional.ofNullable(inputMetadata)
+            .orElse(Collections.emptyMap())
+            .entrySet().stream()
+            .collect(Collectors.toMap(
+                    entry -> new MetadataFieldName(entry.getKey()),
+                    Map.Entry::getValue
+            ));
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/submit/extraction/GrobidImportMetadataSourceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/submit/extraction/GrobidImportMetadataSourceServiceImpl.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.submit.extraction;
 
-import static org.dspace.submit.extraction.grobid.client.ConsolidateHeaderEnum.NO_CONSOLIDATION;
+import static org.dspace.submit.extraction.grobid.client.ConsolidateHeaderEnum.CONSOLIDATE_AND_INJECT_METADATA;
 
 import java.io.InputStream;
 import java.util.List;
@@ -65,7 +65,7 @@ public class GrobidImportMetadataSourceServiceImpl extends AbstractPlainMetadata
     @Override
     protected List<PlainMetadataSourceDto> readData(InputStream inputStream) throws FileSourceException {
         try {
-            TEI tei = grobidClient.processHeaderDocument(inputStream, NO_CONSOLIDATION);
+            TEI tei = grobidClient.processHeaderDocument(inputStream, CONSOLIDATE_AND_INJECT_METADATA);
             return List.of(convertToPlainMetadataSourceDto(tei.getTeiHeader()));
         } catch (RuntimeException ex) {
             LOGGER.error("An error occurs processing header document", ex);

--- a/dspace/config/spring/api/grobid-integration.xml
+++ b/dspace/config/spring/api/grobid-integration.xml
@@ -19,13 +19,12 @@
         <entry key-ref="dcTitle" value-ref="grobidTitleContributor" />
         <entry key-ref="dcAuthors" value-ref="grobidAuthorsContributor" />
         <entry key-ref="dcJournal" value-ref="grobidJournalContributor" />
-		<entry key-ref="dcIssued" value-ref="grobidIssuedContributor" />
-		<entry key-ref="dcJissn" value-ref="grobidJissnContributor" />
+        <entry key-ref="dcIssued" value-ref="grobidIssuedContributor" />
+        <entry key-ref="dcJissn" value-ref="grobidJissnContributor" />
         <entry key-ref="dcPisbn" value-ref="grobidPisbnContributor" />
-        <!-- Using 'dc.identifier.doi' instead of 'dc.identifier' to be more precise. -->
-		<entry key-ref="grobid.doi" value-ref="grobidDoiContributor" />
-		<entry key-ref="dcAbstract" value-ref="grobidAbstractContributor" />
-		<entry key-ref="dcAllKeyword" value-ref="grobidKeywordsContributor" />
+        <entry key-ref="dcAbstract" value-ref="grobidAbstractContributor" />
+        <entry key-ref="dcAllKeyword" value-ref="grobidKeywordsContributor" />
+        <entry key-ref="grobid.doi" value-ref="grobidDoiContributor" />
         <entry key-ref="grobid.journalVolume" value-ref="grobidSerialVolume"/>
         <entry key-ref="grobid.journalIssue" value-ref="grobidSerialIssue"/>
         <entry key-ref="grobid.journalPages" value-ref="grobidSerialPages"/>
@@ -37,10 +36,14 @@
         <property name="key" value="analytictitle" />
     </bean>
     
-    <bean id="grobidAuthorsContributor" class="org.dspace.importer.external.metadatamapping.contributor.SimpleMetadataContributor">
+    <bean id="grobidAuthorsContributor" class="org.dspace.importer.external.metadatamapping.contributor.SimpleAdditionMetadataContributor">
         <property name="field" ref="dcAuthors"/>
         <property name="key" value="analyticname" />
+        <property name="additionalMetadata" ref="authorAdditionalMetadata"/>
     </bean>
+    <util:map id="authorAdditionalMetadata" map-class="java.util.HashMap" key-type="java.lang.String" value-type="java.lang.String">
+        <entry key="authors.role" value="author" />
+    </util:map>
 
     <bean id="grobidJournalContributor" class="org.dspace.importer.external.metadatamapping.contributor.SimpleMetadataContributor">
         <property name="field" ref="grobid.journalTitle"/>
@@ -62,10 +65,18 @@
         <property name="key" value="isbn" />
     </bean>
     
-    <bean id="grobidDoiContributor" class="org.dspace.importer.external.metadatamapping.contributor.SimpleMetadataContributor">
+    <bean id="grobidDoiContributor" class="org.dspace.importer.external.metadatamapping.contributor.SimpleAdditionMetadataContributor">
         <property name="field" ref="grobid.doi"/>
         <property name="key" value="doi" />
+        <property name="additionalMetadata" ref="doiAdditionalMetadata"/>
     </bean>
+    <!-- By default, if grobid find a DOI, we don't know the document type.... But if we don't save a value for this
+         metadata, the specific fields will be removed by `cleaner` consumer. To avoid this issue, force a default
+         value for this field (that could be override next by DOI importer for more accurate value) -->
+    <util:map id="doiAdditionalMetadata" map-class="java.util.HashMap" key-type="java.lang.String" value-type="java.lang.String">
+      <entry key="dc.type.maintype" value="text::journal-article"/>
+      <entry key="dc.type.subtype" value="research-article"/>
+    </util:map>
     
     <bean id="grobidAbstractContributor" class="org.dspace.importer.external.metadatamapping.contributor.SimpleMetadataContributor">
         <property name="field" ref="dcAbstract"/>


### PR DESCRIPTION
* Add "authors.role" metadata for any extrated authors
* Add default "dc.type.maintype" to prevent "dc.identifier.doi" clean
* Update GrobID to use "consolidation mode"

Authored-by: Renaud Michotte <renaud.michotte@uclouvain.be>

## Checklist

- [ ] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module