### PR TITLE
[ADD] feat(cataretro): authority for degree search on cataretro degrees

### DIFF
--- a/dspace-api/src/main/java/org/dspace/uclouvain/authority/UCLouvainDegreeAuthority.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/authority/UCLouvainDegreeAuthority.java
@@ -1,0 +1,149 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.authority;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.dspace.content.authority.Choice;
+import org.dspace.content.authority.ChoiceAuthority;
+import org.dspace.content.authority.Choices;
+import org.dspace.uclouvain.factories.UCLouvainServiceFactory;
+import org.dspace.uclouvain.services.DegreeSearchResult;
+import org.dspace.uclouvain.services.DegreeService;
+
+/**
+ * ChoiceAuthority implementation that searches for degrees from existing
+ * thesis items in the Solr index via MasterThesisService.
+ * <p>
+ * This is ideal for the cataretro form where submitters need to browse
+ * historical degrees that may no longer exist in the entity configuration.
+ * <p>
+ * When a degree is selected, it auto-populates the following hidden fields:
+ * <ul>
+ *   <li>{@code masterthesis.degree.code} - the selected degree code</li>
+ *   <li>{@code masterthesis.rootdegree.code} - the root degree code</li>
+ *   <li>{@code masterthesis.rootdegree.label} - the root degree label</li>
+ * </ul>
+ *
+ * @author Michaël Pourbaix (michael.pourbaix@uclouvain.be)
+ */
+public class UCLouvainDegreeAuthority implements ChoiceAuthority {
+
+    private String pluginInstanceName;
+
+    private DegreeService degreeService = UCLouvainServiceFactory.getInstance().getDegreeService();
+
+    /**
+     * Search for degrees matching the query string by querying Solr.
+     * Matches against degreelabel (partial) and degreecode (exact).
+     *
+     * @param query  the search text entered by the user
+     * @param start  index to start from
+     * @param limit  maximum number of results
+     * @param locale locale (unused)
+     * @return Choices containing matching degrees
+     */
+    @Override
+    public Choices getMatches(String query, int start, int limit, String locale) {
+        if (StringUtils.isBlank(query)) {
+            return new Choices(Choices.CF_NOTFOUND);
+        }
+
+        if (limit <= 0) {
+            limit = -1; // No limit, return all results
+        }
+
+        List<DegreeSearchResult> results = degreeService.search(query, limit);
+        List<Choice> choices = buildChoicesFromResults(results);
+        Choice[] resultsArray = choices.toArray(new Choice[0]);
+
+        return new Choices(resultsArray, start, results.size(), Choices.CF_AMBIGUOUS, false, -1);
+    }
+
+    /**
+     * Find the best (exact) match for the given text.
+     *
+     * @param text   the text to match
+     * @param locale locale (unused)
+     * @return Choices with best match or CF_NOTFOUND
+     */
+    @Override
+    public Choices getBestMatch(String text, String locale) {
+        if (StringUtils.isBlank(text)) {
+            return new Choices(Choices.CF_NOTFOUND);
+        }
+
+        List<DegreeSearchResult> results = degreeService.search(text, -1);
+        if (results.isEmpty()) {
+            return new Choices(Choices.CF_NOTFOUND);
+        }
+
+        List<Choice> choices = buildChoicesFromResults(results);
+        Choice[] resultsArray = choices.toArray(new Choice[0]);
+        return new Choices(resultsArray, 0, 1, Choices.CF_ACCEPTED, false, -1);
+    }
+
+    /**
+     * Retrieve the label for a given degree key.
+     * Since the key is the degree label itself, simply return it.
+     *
+     * @param key    the degree label
+     * @param locale locale (unused)
+     * @return the degree label
+     */
+    @Override
+    public String getLabel(String key, String locale) {
+        return key;
+    }
+
+    /**
+     * Build Choice objects from degree search results.
+     *
+     * @param results the degree search results
+     * @return list of choices
+     */
+    private List<Choice> buildChoicesFromResults(List<DegreeSearchResult> results) {
+        return results.stream()
+            .map(result -> new Choice(null, getChoiceLabel(result), result.degreeLabel(), generateExtras(result)))
+            .toList();
+    }
+
+    private String getChoiceLabel(DegreeSearchResult result) {
+        String label = result.degreeLabel();
+        if (result.degreeCode() != null) {
+            label = result.degreeCode() + " - " + label;
+        }
+        return label;
+    }
+
+    /**
+     * Generate extra fields for auto-population when a degree is selected.
+     *
+     * @param result the degree search result
+     * @return map of field keys to values for auto-population
+     */
+    private Map<String, String> generateExtras(DegreeSearchResult result) {
+        return Map.of(
+            "data-masterthesis_degree_code", StringUtils.defaultIfBlank(result.degreeCode(), ""),
+            "data-masterthesis_rootdegree_code", StringUtils.defaultIfBlank(result.rootDegreeCode(), ""),
+            "data-masterthesis_rootdegree_label", StringUtils.defaultIfBlank(result.rootDegreeLabel(), "")
+        );
+    }
+
+    @Override
+    public String getPluginInstanceName() {
+        return pluginInstanceName;
+    }
+
+    @Override
+    public void setPluginInstanceName(String name) {
+        this.pluginInstanceName = name;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/factories/UCLouvainServiceFactory.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/factories/UCLouvainServiceFactory.java
@@ -13,6 +13,7 @@ import org.dspace.uclouvain.content.service.CommentService;
 import org.dspace.uclouvain.core.mails.metadataParser.MailMetadataParserService;
 import org.dspace.uclouvain.itemEnhancer.UCLouvainItemEnhancerService;
 import org.dspace.uclouvain.itemEnhancer.poller.UCLouvainItemEnhancerPoller;
+import org.dspace.uclouvain.services.DegreeService;
 import org.dspace.uclouvain.services.DirectLinkService;
 import org.dspace.uclouvain.services.FacultyManagerService;
 import org.dspace.uclouvain.services.MasterThesisService;
@@ -37,6 +38,7 @@ public abstract  class UCLouvainServiceFactory {
     public abstract FacultyManagerService getFacultyManagerService();
     public abstract MasterThesisService getMasterThesisService();
     public abstract UCLouvainCitationsService getCitationsService();
+    public abstract DegreeService getDegreeService();
 
     public static UCLouvainServiceFactory getInstance() {
         return DSpaceServicesFactory

--- a/dspace-api/src/main/java/org/dspace/uclouvain/factories/UCLouvainServiceFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/factories/UCLouvainServiceFactoryImpl.java
@@ -12,6 +12,7 @@ import org.dspace.uclouvain.content.service.CommentService;
 import org.dspace.uclouvain.core.mails.metadataParser.MailMetadataParserService;
 import org.dspace.uclouvain.itemEnhancer.UCLouvainItemEnhancerService;
 import org.dspace.uclouvain.itemEnhancer.poller.UCLouvainItemEnhancerPoller;
+import org.dspace.uclouvain.services.DegreeService;
 import org.dspace.uclouvain.services.DirectLinkService;
 import org.dspace.uclouvain.services.FacultyManagerService;
 import org.dspace.uclouvain.services.MasterThesisService;
@@ -46,6 +47,8 @@ public class UCLouvainServiceFactoryImpl extends UCLouvainServiceFactory {
     private MasterThesisService masterThesisService;
     @Autowired(required = true)
     private UCLouvainCitationsService uclouvainCitationsService;
+    @Autowired
+    private DegreeService degreeService;
 
     @Override
     public UCLouvainResourcePolicyService getResourcePolicyService() {
@@ -88,4 +91,7 @@ public class UCLouvainServiceFactoryImpl extends UCLouvainServiceFactory {
         return uclouvainCitationsService;
     }
 
+    public DegreeService getDegreeService() {
+        return degreeService;
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/uclouvain/services/DegreeSearchResult.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/services/DegreeSearchResult.java
@@ -1,0 +1,21 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.services;
+
+/**
+ * Record representing a degree found in the Solr index.
+ *
+ * @param degreeLabel       the degree label
+ * @param degreeCode        the degree code
+ * @param rootDegreeLabel   the root degree label
+ * @param rootDegreeCode    the root degree code
+ * @author Michaël Pourbaix (michael.pourbaix@uclouvain.be)
+ */
+public record DegreeSearchResult(String degreeLabel, String degreeCode,
+                                  String rootDegreeLabel, String rootDegreeCode) {
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/services/DegreeService.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/services/DegreeService.java
@@ -1,0 +1,32 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.services;
+
+import java.util.List;
+
+/**
+ * Service to search for degrees from multiple sources:
+ * <ul>
+ *   <li>Solr index — degrees from existing thesis items in the archive</li>
+ *   <li>EntityService — configured degrees from the entity configuration file</li>
+ * </ul>
+ * Results are merged and deduplicated by degree label.
+ *
+ * @author Michaël Pourbaix (michael.pourbaix@uclouvain.be)
+ */
+public interface DegreeService {
+
+    /**
+     * Search for degrees matching the given query text.
+     *
+     * @param query search text matched against degree labels (partial match)
+     * @param limit maximum number of results
+     * @return list of distinct degree search results
+     */
+    List<DegreeSearchResult> search(String query, int limit);
+}

--- a/dspace-api/src/main/java/org/dspace/uclouvain/services/DegreeServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/uclouvain/services/DegreeServiceImpl.java
@@ -1,0 +1,184 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.uclouvain.services;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Triple;
+import org.dspace.content.Item;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Context;
+import org.dspace.discovery.SearchServiceException;
+import org.dspace.uclouvain.core.model.Entity;
+import org.dspace.uclouvain.core.model.EntityType;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Implementation of {@link DegreeService} that searches for degrees from
+ * multiple sources:
+ * <ul>
+ *   <li>MasterThesisService — degrees from existing thesis items in the archive (via Solr)</li>
+ *   <li>EntityService — configured degrees from the entity configuration file</li>
+ * </ul>
+ * Results are merged and deduplicated by degree label.
+ *
+ * @author Michaël Pourbaix (michael.pourbaix@uclouvain.be)
+ */
+public class DegreeServiceImpl implements DegreeService {
+
+    public static final String DEGREE_LABEL_FIELD = "masterthesis.degree.label";
+    public static final String DEGREE_CODE_FIELD = "masterthesis.degree.code";
+    public static final String ROOT_DEGREE_LABEL_FIELD = "masterthesis.rootdegree.label";
+    public static final String ROOT_DEGREE_CODE_FIELD = "masterthesis.rootdegree.code";
+
+    @Autowired
+    private MasterThesisService masterThesisService;
+
+    @Autowired
+    private UCLouvainEntityService entityService;
+
+    @Autowired
+    private ItemService itemService;
+
+    @Override
+    public List<DegreeSearchResult> search(String query, int limit) {
+        // 1) Search MasterThesis items and extract degrees
+        List<DegreeSearchResult> thesisResults = searchMasterThesis(query);
+
+        // 2) Search EntityService for configured degrees (fills gap for degrees not in archive)
+        List<DegreeSearchResult> entityResults = searchEntities(query);
+
+        // 3) Merge and deduplicate by degreeLabel (thesis results take priority)
+        List<DegreeSearchResult> results = deduplicate(thesisResults, entityResults);
+
+        return (limit <= 0 || results.size() <= limit)
+            ? results
+            : results.subList(0, limit); // Apply pagination
+    }
+
+    /**
+     * Deduplicate two lists of results by degree label.
+     * Results from the first (thesis) list take priority.
+     *
+     * @param first  primary results (higher priority)
+     * @param second secondary results (fill the gap)
+     * @return merged and deduplicated list
+     */
+    private List<DegreeSearchResult> deduplicate(List<DegreeSearchResult> first,
+                                                  List<DegreeSearchResult> second) {
+        return Stream.concat(first.stream(), second.stream())
+            .collect(Collectors.toMap(
+                DegreeSearchResult::degreeLabel, // Key
+                degreeResult -> degreeResult, // Value
+                (existing, replacement) -> existing, // If duplicate key, keep existing key
+                LinkedHashMap::new
+            ))
+            .values().stream().toList();
+    }
+
+    /**
+     * Search for degrees by querying MasterThesis items via Solr and
+     * extracting degree metadata from the matching items.
+     *
+     * @param query the search text
+     * @return list of degree search results from thesis items
+     */
+    private List<DegreeSearchResult> searchMasterThesis(String query) {
+        List<DegreeSearchResult> results = new ArrayList<>();
+        try (Context context = new Context()) {
+            Triple<String, Object, Boolean> criteria = Triple.of(DEGREE_LABEL_FIELD, query, true);
+            Iterator<Item> items = masterThesisService.search(context, criteria);
+
+            while (items.hasNext()) {
+                results.addAll(extractDegreesFromItem(items.next(), query));
+            }
+        } catch (SearchServiceException e) {
+            // Log but don't fail — fall back to EntityService results
+        }
+        return results;
+    }
+
+    /**
+     * Extract degree metadata values from a single thesis Item.
+     * Handles multi-valued metadata fields (parallel lists for label, code,
+     * rootdegree label, rootdegree code). Only degrees whose label matches
+     * the query text are returned.
+     *
+     * @param item  the thesis Item
+     * @param query the search query text
+     * @return list of degree search results for this item
+     */
+    private List<DegreeSearchResult> extractDegreesFromItem(Item item, String query) {
+        List<String> labels = getAllMetadataValues(item, DEGREE_LABEL_FIELD);
+        List<String> codes = getAllMetadataValues(item, DEGREE_CODE_FIELD);
+        List<String> rootLabels = getAllMetadataValues(item, ROOT_DEGREE_LABEL_FIELD);
+        List<String> rootCodes = getAllMetadataValues(item, ROOT_DEGREE_CODE_FIELD);
+
+        return IntStream.range(0, labels.size())
+            .filter(i -> labels.get(i) != null)
+            .filter(i -> StringUtils.containsIgnoreCase(labels.get(i), query))
+            .mapToObj(i -> new DegreeSearchResult(
+                labels.get(i),
+                getValueOrNull(codes, i),
+                getValueOrNull(rootLabels, i),
+                getValueOrNull(rootCodes, i)
+            )).toList();
+    }
+
+    private String getValueOrNull(List<String> list, int index) {
+        return index < list.size() ? list.get(index) : null;
+    }
+
+    private List<String> getAllMetadataValues(Item item, String metadataField) {
+        return itemService.getMetadataByMetadataString(item, metadataField)
+                .stream().map(mv -> mv.getValue()).toList();
+    }
+
+    /**
+     * Search for degrees in the EntityService configuration.
+     *
+     * @param query the search text
+     * @return list of configured degree search results matching the query
+     */
+    private List<DegreeSearchResult> searchEntities(String query) {
+        return entityService.find(EntityType.DEGREE).stream()
+            .filter(degree -> degree.getName() != null)
+            .filter(degree -> StringUtils.containsIgnoreCase(degree.getName(), query))
+            .map(degree -> {
+                Entity root = getRootDegree(degree);
+                return new DegreeSearchResult(
+                    degree.getName(),
+                    degree.getCode(),
+                    (root != null) ? root.getName() : null,
+                    (root != null) ? root.getCode() : null
+                );
+            })
+            .toList();
+    }
+
+    /**
+     * Retrieve the root degree of a given degree.
+     */
+    private Entity getRootDegree(Entity degree) {
+        if (degree == null) {
+            return null;
+        }
+        Entity root = getRootDegree(degree.getParent());
+        if (root != null) {
+            return root;
+        }
+        return degree.getType() == EntityType.DEGREE ? degree : null;
+    }
+}

--- a/dspace/config/modules/authority.cfg
+++ b/dspace/config/modules/authority.cfg
@@ -99,7 +99,8 @@ plugin.named.org.dspace.content.authority.ChoiceAuthority = \
  org.dspace.content.authority.SherpaAuthority = SherpaAuthority,\
  # UCLouvain authority
  org.dspace.uclouvain.authority.UCLouvainAuthorAuthority = ThesisAuthorAuthority,\
- org.dspace.uclouvain.authority.UCLouvainPromoterAuthority = ThesisPromoterAuthority
+ org.dspace.uclouvain.authority.UCLouvainPromoterAuthority = ThesisPromoterAuthority,\
+ org.dspace.uclouvain.authority.UCLouvainDegreeAuthority = DegreeAuthority
  
 
 ### Login MIUR
@@ -172,6 +173,11 @@ authority.controlled.dc.contributor.author = true
 choices.plugin.dc.contributor.advisor = ThesisPromoterAuthority
 choices.presentation.dc.contributor.advisor = suggest
 authority.controlled.dc.contributor.advisor = true
+
+# UCLouvain degree authority
+choices.plugin.masterthesis.degree.label = DegreeAuthority
+choices.presentation.masterthesis.degree.label = suggest
+authority.controlled.masterthesis.degree.label = true
 
 choices.plugin.oairecerif.author.affiliation = OrgUnitAuthority
 choices.presentation.oairecerif.author.affiliation = suggest

--- a/dspace/config/spring/uclouvain/uclouvain-services.xml
+++ b/dspace/config/spring/uclouvain/uclouvain-services.xml
@@ -38,6 +38,7 @@
     <bean id="uclouvainDirectLinkService" class="org.dspace.uclouvain.services.DirectLinkServiceImpl"/>
     <bean id="facultyManagerService" class="org.dspace.uclouvain.services.FacultyManagerServiceImpl"/>
     <bean id="masterThesisService" class="org.dspace.uclouvain.services.MasterThesisServiceImpl"/>
+    <bean id="degreeService" class="org.dspace.uclouvain.services.DegreeServiceImpl"/>
     <bean id="uclouvainEntityService" class="org.dspace.uclouvain.services.UCLouvainEntityServiceImpl"/>
     <bean id="uclouvainResourcePolicyService" class="org.dspace.uclouvain.services.UCLouvainResourcePolicyServiceImpl">
         <property name="resourcePolicyPriorities" ref="resourcePolicyPriorities"/>

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -321,6 +321,56 @@
         </field>
       </row>
     </form>
+    <form name="master-thesis-cataretro-masterthesis-degree-label">
+      <row>
+        <field>
+          <dc-schema>masterthesis</dc-schema>
+          <dc-element>degree</dc-element>
+          <dc-qualifier>label</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Degree label</label>
+          <input-type>onebox</input-type>
+          <hint>Enter a degree label related to this master thesis.</hint>
+          <required>You must enter a degree label.</required>
+        </field>
+      </row>
+      <row>
+        <field>
+          <dc-schema>masterthesis</dc-schema>
+          <dc-element>degree</dc-element>
+          <dc-qualifier>code</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Degree code</label>
+          <input-type>onebox</input-type>
+          <hint>Enter a degree code related to this master thesis.</hint>
+          <required>You must enter a degree code.</required>
+        </field>
+      </row>
+      <row>
+        <field>
+          <dc-schema>masterthesis</dc-schema>
+          <dc-element>rootdegree</dc-element>
+          <dc-qualifier>code</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Root degree code</label>
+          <input-type>onebox</input-type>
+          <hint>Enter a root degree code related to this master thesis.</hint>
+          <required>You must enter a root degree code.</required>
+        </field>
+      </row>
+      <row>
+        <field>
+          <dc-schema>masterthesis</dc-schema>
+          <dc-element>rootdegree</dc-element>
+          <dc-qualifier>label</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Root degree label</label>
+          <input-type>onebox</input-type>
+          <hint>Enter a root degree label related to this master thesis.</hint>
+          <required>You must enter a root degree label.</required>
+        </field>
+      </row>
+    </form>
     <form name="master-thesis-cataretro">
       <row>
         <field>
@@ -424,8 +474,8 @@
           <dc-element>degree</dc-element>
           <dc-qualifier>label</dc-qualifier>
           <repeatable>true</repeatable>
-          <label>Degree label</label>
-          <input-type>onebox</input-type>
+          <label>Degree</label>
+          <input-type>group</input-type>
           <hint>Enter degree labels related to this master thesis.</hint>
         </field>
       </row>

--- a/dspace/config/submission-forms_fr.xml
+++ b/dspace/config/submission-forms_fr.xml
@@ -320,6 +320,56 @@
         </field>
       </row>
     </form>
+    <form name="master-thesis-cataretro-masterthesis-degree-label">
+      <row>
+        <field>
+          <dc-schema>masterthesis</dc-schema>
+          <dc-element>degree</dc-element>
+          <dc-qualifier>label</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Libellé diplôme</label>
+          <input-type>onebox</input-type>
+          <hint>Entrez un libellé de diplôme lié au mémoire.</hint>
+          <required>Veuillez entrer un libellé de diplôme.</required>
+        </field>
+      </row>
+      <row>
+        <field>
+          <dc-schema>masterthesis</dc-schema>
+          <dc-element>degree</dc-element>
+          <dc-qualifier>code</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Code diplôme</label>
+          <input-type>onebox</input-type>
+          <hint>Entrez un code de diplôme lié au mémoire.</hint>
+          <required>Veuillez entrer un code de diplôme.</required>
+        </field>
+      </row>
+      <row>
+        <field>
+          <dc-schema>masterthesis</dc-schema>
+          <dc-element>rootdegree</dc-element>
+          <dc-qualifier>code</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Code diplôme racine</label>
+          <input-type>onebox</input-type>
+          <hint>Entrez un code racine de diplôme lié au mémoire.</hint>
+          <required>Veuillez entrer un code racine de diplôme.</required>
+        </field>
+      </row>
+      <row>
+        <field>
+          <dc-schema>masterthesis</dc-schema>
+          <dc-element>rootdegree</dc-element>
+          <dc-qualifier>label</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Libellé diplôme racine</label>
+          <input-type>onebox</input-type>
+          <hint>Entrez un libellé racine de diplôme lié au mémoire.</hint>
+          <required>Veuillez entrer un libellé racine de diplôme.</required>
+        </field>
+      </row>
+    </form>
     <form name="master-thesis-cataretro">
       <row>
         <field>
@@ -424,7 +474,7 @@
           <dc-qualifier>label</dc-qualifier>
           <repeatable>true</repeatable>
           <label>Diplôme</label>
-          <input-type>onebox</input-type>
+          <input-type>group</input-type>
           <hint>Entrez le ou les noms des diplômes reliés à ce mémoire. (Exemple: "Master [120] en imagerie médicale")</hint>
         </field>
       </row>


### PR DESCRIPTION
## Description

When adding degree labels to a cataretro thesis, we can now search for existing degrees.

Created a new dedicated DegreeService that orchestrates degree searches from two sources:
- MasterThesisService.search() to find degrees from existing thesis items
- UCLouvainEntityService.find() for configured degrees in entities.json

Results are merged and deduplicated by degree label, with proper handling of multi-valued metadata fields (parallel lists for label, code, root label, root code) so only degrees matching the query text are returned.

Created a new authority class to handle degree search for frontend. This class uses the DegreeService to find potential matches.

closes #406

## Checklist

- [x] Check the code style using the command `mvn clean && mvn install` on local desktop
- [ ] Run unitest for `dspace-uclouvain` module