### PR TITLE
[UPD] feat(export) New uclouvain export script.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/uclouvain/export/script/PublicationExport.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/export/script/PublicationExport.java
@@ -1,0 +1,169 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.export.script;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.lang3.StringUtils;
+import org.dspace.content.crosswalk.CrosswalkException;
+import org.dspace.core.Context;
+import org.dspace.discovery.SearchServiceException;
+import org.dspace.kernel.ServiceManager;
+import org.dspace.scripts.DSpaceRunnable;
+import org.dspace.uclouvain.export.result.ExportResult;
+import org.dspace.uclouvain.export.services.UCLouvainExportService;
+import org.dspace.uclouvain.factories.UCLouvainServiceFactory;
+import org.dspace.utils.DSpace;
+
+/**
+ * Custom publication export script to export publication of a profile in FWB or FNRS format.
+ * This is used when running export process in the frontend (asynchronous process).
+ * 
+ * @author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+public class PublicationExport extends DSpaceRunnable<PublicationExportScriptConfiguration<PublicationExport>> {
+
+    public enum PublicationExportType {
+        FNRS,
+        FWB
+    }
+
+    private UCLouvainExportService exportService;
+
+    private String uuid;
+    private String fgs;
+    private PublicationExportType exportType;
+    private String startYear;
+    private String endYear;
+    private String includePosters = "false";
+
+    @Override
+    public void setup() throws ParseException {
+        exportService = UCLouvainServiceFactory.getInstance().getExportService();
+
+        uuid = commandLine.getOptionValue('u');
+        fgs = commandLine.getOptionValue('f');
+        String type = commandLine.getOptionValue('t');
+        startYear = commandLine.getOptionValue('s');
+        endYear = commandLine.getOptionValue('e');
+
+        if (StringUtils.isNotBlank(commandLine.getOptionValue('i'))) {
+            includePosters = String.valueOf(Boolean.parseBoolean(commandLine.getOptionValue('i')));
+        }
+
+        if (StringUtils.isAllBlank(uuid, fgs)) {
+            throw new ParseException("Either uuid or fgs should be provided");
+        }
+
+        if (StringUtils.isBlank(type)) {
+            throw new ParseException("The export type (-t) is required.");
+        }
+
+        try {
+            // Check that the provided value is accepted.
+            exportType = PublicationExportType.valueOf(type.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new ParseException(
+                "Illegal value for --type : " + type + ". Accepted values are "
+                + Arrays.toString(PublicationExportType.values()));
+        }
+    }
+
+    @Override
+    public void internalRun() throws Exception {
+        Context context = new Context(Context.Mode.READ_ONLY);
+        Map<String, String> filters = parseFilters();
+
+        try {
+            handler.logInfo(
+                "Starting export process for ids: 'fgs': %s, 'uuid': %s; with filters: %s".formatted(
+                    fgs,
+                    uuid,
+                    filters
+                )
+            );
+            ExportResult exportResult = export(context, uuid, fgs, filters, exportType);
+            handler.logInfo("Export ended, streaming content to user...");
+            // READ_WRITE mode is necessary for writing/reading files in dspace.
+            context.setMode(Context.Mode.READ_WRITE);
+            handler.writeFilestream(
+                context,
+                exportResult.getFileName(),
+                exportResult.readStream(),
+                exportResult.getMimeType()
+            );
+            context.complete();
+            handler.logInfo("Export done.");
+        } catch (Exception e) {
+            handler.handleException(e);
+            context.abort();
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public PublicationExportScriptConfiguration<PublicationExport> getScriptConfiguration() {
+        ServiceManager serviceManager = new DSpace().getServiceManager();
+        return serviceManager.getServiceByName("publication-export", PublicationExportScriptConfiguration.class);
+    }
+
+    /**
+     * Parse filters based on provided script configuration.
+     */
+    private Map<String, String> parseFilters() {
+        Map<String, String> filters = new HashMap<>();
+        addIfNotBlank(filters, "year", extractYear());
+        addIfNotBlank(filters, "includePoster", includePosters);
+        return filters;
+    }
+
+    private void addIfNotBlank(Map<String, String> map, String key, String value) {
+        if (StringUtils.isNotBlank(value)) {
+            map.put(key, value);
+        }
+    }
+
+    /**
+     * Extract the year from the script configuration. Year filter is built by concatenating the start and end year.
+     * 
+     * @return A filter string for the year.
+     */
+    private String extractYear() {
+        boolean hasStart = StringUtils.isNotBlank(startYear);
+        boolean hasEnd = StringUtils.isNotBlank(endYear);
+        if (hasStart || hasEnd) {
+            String s = hasStart ? startYear.trim() : "*";
+            String e = hasEnd ? endYear.trim() : "*";
+            return "%s-%s".formatted(s, e);
+        }
+        return null;
+    }
+
+    /**
+     * Using the provided configuration, do the correct export and return an {@link ExportResult} object.
+     * 
+     * @param context The current DSace application context.
+     * @param uuid The uuid of the profile to export publications of.
+     * @param fgs The fgs of the profile to export publications of.
+     * @param params The export params.
+     * @param exportType The type of export that needs to be performed (fnrs, fwb...).
+     * @return An {@link ExportResult} object containing all export information (file content, filename, MIME...)
+     */
+    private ExportResult export(
+        Context context, String uuid, String fgs, Map<String, String> params, PublicationExportType exportType
+    ) throws SearchServiceException, CrosswalkException {
+        handler.logInfo("Export type is '%s'".formatted(exportType));
+        return switch (exportType) {
+            case FNRS -> exportService.getAuthorFNRSBibliography(context, uuid, fgs, params);
+            case FWB  -> exportService.getAuthorFWBBibliography(context, uuid, fgs, params);
+        };
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/export/script/PublicationExportCli.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/export/script/PublicationExportCli.java
@@ -1,0 +1,11 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.export.script;
+
+public class PublicationExportCli extends PublicationExport {
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/export/script/PublicationExportCliScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/export/script/PublicationExportCliScriptConfiguration.java
@@ -1,0 +1,12 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.export.script;
+
+public class PublicationExportCliScriptConfiguration<T extends PublicationExportCli>
+    extends PublicationExportScriptConfiguration<T> {
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/export/script/PublicationExportScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/export/script/PublicationExportScriptConfiguration.java
@@ -1,0 +1,99 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.export.script;
+
+import java.util.List;
+
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.dspace.core.Context;
+import org.dspace.scripts.DSpaceCommandLineParameter;
+import org.dspace.scripts.configuration.ScriptConfiguration;
+
+public class PublicationExportScriptConfiguration<T extends PublicationExport> extends ScriptConfiguration<T> {
+    private Class<T> dspaceRunnableClass;
+
+    @Override
+    public boolean isAllowedToExecute(Context context, List<DSpaceCommandLineParameter> commandLineParameters) {
+        // Make sure the user is authenticated to allow bibliographic export.
+        return context.getCurrentUser() != null;
+    }
+
+    @Override
+    public Options getOptions() {
+        if (options == null) {
+            options = new Options();
+
+            options.addOption(
+                Option.builder("u")
+                    .longOpt("uuid")
+                    .desc("The uuid of the profile to export publication of")
+                    .hasArg(true)
+                    .type(String.class)
+                    .required(false)
+                    .build()
+            );
+            options.addOption(
+                Option.builder("f")
+                    .longOpt("fgs")
+                    .desc("The fgs of the profile to export publication of")
+                    .hasArg(true)
+                    .type(String.class)
+                    .required(false)
+                    .build()
+            );
+            options.addOption(
+                Option.builder("t")
+                    .longOpt("type")
+                    .desc("The type of export to perform: 'fnrs' or 'fwb'")
+                    .hasArg(true)
+                    .type(String.class)
+                    .required(true)
+                    .build()
+            );
+            options.addOption(
+                Option.builder("s")
+                    .longOpt("startYear")
+                    .desc("Export only publications after this date")
+                    .hasArg(true)
+                    .type(String.class)
+                    .required(false)
+                    .build()
+            );
+            options.addOption(
+                Option.builder("e")
+                    .longOpt("endYear")
+                    .desc("Export only publications before this date")
+                    .hasArg(true)
+                    .type(String.class)
+                    .required(false)
+                    .build()
+            );
+            options.addOption(
+                Option.builder("i")
+                    .longOpt("includePosters")
+                    .desc("Include posters into the export. Default is false.")
+                    .hasArg(true)
+                    .required(false)
+                    .build()
+            );
+        }
+        return options;
+    }
+
+    // SETTER && GETTER
+    @Override
+    public Class<T> getDspaceRunnableClass() {
+        return dspaceRunnableClass;
+    }
+
+    @Override
+    public void setDspaceRunnableClass(Class<T> dspaceRunnableClass) {
+        this.dspaceRunnableClass = dspaceRunnableClass;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/factories/UCLouvainServiceFactory.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/factories/UCLouvainServiceFactory.java
@@ -12,6 +12,7 @@ import org.dspace.uclouvain.citations.UCLouvainCitationsService;
 import org.dspace.uclouvain.content.cleanMetadata.CleanMetadataService;
 import org.dspace.uclouvain.content.service.CommentService;
 import org.dspace.uclouvain.core.mails.metadataParser.MailMetadataParserService;
+import org.dspace.uclouvain.export.services.UCLouvainExportService;
 import org.dspace.uclouvain.itemEnhancer.UCLouvainItemEnhancerService;
 import org.dspace.uclouvain.itemEnhancer.poller.UCLouvainItemEnhancerUpdatePoller;
 import org.dspace.uclouvain.profileIngester.services.IDMPersonValidityService;
@@ -46,6 +47,7 @@ public abstract  class UCLouvainServiceFactory {
     public abstract PublicationService getPublicationService();
     public abstract IDMPersonValidityService getIDMPersonValidityService();
     public abstract CleanMetadataService getCleanMetadataService();
+    public abstract UCLouvainExportService getExportService();
 
     public static UCLouvainServiceFactory getInstance() {
         return DSpaceServicesFactory

--- a/dspace-api/src/main/java/org/dspace/uclouvain/factories/UCLouvainServiceFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/factories/UCLouvainServiceFactoryImpl.java
@@ -11,6 +11,7 @@ import org.dspace.uclouvain.citations.UCLouvainCitationsService;
 import org.dspace.uclouvain.content.cleanMetadata.CleanMetadataService;
 import org.dspace.uclouvain.content.service.CommentService;
 import org.dspace.uclouvain.core.mails.metadataParser.MailMetadataParserService;
+import org.dspace.uclouvain.export.services.UCLouvainExportService;
 import org.dspace.uclouvain.itemEnhancer.UCLouvainItemEnhancerService;
 import org.dspace.uclouvain.itemEnhancer.poller.UCLouvainItemEnhancerUpdatePoller;
 import org.dspace.uclouvain.profileIngester.services.IDMPersonValidityService;
@@ -59,6 +60,8 @@ public class UCLouvainServiceFactoryImpl extends UCLouvainServiceFactory {
     private IDMPersonValidityService idmPersonValidityService;
     @Autowired
     private CleanMetadataService cleanMetadataService;
+    @Autowired
+    private UCLouvainExportService exportService;
 
     @Override
     public UCLouvainResourcePolicyService getResourcePolicyService() {
@@ -116,5 +119,8 @@ public class UCLouvainServiceFactoryImpl extends UCLouvainServiceFactory {
     public CleanMetadataService getCleanMetadataService() {
         return cleanMetadataService;
     }
-
+    @Override
+    public UCLouvainExportService getExportService() {
+        return exportService;
+    }
 }

--- a/dspace/config/spring/api/scripts.xml
+++ b/dspace/config/spring/api/scripts.xml
@@ -72,6 +72,11 @@
         <property name="dspaceRunnableClass" value="org.dspace.content.integration.crosswalks.script.BulkItemExportCli"/>
     </bean>
 
+    <bean id="publication-export" class="org.dspace.uclouvain.export.script.PublicationExportCliScriptConfiguration">
+        <property name="description" value="Perform an export on publications based on the given export type"/>
+        <property name="dspaceRunnableClass" value="org.dspace.uclouvain.export.script.PublicationExportCli"/>
+    </bean>
+
     <bean id="collection-export" class="org.dspace.app.bulkedit.CollectionExportCliScriptConfiguration">
         <property name="description" value="Perform the export of all the archived items of the given collection in xls format"/>
         <property name="dspaceRunnableClass" value="org.dspace.app.bulkedit.CollectionExportCli"/>

--- a/dspace/config/spring/rest/scripts.xml
+++ b/dspace/config/spring/rest/scripts.xml
@@ -59,6 +59,12 @@
         <property name="dspaceRunnableClass" value="org.dspace.content.integration.crosswalks.script.BulkItemExport"/>
     </bean>
 
+    <bean id="publication-export" class="org.dspace.uclouvain.export.script.PublicationExportCliScriptConfiguration">
+        <property name="description" value="Perform an export on publications based on the given export type"/>
+        <property name="dspaceRunnableClass" value="org.dspace.uclouvain.export.script.PublicationExportCli"/>
+    </bean>
+
+
     <bean id="collection-export" class="org.dspace.app.bulkedit.CollectionExportScriptConfiguration" primary="true">
         <property name="description" value="Perform the export of all the archived items of the given collection in xls format"/>
         <property name="dspaceRunnableClass" value="org.dspace.app.bulkedit.CollectionExport"/>


### PR DESCRIPTION
## Description

Added a script to export publications of a profile in fwb or fnrs format. This can be used to create process in the frontend for bibliographic export.

closes #363 

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module