### PR TITLE
[UPD] feat(search): Improve fulltext indexing

### DIFF
--- a/dspace/config/modules/uclouvain.cfg
+++ b/dspace/config/modules/uclouvain.cfg
@@ -66,9 +66,5 @@ uclouvain-item-enhancer-poller.enabled = false
 #------------------------------------------------------------#
 #----------------Full-text ingest config---------------------#
 #------------------------------------------------------------#
-
-# Disable full-text ingest max chars limit. This limits the max chars that can be extracted from a file.
-textextractor.max-chars = -1
-
-# Disable Solr full-text indexing limit. This limits the max chars that can be indexed in "fulltext" key of Solr.
-discovery.solr.fulltext.charLimit=-1
+textextractor.max-chars = 50000
+discovery.solr.fulltext.charLimit = 50000

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -889,11 +889,11 @@
                             <property name="maxSize" value="250"/>
                             <property name="snippets" value="2"/>
                         </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
+                        <!--<bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
                             <property name="field" value="fulltext"/>
                             <property name="maxSize" value="250"/>
                             <property name="snippets" value="2"/>
-                        </bean>
+                        </bean>-->
                     </list>
                 </property>
             </bean>
@@ -965,11 +965,11 @@
                             <property name="maxSize" value="250"/>
                             <property name="snippets" value="2"/>
                         </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
+                        <!--<bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
                             <property name="field" value="fulltext"/>
                             <property name="maxSize" value="250"/>
                             <property name="snippets" value="2"/>
-                        </bean>
+                        </bean>-->
                     </list>
                 </property>
             </bean>
@@ -1041,11 +1041,11 @@
                             <property name="maxSize" value="250"/>
                             <property name="snippets" value="2"/>
                         </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
+                        <!--<bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
                             <property name="field" value="fulltext"/>
                             <property name="maxSize" value="250"/>
                             <property name="snippets" value="2"/>
-                        </bean>
+                        </bean>-->
                     </list>
                 </property>
             </bean>
@@ -1116,11 +1116,11 @@
                             <property name="maxSize" value="250"/>
                             <property name="snippets" value="2"/>
                         </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
+                        <!--<bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
                             <property name="field" value="fulltext"/>
                             <property name="maxSize" value="250"/>
                             <property name="snippets" value="2"/>
-                        </bean>
+                        </bean>-->
                     </list>
                 </property>
             </bean>
@@ -1186,11 +1186,11 @@
                             <property name="maxSize" value="250"/>
                             <property name="snippets" value="2"/>
                         </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
+                        <!--<bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
                             <property name="field" value="fulltext"/>
                             <property name="maxSize" value="250"/>
                             <property name="snippets" value="2"/>
-                        </bean>
+                        </bean>-->
                     </list>
                 </property>
             </bean>
@@ -1261,11 +1261,11 @@
                             <property name="maxSize" value="250"/>
                             <property name="snippets" value="2"/>
                         </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
+                        <!--<bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
                             <property name="field" value="fulltext"/>
                             <property name="maxSize" value="250"/>
                             <property name="snippets" value="2"/>
-                        </bean>
+                        </bean>-->
                     </list>
                 </property>
             </bean>

--- a/dspace/solr/search/conf/schema.xml
+++ b/dspace/solr/search/conf/schema.xml
@@ -251,7 +251,7 @@
         via copyField further on in this schema  -->
     <field name="search_text" type="text" indexed="true" stored="false" multiValued="true"/>
 
-    <field name="fulltext" type="text" indexed="true" stored="true" multiValued="true"/>
+    <field name="fulltext" type="text" indexed="true" stored="false" multiValued="true"/>
 
     <!-- Internal DSpace Object ID -->
     <field name="search.resourceid" type="string" indexed="true" stored="true" required="true" omitNorms="true" />


### PR DESCRIPTION
Disable "fulltext" key into highlight configuration. Update "schema.xml" for search core to not store the fulltext content into lucene indexes

Authored-by: Renaud Michotte <renaud.michotte@uclouvain.be>

## Checklist

- [ ] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module