### PR TITLE
[UPD] feat(discovery): Fix read key not correctly indexed.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/uclouvain/async/PublicationProfileAsyncIndexingService.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/async/PublicationProfileAsyncIndexingService.java
@@ -1,0 +1,81 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.async;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.content.Item;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Context;
+import org.dspace.discovery.IndexableObject;
+import org.dspace.discovery.IndexingService;
+import org.dspace.discovery.indexobject.factory.IndexObjectFactoryFactory;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.uclouvain.services.UCLouvainProfileService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service to asynchronously re-index all publication of a profile when an eperson is linked to it.
+ * 
+ * @author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+@Service
+@EnableAsync
+public class PublicationProfileAsyncIndexingService {
+
+    private static final Logger logger = LogManager.getLogger(PublicationProfileAsyncIndexingService.class);
+
+    @Autowired
+    private ItemService itemService;
+    @Autowired
+    private UCLouvainProfileService profileService;
+
+    private IndexingService indexer = DSpaceServicesFactory
+        .getInstance().getServiceManager()
+        .getServiceByName(IndexingService.class.getName(), IndexingService.class);
+    private IndexObjectFactoryFactory indexObjectServiceFactory = IndexObjectFactoryFactory.getInstance();
+
+    @Async
+    public void indexPublicationsForProfile(UUID profileUUID) {
+        try (Context context = new Context()) {
+            context.turnOffAuthorisationSystem();
+            Item profile = itemService.find(context, profileUUID);
+            if (profile == null) {
+                logger.warn("Profile item not found for UUID: {}, aborting async index.", profileUUID);
+                return;
+            }
+            for (Item publication : getPublicationsToIndex(context, profile)) {
+                try {
+                    List<IndexableObject> objects = indexObjectServiceFactory.getIndexableObjects(context, publication);
+                    if (objects != null && !objects.isEmpty()) {
+                        IndexableObject io = objects.get(0);
+                        indexer.indexContent(context, io);
+                        logger.info("Re-indexed publication {} due to profile link", publication.getID());
+                    } else {
+                        logger.warn("No indexable object found for publication {}", publication.getID());
+                    }
+                } catch (Exception e) {
+                    logger.error("Failed to index content for publication: {}", publication.getID(), e);
+                }
+            }
+            context.complete();
+        } catch (Exception e) {
+            logger.error("Could not index publication of profile " + profileUUID.toString() + " for eperson link", e);
+        }
+    }
+
+    private List<Item> getPublicationsToIndex(Context context, Item profile) {
+        return profileService.findLinkedPublications(context, profile);
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/services/UCLouvainProfileServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/services/UCLouvainProfileServiceImpl.java
@@ -144,7 +144,7 @@ public class UCLouvainProfileServiceImpl implements UCLouvainProfileService {
     }
 
     public List<Item> findLinkedPublications(Context context, Item profile) {
-        if (itemService.getEntityType(profile).equals(PROFILE_ENTITY_TYPE)) {
+        if (!itemService.getEntityType(profile).equals(PROFILE_ENTITY_TYPE)) {
             throw new IllegalArgumentException("`profile` parameter isn't a valid Person entity type");
         }
         DiscoverQuery dq = new DiscoverQuery();

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/login/impl/ResearcherProfileAutomaticClaim.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/login/impl/ResearcherProfileAutomaticClaim.java
@@ -30,6 +30,7 @@ import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.service.EPersonService;
 import org.dspace.profile.service.ResearcherProfileService;
+import org.dspace.uclouvain.async.PublicationProfileAsyncIndexingService;
 import org.dspace.uclouvain.services.UCLouvainProfileService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.Assert;
@@ -58,6 +59,9 @@ public class ResearcherProfileAutomaticClaim implements PostLoggedInAction {
 
     @Autowired
     private UCLouvainProfileService uclouvainProfileService;
+
+    @Autowired
+    private PublicationProfileAsyncIndexingService publicationProfileIndexingService;
 
     /**
      * The field of the eperson to search for.
@@ -123,7 +127,14 @@ public class ResearcherProfileAutomaticClaim implements PostLoggedInAction {
             itemService.addMetadata(context, item, "dspace", "object", "owner",
                 null, fullName, id.toString(), CF_ACCEPTED);
             itemService.update(context, item);
+            // Commit to make sure changes are applied (required for the re-index to work properly)
+            context.commit();
+            // Reload current user (can be detached due to commit) for next PostLoggedInAction.
+            currentUser = context.reloadEntity(currentUser);
             context.restoreAuthSystemState();
+
+            // Trigger a re-index of all publications to add correct 'read' solr key.
+            publicationProfileIndexingService.indexPublicationsForProfile(item.getID());
         }
 
     }

--- a/dspace/config/spring/uclouvain/uclouvain-services.xml
+++ b/dspace/config/spring/uclouvain/uclouvain-services.xml
@@ -81,6 +81,8 @@
     <bean id="epersonAuthorize" class="org.dspace.uclouvain.authorize.eperson.EPersonAuthorize"/>
     <bean id="bundleAuthorize" class="org.dspace.uclouvain.authorize.bundle.BundleAuthorize"/>
 
+    <bean id="publicationProfileAsyncIndexingService" class="org.dspace.uclouvain.async.PublicationProfileAsyncIndexingService"/>
+
     <!-- UTILS ============================================================ -->
     <bean id="itemUtils" class="org.dspace.uclouvain.core.utils.ItemUtils" />
     <bean id="metadataTransactionCache" class="org.dspace.uclouvain.content.tracking.MetadataTransactionCache"/>


### PR DESCRIPTION
In some cases, if the user connects after the profile is created, the read key of the publications is not indexed correctly. Added a logic to reindex all publications when a user is linked to a profile when connecting for the first time.

Closes bibsys/Dspace#337.

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module