### PR TITLE
[UPD] feat(workflow): System to anonymize authors specified in the submission form.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/uclouvain/xmlworkflow/actions/UCLouvainAnonymizeAuthorsAction.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/xmlworkflow/actions/UCLouvainAnonymizeAuthorsAction.java
@@ -1,0 +1,74 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.xmlworkflow.actions;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.content.Item;
+import org.dspace.content.MetadataValue;
+import org.dspace.content.authority.Choices;
+import org.dspace.core.Context;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.uclouvain.core.model.MetadataField;
+import org.dspace.xmlworkflow.state.Step;
+import org.dspace.xmlworkflow.state.actions.ActionResult;
+import org.dspace.xmlworkflow.state.actions.processingaction.ProcessingAction;
+import org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem;
+
+public class UCLouvainAnonymizeAuthorsAction extends ProcessingAction {
+
+    private Logger logger = LogManager.getLogger(UCLouvainThesisClearChangeRequestAction.class);
+
+    private final ConfigurationService configService = DSpaceServicesFactory.getInstance().getConfigurationService();
+    private final MetadataField anonymizeAuthorField = new MetadataField(configService.getProperty(
+        "uclouvain.global.metadata.authoranonymize.field"));
+    private final MetadataField authorNameField = new MetadataField(configService.getProperty(
+        "uclouvain.global.metadata.authorname.field"));
+
+    private final String ANONYMOUS_PLACEHOLDER = "Anonymous";
+
+    @Override
+    public void activate(Context context, XmlWorkflowItem wf) {}
+
+    @Override
+    public ActionResult execute(Context context, XmlWorkflowItem wfi, Step step, HttpServletRequest request) {
+        Item item = wfi.getItem();
+        List<MetadataValue> anonymizeList =
+            itemService.getMetadataByMetadataString(item, anonymizeAuthorField.toString());
+        if (anonymizeList.isEmpty()) {
+            return new ActionResult(ActionResult.TYPE.TYPE_OUTCOME, ActionResult.OUTCOME_COMPLETE);
+        }
+        for (MetadataValue mv : anonymizeList) {
+            if (!"true".equalsIgnoreCase(mv.getValue())) {
+                continue;
+            }
+            int place = mv.getPlace();
+            try {
+                itemService.replaceMetadata(
+                    context, item,
+                    authorNameField.getSchema(), authorNameField.getElement(), authorNameField.getQualifier(),
+                    null, ANONYMOUS_PLACEHOLDER, null, Choices.CF_UNSET, place
+                );
+            } catch (SQLException e) {
+                logger.error("Could not anonymize author for item {} at place {}", item.getID(), place);
+                return new ActionResult(ActionResult.TYPE.TYPE_ERROR);
+            }
+        }
+        return new ActionResult(ActionResult.TYPE.TYPE_OUTCOME, ActionResult.OUTCOME_COMPLETE);
+    }
+
+    public List<String> getOptions() {
+        return new ArrayList<>();
+    }
+}

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1118,6 +1118,9 @@ metadata.hide.miur.person.cf = true
 metadata.hide.person.email = true
 metadata.hide.oairecerif.person.gender = true
 metadata.hide.person.birthDate = true
+# Hide emails of authors by default
+metadata.hide.authors.email = true
+metadata.hide.authors.email.official = true
 
 ##### Settings for Submission Process #####
 

--- a/dspace/config/modules/uclouvain.cfg
+++ b/dspace/config/modules/uclouvain.cfg
@@ -46,6 +46,7 @@ uclouvain.global.metadata.facultyname.field = masterthesis.faculty.name
 uclouvain.global.metadata.persistentauthoremail.field = authors.email
 uclouvain.global.metadata.authoremail.field = authors.email.official
 uclouvain.global.metadata.authorinstitution.field = authors.institution.name
+uclouvain.global.metadata.authoranonymize.field = authors.anonymize
 uclouvain.global.metadata.id_fgs.field = authors.identifier.fgs
 uclouvain.global.metadata.id_noma.field = authors.identifier.noma
 uclouvain.global.metadata.authorname.field = dc.contributor.author

--- a/dspace/config/registries/uclouvain-additions-types.xml
+++ b/dspace/config/registries/uclouvain-additions-types.xml
@@ -49,6 +49,12 @@
     </dc-schema>
     <dc-type>
         <schema>authors</schema>
+        <element>anonymize</element>
+        <qualifier />
+        <scope_note>Whether the author information should be anonymized</scope_note>
+    </dc-type>
+    <dc-type>
+        <schema>authors</schema>
         <element>email</element>
         <qualifier />
         <scope_note>Author email</scope_note>

--- a/dspace/config/spring/api/workflow-actions.xml
+++ b/dspace/config/spring/api/workflow-actions.xml
@@ -4,6 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.3.xsd">
 
