### PR TITLE
[UPD] feat(export) Warning for search result exports.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/uclouvain/export/services/UCLouvainExportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/export/services/UCLouvainExportServiceImpl.java
@@ -79,6 +79,7 @@ public class UCLouvainExportServiceImpl implements UCLouvainExportService {
         itemCrosswalk.addTransformerParameter("highlightText", author.getName());
         itemCrosswalk.addTransformerParameter("documentTitle", FWB_DOCUMENT_TITLE.formatted(author.getName()));
         itemCrosswalk.addTransformerParameter("documentSubtitle", FWB_DOCUMENT_SUBTITLE);
+        itemCrosswalk.addTransformerParameter("showWarning", "false");
         return new TempFileExportResult(
             context,
             itemCrosswalk,
@@ -100,6 +101,7 @@ public class UCLouvainExportServiceImpl implements UCLouvainExportService {
         itemCrosswalk.addTransformerParameter("highlightText", author.getName());
         itemCrosswalk.addTransformerParameter("documentTitle", FNRS_DOCUMENT_TITLE.formatted(author.getName()));
         itemCrosswalk.addTransformerParameter("documentSubtitle", FNRS_DOCUMENT_SUBTITLE);
+        itemCrosswalk.addTransformerParameter("showWarning", "false");
         return new TempFileExportResult(
             context,
             itemCrosswalk,

--- a/dspace/config/crosswalks/template/uclouvain/publication-fnrs-template.xsl
+++ b/dspace/config/crosswalks/template/uclouvain/publication-fnrs-template.xsl
@@ -11,6 +11,7 @@
     <xsl:param name="highlightText"/>
     <xsl:param name="documentTitle" select="'Liste des publications'"/>
     <xsl:param name="documentSubtitle"/>
+    <xsl:param name="showWarning" select="'true'"/>
 
     <xsl:param name="fontFamily" />
     <xsl:param name="fontSize" select="'10pt'"/>
@@ -109,6 +110,9 @@
                                         <fo:block font-size="{$smFontSize}">
                                             <xsl:value-of select="$currentDate"/>
                                         </fo:block>
+                                        <fo:block font-size="8pt">
+                                            Export non conforme au format officiel FNRS
+                                        </fo:block>
                                     </fo:table-cell>
                                     <fo:table-cell text-align="right">
                                         <fo:block font-size="{$smFontSize}">
@@ -132,6 +136,20 @@
                           <fo:block font-size="{$fontSize}" color="$secondaryColor">
                             <xsl:value-of select="$documentSubtitle"/>
                           </fo:block>
+                        </xsl:if>
+                        <xsl:if test="$showWarning='true'">
+                            <fo:block
+                                margin-top="8mm"
+                                margin-bottom="8mm"
+                                padding="4mm"
+                                border="1pt solid #cc0000"
+                                background-color="#fff4f4"
+                                color="#cc0000"
+                                font-weight="bold"
+                                text-align="center">
+                                Cet export est non compatible FNRS et destiné uniquement à la consultation. Par conséquent, il ne peut pas être utilisé pour une soumission FNRS.
+                                Veuillez utiliser l'export bibliographique sur votre page "Mon dashboard" pour un export compatible FNRS.
+                            </fo:block>
                         </xsl:if>
                     </fo:block>
 					<xsl:for-each select="Publication[generate-id()=generate-id(key('categorySection', normalize-space(Category))[1])]">

--- a/dspace/config/crosswalks/template/uclouvain/publication-fwb-template.xsl
+++ b/dspace/config/crosswalks/template/uclouvain/publication-fwb-template.xsl
@@ -11,6 +11,7 @@
     <xsl:param name="highlightText"/>
     <xsl:param name="documentTitle" select="'Liste des publications'"/>
     <xsl:param name="documentSubtitle"/>
+    <xsl:param name="showWarning" select="'true'"/>
 
     <xsl:param name="fontFamily" />
     <xsl:param name="fontSize" select="'10pt'"/>
@@ -111,6 +112,9 @@
                                         <fo:block font-size="{$smFontSize}">
                                             <xsl:value-of select="$currentDate"/>
                                         </fo:block>
+                                        <fo:block font-size="8pt">
+                                            Export non conforme au format officiel FWB
+                                        </fo:block>
                                     </fo:table-cell>
                                     <fo:table-cell text-align="right">
                                         <fo:block font-size="{$smFontSize}">
@@ -134,6 +138,20 @@
                           <fo:block font-size="{$fontSize}" color="$secondaryColor">
                             <xsl:value-of select="$documentSubtitle"/>
                           </fo:block>
+                        </xsl:if>
+                        <xsl:if test="$showWarning='true'">
+                            <fo:block
+                                margin-top="8mm"
+                                margin-bottom="8mm"
+                                padding="4mm"
+                                border="1pt solid #cc0000"
+                                background-color="#fff4f4"
+                                color="#cc0000"
+                                font-weight="bold"
+                                text-align="center">
+                                Cet export est non compatible FWB et destiné uniquement à la consultation. Par conséquent, il ne peut pas être utilisé pour une soumission FWB.
+                                Veuillez utiliser l'export bibliographique sur votre page "Mon dashboard" pour un export compatible FWB.
+                            </fo:block>
                         </xsl:if>
                     </fo:block>
 					<xsl:for-each select="Publication[generate-id()=generate-id(key('categorySection', normalize-space(Category))[1])]">


### PR DESCRIPTION
## Description

Added a warning in the search result PDF export to specify that they are not valid for FNRS or FWB export.

Warning on the first page and also at the bottom of each page:
<img width="658" height="894" alt="image" src="https://github.com/user-attachments/assets/d5034d9b-459b-4dbf-b96c-7442df20844c" />

Same logic is applied to FWB export.

closes #381

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module