### PR TITLE
[UPD] feat(pubmed-extraction) Extract DOI from Pubmed extraction.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/uclouvain/external/importer/xml/pubmed/UCLouvainPubmedImportSourceService.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/external/importer/xml/pubmed/UCLouvainPubmedImportSourceService.java
@@ -200,6 +200,8 @@ public class UCLouvainPubmedImportSourceService extends UCLouvainXMLImportSource
         List<MetadataValueDTO> mdValues = new ArrayList<>();
         addMetadata(mdValues, Publication.TITLE_FIELD,
             getFirstText(root, "//ArticleTitle"), null, CF_UNSET, false);
+        addMetadata(mdValues, Publication.DOI_IDENTIFIER_FIELD,
+            extractDOI(root), null, CF_UNSET, false);
         addMetadata(mdValues, Publication.ABSTRACT_FIELD,
             parseAbstract(buildXpath("//Abstract").evaluateFirst(root), "\n"), null, CF_UNSET, false);
         addMetadata(mdValues, Publication.DATE_ISSUED_FIELD,
@@ -366,6 +368,14 @@ public class UCLouvainPubmedImportSourceService extends UCLouvainXMLImportSource
         }
         // fallback
         return pagination.getChildTextTrim("MedlinePgn");
+    }
+
+    private String extractDOI(Element root) {
+        String doi = getFirstText(root, "//ELocationID[@EIdType='doi']");
+        if (doi == null) {
+            doi = getFirstText(root, "//ArticleIdList//ArticleId [@IdType='doi']");
+        }
+        return doi;
     }
 
     // GETTERS AND SETTERS

--- a/dspace/config/modules/uclouvain.cfg
+++ b/dspace/config/modules/uclouvain.cfg
@@ -148,7 +148,7 @@ event.consumer.journaldefaultdeletepolicy.filters = Item+Install
 event.consumer.journaldefaultdeletepolicy.group = Journal manager
 
 event.consumer.enrichmetadata.class = org.dspace.uclouvain.consumer.EnrichMetadataConsumer
-event.consumer.enrichmetadata.filters = Item+Create
+event.consumer.enrichmetadata.filters = Item+Create|Modify|Modify_Metadata
 
 event.consumer.defaultauthorrole.class = org.dspace.uclouvain.consumer.DefaultAuthorRoleConsumer
 event.consumer.defaultauthorrole.filters = Item+All


### PR DESCRIPTION
## Description

Added a extraction mechanism for the DOI when importing data from Pubmed. Also fixed the 'enrich metadata' consumer to be triggered on update of metadata.

closes #380

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module