+    <bean id="anonymizeauthorsactionAPI" class="org.dspace.uclouvain.xmlworkflow.actions.UCLouvainAnonymizeAuthorsAction" scope="prototype"/>
     <bean id="claimactionAPI" class="org.dspace.xmlworkflow.state.actions.userassignment.ClaimAction" scope="prototype"/>
     <bean id="sendemailattestationactionAPI" class="org.dspace.uclouvain.pdfAttestationGenerator.xmlworkflow.actions.SendEmailAttestationAction" scope="prototype" />
     <bean id="createbitstreamaccesscommentactionAPI" class="org.dspace.uclouvain.xmlworkflow.actions.CreateBitstreamAccessCommentAction" scope="prototype" />
@@ -66,6 +67,12 @@
         <constructor-arg type="java.lang.String" value="reviewaction"/>
         <property name="processingAction" ref="reviewactionAPI"/>
         <property name="requiresUI" value="true"/>
+    </bean>
+
+    <bean id="anonymizeauthorsaction" class="org.dspace.xmlworkflow.state.actions.WorkflowActionConfig" scope="prototype">
+        <constructor-arg type="java.lang.String" value="anonymizeauthorsaction"/>
+        <property name="processingAction" ref="anonymizeauthorsactionAPI"/>
+        <property name="requiresUI" value="false"/>
     </bean>
 
     <bean id="editaction" class="org.dspace.xmlworkflow.state.actions.WorkflowActionConfig" scope="prototype">

--- a/dspace/config/spring/api/workflow.xml
+++ b/dspace/config/spring/api/workflow.xml
@@ -44,6 +44,7 @@
                 <ref bean="generatepdfattestationstep" />
                 <ref bean="uclouvainthesisreviewstep"/>
                 <ref bean="uclouvainthesiseditstep"/>
+                <ref bean="anonymizeauthorsstep"/>
             </util:list>
         </property>
     </bean>
@@ -190,9 +191,24 @@
     <bean name="uclouvainthesiseditstep" class="org.dspace.xmlworkflow.state.Step">
         <property name="userSelectionMethod" ref="claimaction"/>
         <property name="role" ref="editor"/>
+        <property name="outcomes">
+            <util:map>
+                <entry key="#{ T(org.dspace.xmlworkflow.state.actions.ActionResult).OUTCOME_COMPLETE}"
+                       value-ref="anonymizeauthorsstep"/>
+            </util:map>
+        </property>
         <property name="actions">
             <list>
                 <ref bean="uclouvainthesiseditaction"/>
+            </list>
+        </property>
+    </bean>
+
+    <bean name="anonymizeauthorsstep" class="org.dspace.xmlworkflow.state.Step">
+        <property name="userSelectionMethod" ref="noUserSelectionAction"/>
+        <property name="actions">
+            <list>
+                <ref bean="anonymizeauthorsaction"/>
             </list>
         </property>
     </bean>

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -119,6 +119,20 @@
           <visibility>workflow</visibility>
         </field>
       </row>
+      <row>
+        <field>
+          <dc-schema>authors</dc-schema>
+          <dc-element>anonymize</dc-element>
+          <repeatable>false</repeatable>
+          <label>Anonymize</label>
+          <input-type>checkbox</input-type>
+          <hint>Anonymize author's name</hint>
+          <visibility>submission</visibility>
+          <settings>
+            <setting name="showFieldLabel">false</setting>
+          </settings>
+        </field>
+      </row> 
     </form>
     <form name="master-thesis-dc-contributor-advisor">
       <row>

--- a/dspace/config/submission-forms_fr.xml
+++ b/dspace/config/submission-forms_fr.xml
@@ -119,6 +119,20 @@
           <visibility>workflow</visibility>
         </field>
       </row>
+      <row>
+        <field>
+          <dc-schema>authors</dc-schema>
+          <dc-element>anonymize</dc-element>
+          <repeatable>false</repeatable>
+          <label>Anonymize</label>
+          <input-type>checkbox</input-type>
+          <hint>Anonymiser le nom de l'auteur</hint>
+          <visibility>submission</visibility>
+          <settings>
+            <setting name="showFieldLabel">false</setting>
+          </settings>
+        </field>
+      </row> 
     </form>
     <form name="master-thesis-dc-contributor-advisor">
       <row>


### PR DESCRIPTION
## Description

When the workflow comes to an end, the last step will anonymize selected authors of the thesis. Then selected authors's names will be replaced by 'Anonymous'. Also added a configuration to hide the emails for user that are not admin.

<img width="823" height="669" alt="image" src="https://github.com/user-attachments/assets/d8664971-de3a-4fe3-a5e7-b7a76164ac9e" />

closes #403

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module