### PR TITLE
[UPD] feat(form): Fix bad label + manager can edit profiles.

### DIFF
--- a/dspace/config/spring/api/edititem-service.xml
+++ b/dspace/config/spring/api/edititem-service.xml
@@ -74,6 +74,20 @@
                             </property>
                             <property name="submissionDefinition" value="person-edit" />
                         </bean>
+                        <bean class="org.dspace.content.edit.EditItemMode">
+                            <property name="name" value="PROFILE_MANAGER" />
+                            <property name="security">
+                                <value type="org.dspace.content.security.CrisSecurity">
+                                    GROUP
+                                </value>
+                            </property>
+                             <property name="groups">
+                                <list>
+                                    <value>Manager</value>
+                                </list>
+                            </property>
+                            <property name="submissionDefinition" value="person-edit" />
+                        </bean>
                     </list>
                 </entry>
                 <entry key="equipment">

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -1362,10 +1362,10 @@
           <dc-schema>publication</dc-schema>
           <dc-element>speech</dc-element>
           <dc-qualifier>status</dc-qualifier>
-          <label>Speech status</label>
+          <label>Published in</label>
           <type-bind type-bind-field="dc.type.maintype">text::conference-speech</type-bind>
           <input-type value-pairs-name="publication_speech_status">dropdown</input-type>
-          <hint>Select in the list the publication status of the document.</hint>
+          <hint>Specify here if your conference speech is published, in a book or a serial</hint>
           <required>You must select a value</required>
           <settings>
             <setting name="useDefault">true</setting>

--- a/dspace/config/submission-forms_fr.xml
+++ b/dspace/config/submission-forms_fr.xml
@@ -1362,10 +1362,10 @@
           <dc-schema>publication</dc-schema>
           <dc-element>speech</dc-element>
           <dc-qualifier>status</dc-qualifier>
-          <label>Statut de la publication</label>
+          <label>Publié dans</label>
           <type-bind type-bind-field="dc.type.maintype">text::conference-speech</type-bind>
           <input-type value-pairs-name="publication_speech_status">dropdown</input-type>
-          <hint>Sélectionnez le statut de la publication dans la liste.</hint>
+          <hint>Précisez ici si votre communication est publiée, dans une monographie ou une revue</hint>
           <required>Vous devez sélectionner une valeur</required>
           <settings>
             <setting name="useDefault">true</setting>


### PR DESCRIPTION
## Description

- Changed the label of 'publication.speech.status' to be different from 'publication.publicationStatus'.
- Added a way for manager to edit the profile of any person.

closes #373
closes #377

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module