### PR TITLE
[UPD] feat(workflow): New librarian step before item goes to archive.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/submit/service/SubmissionConfigService.java
+++ b/dspace-api/src/main/java/org/dspace/submit/service/SubmissionConfigService.java
@@ -14,6 +14,7 @@ import org.dspace.app.util.SubmissionConfig;
 import org.dspace.app.util.SubmissionConfigReaderException;
 import org.dspace.app.util.SubmissionStepConfig;
 import org.dspace.content.Collection;
+import org.dspace.content.Item;
 import org.dspace.core.Context;
 
 /**
@@ -37,6 +38,8 @@ public interface SubmissionConfigService {
     public SubmissionConfig getSubmissionConfigByCollection(Collection collection);
 
     public SubmissionConfig getSubmissionConfigByName(String submitName);
+
+    public SubmissionConfig getSubmissionConfigForWorkflowItem(Context context, Item item, Collection collection);
 
     public SubmissionStepConfig getStepConfig(String stepID)
         throws SubmissionConfigReaderException;

--- a/dspace-api/src/main/java/org/dspace/submit/service/SubmissionConfigServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/submit/service/SubmissionConfigServiceImpl.java
@@ -10,12 +10,18 @@ package org.dspace.submit.service;
 import java.sql.SQLException;
 import java.util.List;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.dspace.app.util.SubmissionConfig;
 import org.dspace.app.util.SubmissionConfigReader;
 import org.dspace.app.util.SubmissionConfigReaderException;
 import org.dspace.app.util.SubmissionStepConfig;
 import org.dspace.content.Collection;
+import org.dspace.content.Item;
 import org.dspace.core.Context;
+import org.dspace.xmlworkflow.factory.XmlWorkflowServiceFactory;
+import org.dspace.xmlworkflow.storedcomponents.ClaimedTask;
+import org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem;
 import org.springframework.beans.factory.InitializingBean;
 
 /**
@@ -24,6 +30,8 @@ import org.springframework.beans.factory.InitializingBean;
  * @author paulo.graca at fccn.pt
  */
 public class SubmissionConfigServiceImpl implements SubmissionConfigService, InitializingBean {
+
+    private Logger logger = LogManager.getLogger(SubmissionConfigServiceImpl.class);
 
     protected SubmissionConfigReader submissionConfigReader;
 
@@ -64,6 +72,46 @@ public class SubmissionConfigServiceImpl implements SubmissionConfigService, Ini
     @Override
     public SubmissionConfig getSubmissionConfigByName(String submitName) {
         return submissionConfigReader.getSubmissionConfigByName(submitName);
+    }
+
+    /**
+     * Get the submission config for a given workflow item.
+     * This is determined by the collection's default submission config and the workflow step.
+     * 
+     * @param context The current DSpace context.
+     * @param item The workflow item to get the submission config for.
+     * @param collection The collection the workflow item belongs to.
+     * @return the submission config for the given workflow item, or null if none.
+     */
+    @Override
+    public SubmissionConfig getSubmissionConfigForWorkflowItem(Context context, Item item, Collection collection) {
+        XmlWorkflowServiceFactory factory = XmlWorkflowServiceFactory.getInstance();
+        try {
+            XmlWorkflowItem wi = (XmlWorkflowItem) factory.getWorkflowItemService().findByItem(context, item);
+            if (wi == null) {
+                return null;
+            }
+
+            ClaimedTask ct = factory
+                .getClaimedTaskService()
+                .findByWorkflowIdAndEPerson(context, wi, context.getCurrentUser());
+            if (ct == null) {
+                return null;
+            }
+            // Get default submission form for the collection.
+            String defaultSubmission = getSubmissionConfigByCollection(collection).getSubmissionName();
+            // Get full workflow step name.
+            String stepName = ct.getStepID();
+
+            // Try to find a specific submission form.
+            return getSubmissionConfigByName(defaultSubmission + "-workflow-" +  stepName);
+        } catch (Exception e) {
+            logger.debug(
+                "Could not retrieve the submission config for the given item :: %s, exception was :: %s".formatted(
+                    item.getID(), e.getMessage()
+                ));
+            return null;
+        }
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/uclouvain/xmlworkflow/actions/UCLouvainThesisAction.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/xmlworkflow/actions/UCLouvainThesisAction.java
@@ -1,0 +1,164 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.xmlworkflow.actions;
+
+import java.sql.SQLException;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.ResourcePolicy;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.content.Bitstream;
+import org.dspace.content.DCDate;
+import org.dspace.content.Item;
+import org.dspace.content.MetadataSchemaEnum;
+import org.dspace.content.service.InstallItemService;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.dspace.eperson.Group;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.uclouvain.core.model.MetadataField;
+import org.dspace.uclouvain.plugins.UCLouvainAccessStatusHelper;
+import org.dspace.xmlworkflow.service.WorkflowRequirementsService;
+import org.dspace.xmlworkflow.state.actions.processingaction.ReviewAction;
+import org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem;
+import org.dspace.xmlworkflow.storedcomponents.service.WorkflowItemRoleService;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Abstract class for UCLouvain thesis actions.
+ * 
+ * @author Michaël Pourbaix (michael.pourbaix@uclouvain.be)
+ */
+public abstract class UCLouvainThesisAction extends ReviewAction {
+    protected final ConfigurationService configService = DSpaceServicesFactory.getInstance().getConfigurationService();
+
+    private Logger logger = LogManager.getLogger(UCLouvainThesisAction.class);
+
+    // Active Request Field
+    protected final MetadataField activeRF = new MetadataField(configService.getProperty(
+        "uclouvain.global.metadata.activerequestchange.field"));
+
+
+    @Autowired
+    protected AuthorizeService authorizeService;
+    @Autowired
+    protected WorkflowItemRoleService workflowItemRoleService;
+    @Autowired
+    protected InstallItemService installItemService;
+
+    /**
+     * Used to archive an item and remove all metadata related to the workflow.
+     *
+     * @param context the current application context.
+     * @param wfi the workflow item to archive.
+     * @throws SQLException if any database exception occurred
+     * @throws AuthorizeException if any authorization occurred
+     */
+    protected void archive(Context context, XmlWorkflowItem wfi) throws SQLException, AuthorizeException {
+        Item item = wfi.getItem();
+        workflowItemRoleService.deleteForWorkflowItem(context, wfi);
+        installItemService.installItem(context, wfi);
+        itemService.clearMetadata(
+            context, item, WorkflowRequirementsService.WORKFLOW_SCHEMA,
+            Item.ANY, Item.ANY, Item.ANY
+        );
+        itemService.update(context, item);
+    }
+
+    /**
+     * Add provenance information to the item using a custom message.
+     *
+     * @param context The current DSpace context.
+     * @param item The item to which the provenance information will be added to.
+     * @param message The custom message to be added to the provenance information.
+     * @throws SQLException if any database exception occurred
+     * @throws AuthorizeException if any authorization occurred
+     */
+    protected void addProvenance(Context context, Item item, String message) throws SQLException, AuthorizeException {
+        String now = DCDate.getCurrent().toString();
+        String userName = xmlWorkflowService
+                .getEPersonName(context.getCurrentUser());
+        String provDescription = getProvenanceStartId() + " " + message + " " + userName + " on " + now + " (GMT) ";
+        context.turnOffAuthorisationSystem();
+        itemService.addMetadata(
+            context,
+            item,
+            MetadataSchemaEnum.DC.getName(),
+            "description", "provenance", "en",
+            provDescription
+        );
+        itemService.update(context, item);
+        context.restoreAuthSystemState();
+    }
+
+    protected void addValidationDate(Context context, Item item) throws SQLException, AuthorizeException {
+        context.turnOffAuthorisationSystem();
+        itemService.setMetadataSingleValue(
+            context, item,
+            MetadataSchemaEnum.DC.getName(), "date", "validated", null,
+            DCDate.getCurrent().toString()
+        );
+        itemService.update(context, item);
+        context.restoreAuthSystemState();
+    }
+
+    /**
+     * Take a bitstream and restricts the access to the administrator group only.
+     *
+     * @param context The current DSpace context.
+     * @param bitstream The bitstream to restrict.
+     * @param adminGroup: The administrator group to grant read rights to.
+     * @throws SQLException if any database exception occurred
+     * @throws AuthorizeException if any authorization occurred
+     */
+    protected void restrictBitstream(Context context, Bitstream bitstream, Group adminGroup)
+            throws SQLException, AuthorizeException {
+        authorizeService.removeAllPolicies(context, bitstream);
+        authorizeService.createResourcePolicy(
+            context,
+            bitstream,
+            adminGroup,
+            null,
+            Constants.READ,
+            ResourcePolicy.TYPE_CUSTOM,
+            UCLouvainAccessStatusHelper.ADMINISTRATOR,
+            null, null, null
+        );
+    }
+
+    /**
+     * Clear the active request change metadata field of the item.
+     * 
+     * @param context The current DSpace application context.
+     * @param wfi The workflow item whose associated item will have its active request change metadata field cleared.
+     */
+    protected void clearRequestField(Context context, XmlWorkflowItem wfi) {
+        Item item = wfi.getItem();
+        try {
+            // Retrieve the value of the active request field
+            String value = itemService.getMetadataFirstValue(item, activeRF, Item.ANY);
+            if (value != null) {
+                this.itemService.clearMetadata(
+                    context,
+                    item,
+                    activeRF.getSchema(),
+                    activeRF.getElement(),
+                    activeRF.getQualifier(),
+                    Item.ANY
+                );
+            }
+            return;
+        } catch (Exception e) {
+            logger.error("An error occurred while clearing the active request change metadata field.", e);
+            return;
+        }
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/xmlworkflow/actions/UCLouvainThesisClearChangeRequestAction.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/xmlworkflow/actions/UCLouvainThesisClearChangeRequestAction.java
@@ -42,7 +42,7 @@ public class UCLouvainThesisClearChangeRequestAction extends ProcessingAction {
     public void activate(Context context, XmlWorkflowItem wfItem) {}
 
     @Override
-    public ActionResult execute(Context context,  XmlWorkflowItem wfi, Step step, HttpServletRequest request) {
+    public ActionResult execute(Context context, XmlWorkflowItem wfi, Step step, HttpServletRequest request) {
         Item item = wfi.getItem();
         try {
             // Retrieve the value of the active request field

--- a/dspace-api/src/main/java/org/dspace/uclouvain/xmlworkflow/actions/UCLouvainThesisEditAction.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/xmlworkflow/actions/UCLouvainThesisEditAction.java
@@ -18,14 +18,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.util.Util;
 import org.dspace.authorize.AuthorizeException;
-import org.dspace.content.Bitstream;
 import org.dspace.content.Item;
-import org.dspace.content.service.BitstreamService;
 import org.dspace.core.Context;
-import org.dspace.eperson.Group;
-import org.dspace.eperson.service.GroupService;
 import org.dspace.uclouvain.content.service.CommentService;
-import org.dspace.uclouvain.core.mails.ThesisChangeRequestEmail;
 import org.dspace.xmlworkflow.state.Step;
 import org.dspace.xmlworkflow.state.actions.ActionResult;
 import org.dspace.xmlworkflow.state.actions.processingaction.ProcessingAction;
@@ -33,53 +28,39 @@ import org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * Custom review action for master theses.
- * This Action contains three outputs: 'Accepted', 'Accepted without diffusion' and 'Rejected'.
- * In the case 'Accepted', we continue the workflow;
- * In the case 'Accepted without diffusion', same as 'Accepted' but we restrict bitstream && add a message to the
- * metadata;
- * In the case 'Rejected', we change the state of the workflow item to 'Withdrawn' && we add it to archive;
- *
+ * Custom edit action for master theses.
+ * This action only has one output of 'approve' and does not allow to reject the item.
+ * The user can also edit the item metadata before approving it.
+ * 
  * @author Michaël Pourbaix (michael.pourbaix@uclouvain.be)
- * @version $Revision$
  */
-public class UCLouvainThesisReviewAction extends UCLouvainThesisAction {
+public class UCLouvainThesisEditAction extends UCLouvainThesisAction {
     private static final String SUBMITTER_IS_DELETED_PAGE = "submitter_deleted";
-    private static final String SUBMIT_APPROVE = "submit_confirm_approve";
-    private static final String SUBMIT_APPROVE_WITHOUT_DIFFUSION = "submit_approve_no_diffusion";
     private static final String SUBMIT_WITHDRAW_REJECT = "submit_withdraw_reject";
-    private static final String RETURN_TO_SUBMITTER = "submit_return_to_submitter";
+    private static final String RETURN_TO_MANAGER = "submit_return_to_manager";
 
-    @Autowired
-    private GroupService groupService;
-    @Autowired
-    private BitstreamService bitstreamService;
     @Autowired
     private CommentService commentService;
 
-    private Logger logger = LogManager.getLogger(UCLouvainThesisReviewAction.class);
+    private Logger logger = LogManager.getLogger(UCLouvainThesisEditAction.class);
 
     /**
      * Method executed to map each option to a specific action.
-     * The option is extracted form the incoming request by splitting the submit button name.
+     * DEV_NOTE: The option is extracted from the incoming request by splitting the submit button name.
      */
     @Override
     public ActionResult execute(Context c, XmlWorkflowItem wfi, Step step, HttpServletRequest request)
         throws SQLException, AuthorizeException, IOException {
-        // In any case, remove the potential request field.
-        clearRequestField(c, wfi);
         if (super.isOptionInParam(request)) {
             switch (Util.getSubmitButton(request, SUBMIT_CANCEL)) {
                 case SUBMIT_APPROVE:
                     return processAccept(c, wfi);
-                case SUBMIT_APPROVE_WITHOUT_DIFFUSION:
-                    return processAcceptWithoutDiffusion(c, wfi);
                 case SUBMIT_WITHDRAW_REJECT:
                     return processRejectPage(c, wfi, request);
                 case SUBMITTER_IS_DELETED_PAGE:
                     return processSubmitterIsDeletedPage(c, wfi, request);
-                case RETURN_TO_SUBMITTER:
-                    return processReturnToSubmitter(c, wfi, request);
+                case RETURN_TO_MANAGER:
+                    return processReturnToManager(c, wfi, request);
                 default:
                     return new ActionResult(ActionResult.TYPE.TYPE_CANCEL);
             }
@@ -94,49 +75,17 @@ public class UCLouvainThesisReviewAction extends UCLouvainThesisAction {
     @Override
     public List<String> getOptions() {
         List<String> options = new ArrayList<>();
+        // In this case approve means "enter archive"
         options.add(SUBMIT_APPROVE);
-        options.add(SUBMIT_APPROVE_WITHOUT_DIFFUSION);
+        // Reject the submission, sets it to withdrawn.
         options.add(SUBMIT_WITHDRAW_REJECT);
-        options.add(RETURN_TO_SUBMITTER);
+        // Return the item to the previous workflow step.
+        options.add(RETURN_TO_MANAGER);
+        // Return to pool for re-assignment to another editor.
         options.add(RETURN_TO_POOL);
         // Edit item button
         options.add(ProcessingAction.SUBMIT_EDIT_METADATA);
         return options;
-    }
-
-    public ActionResult processAccept(Context ctx, XmlWorkflowItem wfi)
-            throws SQLException, AuthorizeException {
-        Item currentItem = wfi.getItem();
-        addValidationDate(ctx, currentItem);
-        return super.processAccept(ctx, wfi);
-    }
-
-    /**
-     * Process result when option 'SUBMIT_APPROVE_WITHOUT_DIFFUSION' is selected.
-     * - First delete all bitstream restrictions and add only administrator access.
-     * - Add a new tag to keep a trace of the operation in the 'dc.description.X' metadata field.
-     * @param ctx the application context
-     * @param wfi the workflow item to manage
-     * @return the action to perform to continue item life cycle
-     */
-    public ActionResult processAcceptWithoutDiffusion(Context ctx, XmlWorkflowItem wfi)
-            throws SQLException, AuthorizeException {
-        // When a manager chooses to approve a publication without any diffusion, we need:
-        //   1) Change bitstreams access restriction: force "admin only" restriction for all bitstreams from ORIGINAL
-        //      bundle
-        //   2) add the "dc.date.validated" metadata
-        //   3) add the "dc.description.provenance" to store item history
-        Item currentItem = wfi.getItem();
-        Group adminGroup = groupService.findByName(ctx, "Administrator");
-        if (adminGroup != null) {
-            for (Bitstream bitstream: bitstreamService.getBitstreamByBundleName(currentItem, "ORIGINAL")) {
-                this.restrictBitstream(ctx, bitstream, adminGroup);
-            }
-        }
-        addValidationDate(ctx, currentItem);
-        addProvenance(ctx, currentItem,
-                "Approved with no diffusion for entry into archive by user: '" + ctx.getCurrentUser().getEmail() + "'");
-        return new ActionResult(ActionResult.TYPE.TYPE_OUTCOME, ActionResult.OUTCOME_COMPLETE);
     }
 
     /**
@@ -156,7 +105,7 @@ public class UCLouvainThesisReviewAction extends UCLouvainThesisAction {
             throws SQLException, AuthorizeException {
         Item item = wfi.getItem();
         addValidationDate(context, item);
-        addProvenance(context, item, "Rejected for entry into archive and placed into withdrawn state by manager: '" +
+        addProvenance(context, item, "Rejected for entry into archive and placed into withdrawn state by librarian: '" +
                 context.getCurrentUser().getEmail() + "'");
         context.turnOffAuthorisationSystem();
         // Archive the item, then instantly withdraw it
@@ -167,45 +116,47 @@ public class UCLouvainThesisReviewAction extends UCLouvainThesisAction {
     }
 
     /**
-     * Process the action 'RETURN_TO_SUBMITTER' which can be performed by a manager and will:
-     *  1) Send the item back to the submitter for modifications.
-     *  2) Add a message (given by the manager) into a metadata field of the item.
-     *  3) The message will then be used to inform the submitter of the necessary changes.
+     * Process the action 'RETURN_TO_MANAGER' which can be performed by a manager and will:
+     *  1) Send the item back to the manager for modifications.
+     *  2) Add a message (given by the librarian) into a metadata field of the item.
+     *  3) The message will then be used to inform the manager of the necessary changes.
      *
      * @param context The current DSpace context.
      * @param wfi The workflow item that is being operated.
      * @param request The current request object.
      * @return An ActionResult object which represents the output of the action.
      */
-    public ActionResult processReturnToSubmitter(Context context, XmlWorkflowItem wfi, HttpServletRequest request) {
+    public ActionResult processReturnToManager(Context context, XmlWorkflowItem wfi, HttpServletRequest request) {
         try {
             context.turnOffAuthorisationSystem();
+
             // Get the mandatory reason from the request object
             String reason = request.getParameter("reason");
             if (StringUtils.isEmpty(reason)) {
                 return new ActionResult(ActionResult.TYPE.TYPE_CANCEL);
             }
 
-            // Send the item back to submission state.
-            xmlWorkflowService.sendWorkflowItemBackSubmission(
-                    context,
-                    wfi,
-                    context.getCurrentUser(),
-                    "",
-                    "Send back to submitter for modifications"
+            // Send the item back to manager for additional validation.
+            xmlWorkflowService.sendWorkflowItemToPreviousStep(
+                context,
+                wfi,
+                context.getCurrentUser(),
+                "",
+                reason
             );
 
             // Encode the reason in the metadata field & store this reason as a new comment related to the item.
             Item item = wfi.getItem();
             if (item != null) {
                 itemService.setMetadataSingleValue(context, item, activeRF, null, reason);
-                String commentContent = "Send back to submitter for modifications :: " + reason;
+                String commentContent = "Send back to manager for modifications :: " + reason;
                 commentService.create(context, item, context.getCurrentUser(), commentContent);
-                // Send email to submitter to notify for the change request.
-                new ThesisChangeRequestEmail(context, item).sendEmail();
+                // Send email to manager to notify for the change request.
+                // TODO: What to do here ????
+                // new ThesisChangeRequestEmail(context, item).sendEmail();
             }
             context.restoreAuthSystemState();
-            return new ActionResult(ActionResult.TYPE.TYPE_SUBMISSION_PAGE);
+            return new ActionResult(ActionResult.TYPE.TYPE_PAGE);
         } catch (Exception e) {
             logger.error("Error while returning the item to the submitter: " + e.getMessage(), e);
             return new ActionResult(ActionResult.TYPE.TYPE_CANCEL);

--- a/dspace-api/src/main/java/org/dspace/workflow/WorkflowService.java
+++ b/dspace-api/src/main/java/org/dspace/workflow/WorkflowService.java
@@ -101,6 +101,19 @@ public interface WorkflowService<T extends WorkflowItem> {
                                                         String rejection_message)
         throws SQLException, AuthorizeException, IOException;
 
+    /** 
+     * Sends a workflow item back to the previous step.
+     * 
+     * @param context The current DSpace application context.
+     * @param wfi The workflow item to send back.
+     * @param user The user sending the workflow item back.
+     * @param provenance The provenance message to add to the item.
+     * @param rejection_message The rejection message to add to the item (given by the user).
+    */
+    public void sendWorkflowItemToPreviousStep(
+        Context context, XmlWorkflowItem wfi, EPerson user, String provenance, String rejection_message
+    ) throws SQLException, AuthorizeException, IOException;
+
     public void restartWorkflow(Context context, XmlWorkflowItem wi, EPerson decliner, String provenance)
         throws SQLException, AuthorizeException, IOException, WorkflowException;
 

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
@@ -60,9 +60,11 @@ import org.dspace.event.Event;
 import org.dspace.handle.service.HandleService;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.EventService;
+import org.dspace.uclouvain.core.model.MetadataField;
 import org.dspace.usage.UsageWorkflowEvent;
 import org.dspace.workflow.WorkflowException;
 import org.dspace.xmlworkflow.factory.XmlWorkflowFactory;
+import org.dspace.xmlworkflow.factory.XmlWorkflowServiceFactory;
 import org.dspace.xmlworkflow.service.WorkflowRequirementsService;
 import org.dspace.xmlworkflow.service.XmlWorkflowService;
 import org.dspace.xmlworkflow.state.Step;
@@ -97,6 +99,8 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
     protected Map<UUID, Boolean> noEMail = new HashMap<>();
 
     private final Logger log = org.apache.logging.log4j.LogManager.getLogger(XmlWorkflowServiceImpl.class);
+
+    private final MetadataField WORKFLOW_PREV_STEP = new MetadataField("workflow.step.previous");
 
     @Autowired(required = true)
     protected AuthorizeService authorizeService;
@@ -507,6 +511,14 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
                     // step at all
                     nextStep = workflow.getNextStep(c, wfi, currentStep, currentOutcome.getResult());
                     c.turnOffAuthorisationSystem();
+                    if (nextStep != null) {
+                        // Set the previous step in the metadata of the item so we can come back to it if necessary.
+                        itemService.setMetadataSingleValue(
+                            c, wfi.getItem(),
+                            WORKFLOW_PREV_STEP.schema, WORKFLOW_PREV_STEP.element, WORKFLOW_PREV_STEP.qualifier,
+                            null, currentStep.getId()
+                        );
+                    }
                     nextActionConfig = processNextStep(c, user, workflow, currentOutcome, wfi, nextStep);
                     //If we require a user interface return null so that the user is redirected to the "submissions
                     // page"
@@ -532,6 +544,14 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
 
 
                         nextStep = workflow.getNextStep(c, wfi, currentStep, currentOutcome.getResult());
+                        if (nextStep != null) {
+                            // Set the previous step in the metadata of the item so we can come back to it if necessary.
+                            itemService.setMetadataSingleValue(
+                                c, wfi.getItem(),
+                                WORKFLOW_PREV_STEP.schema, WORKFLOW_PREV_STEP.element, WORKFLOW_PREV_STEP.qualifier,
+                                null, currentStep.getId()
+                            );
+                        }
 
                         nextActionConfig = processNextStep(c, user, workflow, currentOutcome, wfi, nextStep);
                         //If we require a user interface return null so that the user is redirected to the
@@ -1102,7 +1122,7 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
         String usersName = getEPersonName(e);
 
         // Here's what happened
-        String provDescription = provenance + " Rejected by " + usersName + ", reason: "
+        String provDescription = provenance + " Sent back to submitter by " + usersName + ", reason: "
             + rejection_message + " on " + now + " (GMT) ";
 
         // Add to item as a DC field
@@ -1134,6 +1154,55 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
 
         context.restoreAuthSystemState();
         return wsi;
+    }
+
+    @Override
+    public void sendWorkflowItemToPreviousStep(
+        Context context, XmlWorkflowItem wfi, EPerson user, String provenance, String rejection_message
+    ) throws SQLException, AuthorizeException, IOException {
+        context.turnOffAuthorisationSystem();
+
+        // Find previous workflow step from the metadata that was stored previously.
+        String previousID = itemService.getMetadataFirstValue(wfi.getItem(),
+            WORKFLOW_PREV_STEP.schema, WORKFLOW_PREV_STEP.element, WORKFLOW_PREV_STEP.qualifier, null);
+        if (previousID == null) {
+            log.warn(
+                "Could not send back workflow item " + wfi.getID() + " to previous step because metadata was empty");
+            return;
+        }
+        Step previousStep = XmlWorkflowServiceFactory.getInstance().getWorkflowFactory().getStepByName(previousID);
+        Workflow workflow = previousStep.getWorkflow();
+        ActionResult actionResult = new ActionResult(ActionResult.TYPE.TYPE_OUTCOME, ActionResult.OUTCOME_COMPLETE);
+
+        try {
+            // Important !! Delete the previous claim task
+            ClaimedTask ct = claimedTaskService.findByWorkflowIdAndEPerson(context, wfi, user);
+            if (ct != null) {
+                deleteClaimedTask(context, wfi, ct);
+                workflowRequirementsService.removeClaimedUser(context, wfi, ct.getOwner(), ct.getStepID());
+            }
+            // Make sure the workflow re-enters the desired step. Here we enter the previous step.
+            processNextStep(context, user, workflow, actionResult, wfi, previousStep);
+            log.info(LogHelper.getHeader(context, "send_workflow_item_to_previous_step", "workflow_item_id="
+                + wfi.getID() + "item_id=" + wfi.getItem().getID()
+                + "collection_id=" + wfi.getCollection().getID() + "eperson_id="
+                + user.getID()));
+
+            // Add provenance for history.
+            String provDescription = provenance + " Sent back to manager by " + getEPersonName(user) + ", reason: "
+                + rejection_message + " on " + DCDate.getCurrent().toString() + " (GMT) ";
+            itemService.addMetadata(context, wfi.getItem(), "dc",
+                "description", "provenance", "en", provDescription);
+
+        } catch (Exception e) {
+            log.error(
+                "Could not send the workflow item :: %s back to the previous submission step :: %s".formatted(
+                    wfi.getID(), e.getMessage()
+                )
+            );
+        }
+
+        context.restoreAuthSystemState();
     }
 
     @Override

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/HasRoleLibrarianFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/HasRoleLibrarianFeature.java
@@ -1,0 +1,77 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization.impl;
+
+import java.sql.SQLException;
+
+import org.dspace.app.rest.authorization.AuthorizationFeature;
+import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;
+import org.dspace.app.rest.model.BaseObjectRest;
+import org.dspace.app.rest.model.EPersonRest;
+import org.dspace.app.rest.utils.Utils;
+import org.dspace.core.Context;
+import org.dspace.eperson.EPerson;
+import org.dspace.eperson.service.GroupService;
+import org.dspace.services.ConfigurationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Simple custom feature to determine if a user has the `librarian` role.
+ * 
+ * @author Michaël Pourbaix (michael.pourbaix@uclouvain.be)
+ */
+@Component
+@AuthorizationFeatureDocumentation(
+    name = HasRoleLibrarianFeature.NAME,
+    description = "Allow to determine if the current logged used has the `librarian` role"
+)
+public class HasRoleLibrarianFeature implements AuthorizationFeature {
+
+    public static final String NAME = "hasRoleLibrarian";
+
+    @Autowired
+    private Utils utils;
+    @Autowired
+    private GroupService groupService;
+    @Autowired
+    private ConfigurationService configService;
+
+    /**
+     * This method checks if a user belongs to `librarian` groups
+     * @param context The current DSpace context.
+     * @param user The user to check
+     * @return True if the user could be considerate as a librarian
+     */
+    @Override
+    public boolean isAuthorized(Context context, BaseObjectRest user) throws SQLException {
+        if (!(user instanceof EPersonRest)) {
+            return false;
+        }
+        EPerson ePerson = (EPerson) utils.getDSpaceAPIObjectFromRest(context, user);
+        String[] librarianRoles = configService.getArrayProperty("uclouvain.feature.roles.librarian", new String[0]);
+        for (String role: librarianRoles) {
+            if (groupService.isMember(context, ePerson, role)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * This method lists the supported types for this feature.
+     * In our case, it is only the ePerson type.
+     */
+    @Override
+    public String[] getSupportedTypes() {
+        return new String[] {
+            EPersonRest.CATEGORY + "." + EPersonRest.NAME
+        };
+    }
+
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/AInprogressItemConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/AInprogressItemConverter.java
@@ -135,16 +135,19 @@ public abstract class AInprogressItemConverter<T extends InProgressSubmission,
     }
 
     private SubmissionConfig getSubmissionConfig(Item item, Collection collection) {
-        if (isCorrectionItem(item)) {
-            return submissionConfigService.getCorrectionSubmissionConfigByCollection(collection);
-        } else {
-            return submissionConfigService.getSubmissionConfigByCollection(collection);
+        Context context = ContextUtil.obtainCurrentRequestContext();
+        // Try to get a specific workflow submission form for this item, if it is a workflow item.
+        SubmissionConfig workflowSubmission =
+            submissionConfigService.getSubmissionConfigForWorkflowItem(context, item, collection);
+        if (workflowSubmission != null) {
+            return workflowSubmission;
         }
+        return isCorrectionItem(context, item)
+            ? submissionConfigService.getCorrectionSubmissionConfigByCollection(collection)
+            : submissionConfigService.getSubmissionConfigByCollection(collection);
     }
 
-    private boolean isCorrectionItem(Item item) {
-        Request currentRequest = requestService.getCurrentRequest();
-        Context context = ContextUtil.obtainContext(currentRequest.getServletRequest());
+    private boolean isCorrectionItem(Context context, Item item) {
         try {
             return itemCorrectionService.checkIfIsCorrectionItem(context, item);
         } catch (Exception ex) {

--- a/dspace/config/item-submission.xml
+++ b/dspace/config/item-submission.xml
@@ -273,6 +273,12 @@
       <step id="upload" />
       <step id="master-thesis-cataretro" />
     </submission-process>
+    <submission-process name="master-thesis-workflow-uclouvainthesiseditstep">
+      <step id="extractionstep" />
+      <step id="master-thesis" />
+      <step id="correction" />
+      <step id="license" />
+    </submission-process>
     <submission-process name="product">
       <step id="collection" />
       <step id="product" />

--- a/dspace/config/modules/uclouvain.cfg
+++ b/dspace/config/modules/uclouvain.cfg
@@ -131,6 +131,7 @@ uclouvain.feature.roles.manager = manager
 uclouvain.feature.roles.manager = reviewer
 
 uclouvain.feature.roles.librarian = librarian
+uclouvain.feature.roles.librarian = editor
 
 #------------------------------------------------------------#
 #----------------- Metadata Enhancer Poller -----------------#

--- a/dspace/config/registries/uclouvain-additions-types.xml
+++ b/dspace/config/registries/uclouvain-additions-types.xml
@@ -206,4 +206,11 @@
         <element>contentmodels</element>
         <scope_note>FedoraCommons object content model</scope_note>
     </dc-type>
+    <!-- Workflow schema -->
+    <dc-type>
+        <schema>workflow</schema>
+        <element>step</element>
+        <qualifier>previous</qualifier>
+        <scope_note>Store the previous workflow step id</scope_note>
+    </dc-type>
 </dspace-dc-types>

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -151,6 +151,7 @@
                 <entry key="otherworkspace" value-ref="otherWorkspaceConfiguration" />
                 <!-- "workflow" is a special entry to search for your own workflow tasks -->
                 <entry key="workflow" value-ref="workflowConfiguration" />
+                <entry key="workflowEdit" value-ref="workflowEditConfiguration" />
                 <!-- "workflowAdmin" is a special entry to search for all workflow items if you are an administrator -->
                 <entry key="workflowAdmin" value-ref="workflowAdminConfiguration" />
                 <!-- "supervision" is a special entry to search for all workspace and workflow items if you are an administrator -->
@@ -1168,6 +1169,8 @@
             <list>
                 <!--Only find PoolTask and ClaimedTask -->
                 <value>search.resourcetype:PoolTask OR search.resourcetype:ClaimedTask</value>
+                <!-- Only take items that are in a review step -->
+                <value>step_keyword:uclouvainthesisreviewstep</value>
             </list>
         </property>
         <!-- Define which DSO type should be searched during exportation -->
@@ -1193,6 +1196,83 @@
                             <property name="maxSize" value="250"/>
                             <property name="snippets" value="2"/>
                         </bean>-->
+                    </list>
+                </property>
+            </bean>
+        </property>
+        <!-- When true a "did you mean" example will be displayed, value can be true or false -->
+        <property name="spellCheckEnabled" value="true"/>
+    </bean>
+
+    <bean id="workflowEditConfiguration"
+        class="org.dspace.discovery.configuration.DiscoveryConfiguration"
+        scope="prototype">
+        <property name="id" value="workflowEdit" />
+        <!--Which sidebar facets are to be displayed -->
+        <property name="sidebarFacets">
+            <list>
+                <ref bean="searchFilterObjectNamedType" />
+                <ref bean="searchFilterAdvisor"/>
+                <ref bean="searchFilterFaculty"/>
+                <ref bean="searchFilterDegreeCode"/>
+                <ref bean="searchFilterSessionYear"/>
+                <ref bean="searchFilterAccessType"/>
+            </list>
+        </property>
+        <!--The search filters which can be used on the discovery search page -->
+        <property name="searchFilters">
+            <list>
+                <ref bean="searchFilterObjectNamedType" />
+                <ref bean="searchFilterAdvisor"/>
+                <ref bean="searchFilterFaculty"/>
+                <ref bean="searchFilterDegreeCode"/>
+                <ref bean="searchFilterSessionYear"/>
+                <ref bean="searchFilterEntityType" />
+                <ref bean="searchFilterAccessType"/>
+            </list>
+        </property>
+        <!--The sort filters for the discovery search-->
+        <property name="searchSortConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
+                <property name="sortFields">
+                    <list>
+                        <ref bean="sortLastModified" />
+                        <ref bean="sortNOMAAsc" />
+                        <ref bean="sortNOMADesc" />
+                        <ref bean="sortAuthorNameAsc" />
+                        <ref bean="sortAuthorNameDesc" />
+                    </list>
+                </property>
+            </bean>
+        </property>
+        <!--Any default filter queries, these filter queries will be used for all
+            queries done by discovery for this configuration -->
+        <property name="defaultFilterQueries">
+            <list>
+                <!--Only find PoolTask and ClaimedTask -->
+                <value>search.resourcetype:PoolTask OR search.resourcetype:ClaimedTask</value>
+                <!-- Only take items that are in an edit step -->
+                <value>step_keyword:uclouvainthesiseditstep</value>
+            </list>
+        </property>
+        <!-- Define which DSO type should be searched during exportation -->
+        <property name="exportableDSOType" value="XmlWorkflowItem"/>
+        <property name="exportAllMetadata" value="false"/>
+        <!--Default result per page  -->
+        <property name="defaultRpp" value="10" />
+        <property name="hitHighlightingConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightingConfiguration">
+                <property name="metadataFields">
+                    <list>
+                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
+                            <property name="field" value="dc.title"/>
+                            <property name="snippets" value="5"/>
+                        </bean>
+                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
+                            <property name="field" value="dc.description.abstract"/>
+                            <property name="maxSize" value="250"/>
+                            <property name="snippets" value="2"/>
+                        </bean>
                     </list>
                 </property>
             </bean>

--- a/dspace/config/spring/api/edititem-service.xml
+++ b/dspace/config/spring/api/edititem-service.xml
@@ -202,7 +202,8 @@
                             </property>
                             <property name="submissionDefinition" value="master-thesis-edit" />
                         </bean>
-                        <bean class="org.dspace.content.edit.EditItemMode">
+                        <!-- Disable librarian edit, replaced by workflow edit -->
+                        <!-- <bean class="org.dspace.content.edit.EditItemMode">
                             <property name="name" value="LIBRARIAN" />
                             <property name="security">
                                 <value type="org.dspace.content.security.CrisSecurity">
@@ -215,7 +216,7 @@
                                 </list>
                             </property>
                             <property name="submissionDefinition" value="master-thesis-edit-librarian" />
-                        </bean>
+                        </bean> -->
                     </list>
                 </entry>
                 <entry key="masterthesis.master-thesis-cataretro">

--- a/dspace/config/spring/api/workflow-actions.xml
+++ b/dspace/config/spring/api/workflow-actions.xml
@@ -8,6 +8,7 @@
     <bean id="sendemailattestationactionAPI" class="org.dspace.uclouvain.pdfAttestationGenerator.xmlworkflow.actions.SendEmailAttestationAction" scope="prototype" />
     <bean id="createbitstreamaccesscommentactionAPI" class="org.dspace.uclouvain.xmlworkflow.actions.CreateBitstreamAccessCommentAction" scope="prototype" />
     <bean id="uclouvainthesisreviewactionAPI" class="org.dspace.uclouvain.xmlworkflow.actions.UCLouvainThesisReviewAction" scope="prototype"/>
+    <bean id="uclouvainthesiseditactionAPI" class="org.dspace.uclouvain.xmlworkflow.actions.UCLouvainThesisEditAction" scope="prototype"/>
     <bean id="clearchangerequestactionAPI" class="org.dspace.uclouvain.xmlworkflow.actions.UCLouvainThesisClearChangeRequestAction" scope="prototype"/>
     <bean id="reviewactionAPI" class="org.dspace.xmlworkflow.state.actions.processingaction.ReviewAction" scope="prototype"/>
     <bean id="editactionAPI" class="org.dspace.xmlworkflow.state.actions.processingaction.AcceptEditRejectAction" scope="prototype"/>
@@ -46,6 +47,12 @@
     <bean id="uclouvainthesisreviewaction" class="org.dspace.xmlworkflow.state.actions.WorkflowActionConfig" scope="prototype">
         <constructor-arg type="java.lang.String" value="uclouvainthesisreviewaction"/>
         <property name="processingAction" ref="uclouvainthesisreviewactionAPI"/>
+        <property name="requiresUI" value="true"/>
+    </bean>
+
+    <bean id="uclouvainthesiseditaction" class="org.dspace.xmlworkflow.state.actions.WorkflowActionConfig" scope="prototype">
+        <constructor-arg type="java.lang.String" value="uclouvainthesiseditaction"/>
+        <property name="processingAction" ref="uclouvainthesiseditactionAPI"/>
         <property name="requiresUI" value="true"/>
     </bean>
 

--- a/dspace/config/spring/api/workflow.xml
+++ b/dspace/config/spring/api/workflow.xml
@@ -43,6 +43,7 @@
                 <ref bean="createBitstreamAccessCommentStep"/>
                 <ref bean="generatepdfattestationstep" />
                 <ref bean="uclouvainthesisreviewstep"/>
+                <ref bean="uclouvainthesiseditstep"/>
             </util:list>
         </property>
     </bean>
@@ -173,10 +174,26 @@
     <bean name="uclouvainthesisreviewstep" class="org.dspace.xmlworkflow.state.Step">
         <property name="userSelectionMethod" ref="claimaction"/>
         <property name="role" ref="reviewer"/>
+        <property name="outcomes">
+            <util:map>
+                <entry key="#{ T(org.dspace.xmlworkflow.state.actions.ActionResult).OUTCOME_COMPLETE}"
+                       value-ref="uclouvainthesiseditstep"/>
+            </util:map>
+        </property>
         <property name="actions">
             <util:list>
                 <ref bean="uclouvainthesisreviewaction"/>
             </util:list>
+        </property>
+    </bean>
+
+    <bean name="uclouvainthesiseditstep" class="org.dspace.xmlworkflow.state.Step">
+        <property name="userSelectionMethod" ref="claimaction"/>
+        <property name="role" ref="editor"/>
+        <property name="actions">
+            <list>
+                <ref bean="uclouvainthesiseditaction"/>
+            </list>
         </property>
     </bean>
 

--- a/scripts/config/permissions.json
+++ b/scripts/config/permissions.json
@@ -13,6 +13,12 @@
             "groups": [
                 "manager"
             ]
+        }, {
+            "mode": "role",
+            "type": "editor",
+            "groups": [
+                "librarian"
+            ]
         }]
     }, {
         "collection_name": "Master thesis - Cataretro",


### PR DESCRIPTION
## Description

Librarians must now validate items before they go into the public archive. When validating, a librairan can:
- See the full item view (including metadata and files),
- Edit the item (only metadata),
- Accept the item (goes into archive),
- Reject the item (goes into archive but withdrawn),
- Return the item to managers.

Removed the possibility for a librarian to edit items in the archive (must edit during workflow).

closes #395 

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module